### PR TITLE
feat: support AllReduce example with OpenMPI backend implementation

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,5 +7,20 @@ foreach(source_file ${EXAMPLE_SOURCES})
 
     target_link_libraries(${example_name} PRIVATE infiniccl)
 
-    target_include_directories(${example_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    # Add runtime and backend dependencies for direct runtime/backend usage
+    if(WITH_NVIDIA)
+        target_link_libraries(${example_name} PRIVATE CUDA::cudart)
+    endif()
+    
+    if(WITH_OMPI)
+        target_link_libraries(${example_name} PRIVATE MPI::MPI_CXX)
+    endif()
+
+    # Explicitly allow examples to "peek" into the internal src and binary dirs
+    # This is necessary because these were marked PRIVATE in the library's CMake
+    target_include_directories(${example_name} PRIVATE 
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        "${PROJECT_SOURCE_DIR}/src"         # For internal templates like runtime.h
+        "${CMAKE_BINARY_DIR}/src"           # For the generated backend_manifest.h
+    )
 endforeach()

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -36,7 +36,8 @@ int main(int argc, char **argv) {
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
 
-  // Map local rank to GPU device
+  // Map local rank to GPU device.
+  // Note: this is just for info printing. In practice, this part is not needed.
   const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
   int local_rank = 0;
   if (local_rank_str != nullptr) {
@@ -47,24 +48,11 @@ int main(int argc, char **argv) {
             << " | GPU: " << Device::StringFromType(kDevType) << " "
             << " | Device " << local_rank << std::endl;
 
-  std::cout << "Rank initialized successfully." << std::endl;
+  // Setup Communicator
+  infiniComm_t comm;
+  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
-  // 2. Setup Device (NVIDIA/MetaX)
-  // In a real scenario, we'd use local_rank to pick a GPU
-  // int local_rank = rank % gpus_per_node;
-  // Runtime::setDevice(local_rank);
-
-  // 3. Setup Communicator (Planned)
-  // infiniComm_t comm;
-  int *devlist = new int[size];
-  int num_gpus_per_node = (size > 1) ? (size >> 1) : 1;
-
-  for (int i = 0; i < size; i++) {
-    devlist[i] = i % num_gpus_per_node;
-  }
-  // CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
-
-  // 4. Prepare Data
+  // Prepare Data
   const int kNumElements = 1024;
   std::vector<float> h_send(kNumElements, 1.0f);
   std::vector<float> h_recv(kNumElements, 0.0f);
@@ -97,12 +85,11 @@ int main(int argc, char **argv) {
   Runtime<kDevType>::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
                             Runtime<kDevType>::MemcpyDeviceToHost);
 
-  // 6. Cleanup
+  // Cleanup
   Runtime<kDevType>::Free(d_send);
   Runtime<kDevType>::Free(d_recv);
-  delete[] devlist;
 
-  // CHECK_INFINI(infiniCommDestroy(comm));
+  CHECK_INFINI(infiniCommDestroy(comm));
   CHECK_INFINI(infiniFinalize());
 
   std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -53,37 +53,57 @@ int main(int argc, char **argv) {
   CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
   // Prepare Data
-  const int kNumElements = 1024;
-  std::vector<float> h_send(kNumElements, 1.0f);
+  const int kNumElements = 1 << 20;
+  std::vector<float> h_send(kNumElements);
   std::vector<float> h_recv(kNumElements, 0.0f);
 
+  // Initialize: each rank provides its (rank + 1) as data
+  for (size_t i = 0; i < kNumElements; i++) {
+    h_send[i] = static_cast<float>(rank + 1);
+  }
+
   float *d_send, *d_recv;
-  Runtime<kDevType>::Malloc(&d_send, kNumElements * sizeof(*d_send));
-  Runtime<kDevType>::Malloc(&d_recv, kNumElements * sizeof(*d_recv));
-  Runtime<kDevType>::Memcpy(d_send, h_send.data(),
-                            kNumElements * sizeof(*d_send),
+  size_t total_bytes = kNumElements * sizeof(*d_send);
+  Runtime<kDevType>::Malloc(&d_send, total_bytes);
+  Runtime<kDevType>::Malloc(&d_recv, total_bytes);
+  Runtime<kDevType>::Memcpy(d_send, h_send.data(), total_bytes,
                             Runtime<kDevType>::MemcpyHostToDevice);
-  Runtime<kDevType>::Memcpy(d_recv, h_recv.data(),
-                            kNumElements * sizeof(*d_recv),
+  Runtime<kDevType>::Memcpy(d_recv, h_recv.data(), total_bytes,
                             Runtime<kDevType>::MemcpyHostToDevice);
 
-  // 5. Perform AllReduce (Conceptual API)
-  std::cout << "Starting AllReduce operation (Placeholder)..." << std::endl;
+  if (rank == 0) {
+    std::cout << "\n=== Performing AllReduce on GPU Memory ===" << std::endl;
+    std::cout << "Data size: " << kNumElements << " floats ("
+              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
+    std::cout << "Operation: Sum" << std::endl;
+  }
 
-  /*
-  CHECK_INFINI(infiniAllReduce(
-      d_send,
-      d_recv,
-      kNumElements,
-      infiniFloat32,
-      infiniSum,
-      comm,
-      nullptr
-  ));
-  */
+  Runtime<kDevType>::StreamSynchronize(nullptr);
+
+  Timer timer;
+
+  CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                               infiniSum, comm, nullptr));
+
+  Runtime<kDevType>::StreamSynchronize(nullptr);
+  double elapsed = timer.elapsed_ms();
 
   Runtime<kDevType>::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
                             Runtime<kDevType>::MemcpyDeviceToHost);
+
+  // Result Validation
+  float expected = 0.0f;
+  for (int r = 0; r < size; r++) {
+    expected += static_cast<float>(r + 1);
+  }
+
+  Validator::ValidateResult(h_recv.data(), kNumElements, expected, rank);
+
+  // Metrics Reporting (Only from rank 0 for cleaner output)
+  if (rank == 0) {
+    Metrics metrics{elapsed, total_bytes, size};
+    metrics.Print();
+  }
 
   // Cleanup
   Runtime<kDevType>::Free(d_send);
@@ -92,7 +112,9 @@ int main(int argc, char **argv) {
   CHECK_INFINI(infiniCommDestroy(comm));
   CHECK_INFINI(infiniFinalize());
 
-  std::cout << "InfiniCCL finalized." << std::endl;
+  if (rank == 0) {
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
 
   return 0;
 }

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -23,7 +23,8 @@
 
 using namespace infini::ccl;
 
-int main(int argc, char **argv) {
+void RunAllReduceExample(int argc, char **argv, int warmup_iter,
+                         int profile_iter, const size_t kNumElements) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
 
@@ -53,7 +54,6 @@ int main(int argc, char **argv) {
   CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
   // Prepare Data
-  const int kNumElements = 1 << 20;
   std::vector<float> h_send(kNumElements);
   std::vector<float> h_recv(kNumElements, 0.0f);
 
@@ -76,20 +76,34 @@ int main(int argc, char **argv) {
     std::cout << "Data size: " << kNumElements << " floats ("
               << total_bytes / 1024 / 1024 << " MB)" << std::endl;
     std::cout << "Operation: Sum" << std::endl;
+    std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
+    std::cout << "Profile iterations: " << profile_iter << std::endl;
   }
 
   Runtime<kDevType>::StreamSynchronize(nullptr);
 
-  Timer timer;
-
+  // warm-up and D2H transfer the answer
   CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
                                infiniSum, comm, nullptr));
-
-  Runtime<kDevType>::StreamSynchronize(nullptr);
-  double elapsed = timer.elapsed_ms();
-
   Runtime<kDevType>::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
                             Runtime<kDevType>::MemcpyDeviceToHost);
+
+  for (int i = 1; i < warmup_iter; ++i) {
+    CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                                 infiniSum, comm, nullptr));
+  }
+  Runtime<kDevType>::StreamSynchronize(nullptr);
+
+  // Profiling
+  Timer timer;
+
+  for (int i = 0; i < profile_iter; i++) {
+    CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                                 infiniSum, comm, nullptr));
+  }
+
+  Runtime<kDevType>::StreamSynchronize(nullptr);
+  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
 
   // Result Validation
   float expected = 0.0f;
@@ -115,6 +129,14 @@ int main(int argc, char **argv) {
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;
   }
+}
 
-  return 0;
+int main(int argc, char **argv) {
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  RunAllReduceExample(argc, argv, warmup_iters, profile_iters, num_elements);
+
+  return EXIT_SUCCESS;
 }

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -5,6 +5,7 @@
  */
 
 #include <iostream>
+#include <unistd.h>
 #include <vector>
 
 // Public API
@@ -41,8 +42,22 @@ int main(int argc, char **argv) {
   int rank, size;
   // Planned API to get global rank info
   // For now, these would be wrappers around MPI_Comm_rank/size
-  // infiniGetRank(&rank);
+  infiniGetRank(&rank);
   // infiniGetSize(&size);
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  // Map local rank to GPU device
+  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_str != nullptr) {
+    local_rank = std::atoi(local_rank_str);
+  }''
+
+  std::cout << "[Rank " << rank << "] Host: " << hostname
+            << " | GPU: " << Device::StringFromType(kDevType) << " "
+            << " | Device " << local_rank << std::endl;
 
   std::cout << "Rank initialized successfully." << std::endl;
 

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -5,10 +5,19 @@
  */
 
 #include <iostream>
-#include <numeric>
 #include <vector>
 
+// Public API
 #include "infiniccl.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
 
 // Simple check macro for the C-API
 #define CHECK_INFINI(cmd)                                                      \
@@ -25,6 +34,9 @@ int main(int argc, char **argv) {
   // Currently, this is the only fully implemented part!
   // It bootstraps the underlying MPI/OMPI environment.
   CHECK_INFINI(infiniInit(&argc, &argv));
+
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
 
   int rank, size;
   // Planned API to get global rank info
@@ -44,34 +56,42 @@ int main(int argc, char **argv) {
   // CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
   // 4. Prepare Data
-  const int count = 1024;
-  std::vector<float> h_send(count, 1.0f);
-  std::vector<float> h_recv(count, 0.0f);
+  const int kNumElements = 1024;
+  std::vector<float> h_send(kNumElements, 1.0f);
+  std::vector<float> h_recv(kNumElements, 0.0f);
 
-  /* Note: In a final version, we would allocate GPU memory here:
-     float *d_send, *d_recv;
-     Runtime::malloc(&d_send, count * sizeof(float));
-     Runtime::memcpy(d_send, h_send.data(), ...);
-  */
+  float *d_send, *d_recv;
+  Runtime<kDevType>::Malloc(&d_send, kNumElements * sizeof(*d_send));
+  Runtime<kDevType>::Malloc(&d_recv, kNumElements * sizeof(*d_recv));
+  Runtime<kDevType>::Memcpy(d_send, h_send.data(),
+                            kNumElements * sizeof(*d_send),
+                            Runtime<kDevType>::MemcpyHostToDevice);
+  Runtime<kDevType>::Memcpy(d_recv, h_recv.data(),
+                            kNumElements * sizeof(*d_recv),
+                            Runtime<kDevType>::MemcpyHostToDevice);
 
   // 5. Perform AllReduce (Conceptual API)
   std::cout << "Starting AllReduce operation (Placeholder)..." << std::endl;
 
   /*
   CHECK_INFINI(infiniAllReduce(
-      h_send.data(),  // Input (eventually d_send)
-      h_recv.data(),  // Output (eventually d_recv)
-      count,
+      d_send,
+      d_recv,
+      kNumElements,
       infiniFloat32,
       infiniSum,
       comm,
-      nullptr         // Stream
+      nullptr
   ));
   */
 
+  Runtime<kDevType>::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
+                            Runtime<kDevType>::MemcpyDeviceToHost);
   // 6. Cleanup
   // CHECK_INFINI(infiniCommDestroy(comm));
-  //   CHECK_INFINI(infiniFinalize());
+  // CHECK_INFINI(infiniFinalize());
+  Runtime<kDevType>::Free(d_send);
+  Runtime<kDevType>::Free(d_recv);
 
   std::cout << "InfiniCCL finalized." << std::endl;
   return 0;

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -11,6 +11,9 @@
 // Public API
 #include "infiniccl.h"
 
+// Example-specific utilities
+#include "utils.h"
+
 // Internal Headers (Accessible via example-specific include paths, technically
 // not public APIs)
 #include "backend_manifest.h"
@@ -20,30 +23,15 @@
 
 using namespace infini::ccl;
 
-// Simple check macro for the C-API
-#define CHECK_INFINI(cmd)                                                      \
-  do {                                                                         \
-    infiniResult_t res = (cmd);                                                \
-    if (res != infiniSuccess) {                                                \
-      std::cerr << "InfiniCCL Error at " << __LINE__ << std::endl;             \
-      exit(EXIT_FAILURE);                                                      \
-    }                                                                          \
-  } while (0)
-
 int main(int argc, char **argv) {
-  // 1. Initialize the Runtime
-  // Currently, this is the only fully implemented part!
-  // It bootstraps the underlying MPI/OMPI environment.
-  CHECK_INFINI(infiniInit(&argc, &argv));
-
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
 
+  CHECK_INFINI(infiniInit(&argc, &argv));
+
   int rank, size;
-  // Planned API to get global rank info
-  // For now, these would be wrappers around MPI_Comm_rank/size
-  infiniGetRank(&rank);
-  infiniGetSize(&size);
+  CHECK_INFINI(infiniGetRank(&rank));
+  CHECK_INFINI(infiniGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -69,9 +57,10 @@ int main(int argc, char **argv) {
   // 3. Setup Communicator (Planned)
   // infiniComm_t comm;
   int *devlist = new int[size];
+  int num_gpus_per_node = (size > 1) ? (size >> 1) : 1;
+
   for (int i = 0; i < size; i++) {
-    int local_rank = i % (size >> 1);
-    devlist[i] = local_rank;
+    devlist[i] = i % num_gpus_per_node;
   }
   // CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
@@ -107,12 +96,16 @@ int main(int argc, char **argv) {
 
   Runtime<kDevType>::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
                             Runtime<kDevType>::MemcpyDeviceToHost);
+
   // 6. Cleanup
-  // CHECK_INFINI(infiniCommDestroy(comm));
-  // CHECK_INFINI(infiniFinalize());
   Runtime<kDevType>::Free(d_send);
   Runtime<kDevType>::Free(d_recv);
+  delete[] devlist;
+
+  // CHECK_INFINI(infiniCommDestroy(comm));
+  CHECK_INFINI(infiniFinalize());
 
   std::cout << "InfiniCCL finalized." << std::endl;
+
   return 0;
 }

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
   // Planned API to get global rank info
   // For now, these would be wrappers around MPI_Comm_rank/size
   infiniGetRank(&rank);
-  // infiniGetSize(&size);
+  infiniGetSize(&size);
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
   int local_rank = 0;
   if (local_rank_str != nullptr) {
     local_rank = std::atoi(local_rank_str);
-  }''
+  }
 
   std::cout << "[Rank " << rank << "] Host: " << hostname
             << " | GPU: " << Device::StringFromType(kDevType) << " "
@@ -68,6 +68,11 @@ int main(int argc, char **argv) {
 
   // 3. Setup Communicator (Planned)
   // infiniComm_t comm;
+  int *devlist = new int[size];
+  for (int i = 0; i < size; i++) {
+    int local_rank = i % (size >> 1);
+    devlist[i] = local_rank;
+  }
   // CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
   // 4. Prepare Data

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -6,7 +6,8 @@
   do {                                                                         \
     infiniResult_t res = (cmd);                                                \
     if (res != infiniSuccess) {                                                \
-      std::cerr << "InfiniCCL Error at " << __LINE__ << std::endl;             \
+      std::cerr << "[InfiniCCL Error] received error code " << res             \
+                << " at line " << __LINE__ << std::endl;                       \
       exit(EXIT_FAILURE);                                                      \
     }                                                                          \
   } while (0)

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -1,0 +1,14 @@
+#ifndef INFINI_CCL_EXAMPLES_UTILS_H_
+#define INFINI_CCL_EXAMPLES_UTILS_H_
+
+// Simple check macro for the C-API
+#define CHECK_INFINI(cmd)                                                      \
+  do {                                                                         \
+    infiniResult_t res = (cmd);                                                \
+    if (res != infiniSuccess) {                                                \
+      std::cerr << "InfiniCCL Error at " << __LINE__ << std::endl;             \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#endif

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -1,6 +1,13 @@
 #ifndef INFINI_CCL_EXAMPLES_UTILS_H_
 #define INFINI_CCL_EXAMPLES_UTILS_H_
 
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
 // Simple check macro for the C-API
 #define CHECK_INFINI(cmd)                                                      \
   do {                                                                         \
@@ -11,5 +18,83 @@
       exit(EXIT_FAILURE);                                                      \
     }                                                                          \
   } while (0)
+
+// Simple Timer for profiling
+class Timer {
+  std::chrono::high_resolution_clock::time_point start;
+
+public:
+  Timer() : start(std::chrono::high_resolution_clock::now()) {}
+  double elapsed_ms() const {
+    auto end = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration<double, std::milli>(end - start).count();
+  }
+};
+
+struct Metrics {
+  double elapsed_ms;
+  size_t total_bytes;
+  int world_size;
+
+  void Print() const {
+    double seconds = elapsed_ms / 1000.0;
+    double gigabytes =
+        static_cast<double>(total_bytes) / (1024.0 * 1024.0 * 1024.0);
+
+    // Industry standard formula: 2 * (n-1) / n
+    double bus_bw =
+        (2.0 * (world_size - 1) / world_size) * (gigabytes / seconds);
+    double alg_bw = gigabytes / seconds;
+
+    std::cout << "Time:           " << std::fixed << std::setprecision(3)
+              << elapsed_ms << " ms" << std::endl;
+    std::cout << "Throughput:     " << std::fixed << std::setprecision(2)
+              << bus_bw << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << std::fixed << std::setprecision(2)
+              << alg_bw << " GB/s" << std::endl;
+  }
+};
+
+class Validator {
+public:
+  template <typename T>
+  static bool ValidateResult(const T *data, size_t count, T expected_val,
+                             int rank) {
+    bool correct = true;
+    int error_count = 0;
+
+    for (size_t i = 0; i < count; ++i) {
+      if (std::fabs(static_cast<double>(data[i]) -
+                    static_cast<double>(expected_val)) > 1e-3) {
+        correct = false;
+        error_count++;
+        if (error_count <= 3 && rank == 0) {
+          std::cerr << "Error at index " << i << ": " << data[i]
+                    << " != " << expected_val << std::endl;
+        }
+      }
+    }
+
+    if (rank == 0) {
+      const char *GREEN = "\033[32m";
+      const char *RED = "\033[31m";
+      const char *RESET = "\033[0m";
+
+      std::cout << "\n=== AllReduce Results ===" << std::endl;
+      std::cout << "Correct: "
+                << (correct ? (GREEN + std::string("YES") + RESET)
+                            : (RED + std::string("NO") + RESET));
+      if (!correct)
+        std::cout << " (" << error_count << " errors)";
+      std::cout << std::endl;
+
+      std::cout << "Expect:  " << std::fixed << std::setprecision(2)
+                << static_cast<double>(expected_val) << std::endl;
+      std::cout << "Actual:  " << std::fixed << std::setprecision(2)
+                << static_cast<double>(data[0]) << std::endl;
+    }
+    return correct;
+  }
+};
 
 #endif

--- a/include/comm.h
+++ b/include/comm.h
@@ -14,6 +14,7 @@ typedef void *infiniComm_t;
 
 // Initialization
 infiniResult_t infiniInit(int *argc, char ***argv);
+infiniResult_t infiniFinalize(void);
 
 // Rank/Size Query
 infiniResult_t infiniGetRank(int *rank);

--- a/include/comm.h
+++ b/include/comm.h
@@ -15,6 +15,9 @@ typedef void *infiniComm_t;
 // Initialization
 infiniResult_t infiniInit(int *argc, char ***argv);
 
+// Rank/Size Query
+infiniResult_t infiniGetRank(int *rank);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/comm.h
+++ b/include/comm.h
@@ -25,6 +25,22 @@ infiniResult_t infiniCommInitAll(infiniComm_t *comm, int ndev,
                                  const int *devlist);
 infiniResult_t infiniCommDestroy(infiniComm_t comm);
 
+// --- Reduction Operations ---
+typedef enum {
+  infiniSum = 0,
+  infiniProd = 1,
+  infiniMax = 2,
+  infiniMin = 3,
+  infiniAvg = 4,
+  infiniNumOps
+} infiniRedOp_t;
+
+// Collective Communication Functions
+infiniResult_t infiniAllReduce(const void *sendbuff, void *recvbuff,
+                               size_t count, infiniDataType_t datatype,
+                               infiniRedOp_t op, infiniComm_t comm,
+                               void *stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/comm.h
+++ b/include/comm.h
@@ -17,6 +17,7 @@ infiniResult_t infiniInit(int *argc, char ***argv);
 
 // Rank/Size Query
 infiniResult_t infiniGetRank(int *rank);
+infiniResult_t infiniGetSize(int *size);
 
 #ifdef __cplusplus
 }

--- a/include/comm.h
+++ b/include/comm.h
@@ -20,6 +20,11 @@ infiniResult_t infiniFinalize(void);
 infiniResult_t infiniGetRank(int *rank);
 infiniResult_t infiniGetSize(int *size);
 
+// Communicator Management
+infiniResult_t infiniCommInitAll(infiniComm_t *comm, int ndev,
+                                 const int *devlist);
+infiniResult_t infiniCommDestroy(infiniComm_t comm);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -85,24 +85,44 @@ def generate(project_root, output_dir, devices, backends):
         "#define INFINI_CCL_BACKEND_MANIFEST_H_"
     ]
 
+    found_devices = []
+
     # Process Active Devices
     for dev in devices:
         if not dev: continue
+        
+        device_included = False
         manifest_lines.append(f"\n// --- DEVICE: {dev.upper()} ---")
+
         for trait in DEVICE_TRAIT_HEADERS:
             rel_path = f"{dev}/{trait}"
             if os.path.exists(os.path.join(src_dir, rel_path)):
                 manifest_lines.append(f"#include \"{rel_path}\"")
+                device_included = True
+
+        if device_included:
+            found_devices.append(f"Device::Type::k{dev.capitalize()}")
 
     # Process Active Backends
     for bb in backends:
         if not bb or bb not in BACKEND_PATH_MAP: continue
+
         manifest_lines.append(f"\n// --- BACKEND: {bb.upper()} ---")
         impl_subpath = BACKEND_PATH_MAP[bb]
+
         for op in ops_in_base:
             rel_path = f"{impl_subpath}/{op}.h"
             if os.path.exists(os.path.join(src_dir, rel_path)):
                 manifest_lines.append(f"#include \"{rel_path}\"")
+
+    # Add the Type Alias `EnabledDevices`
+    manifest_lines.append("\nnamespace infini::ccl {\n")
+    if found_devices:
+        dev_list_str = ", ".join(found_devices)
+        manifest_lines.append(f"using EnabledDevices = List<{dev_list_str}>;")
+    else:
+        manifest_lines.append("using EnabledDevices = List<>;")
+    manifest_lines.append("\n} // namespace infini::ccl")
 
     manifest_lines.append("\n#endif // INFINI_CCL_BACKEND_MANIFEST_H_\n")
     

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -133,16 +133,42 @@ def generate(project_root, output_dir, devices, backends):
     bridge_lines = [
         AUTOGEN_HEADER,
         '#include "backend_manifest.h"',
-        '#include "operation.h"',
         '#include "comm.h"',
+        '#include "comm_impl.h"',
+        '#include "data_type_impl.h"',
+        '#include "operation.h"',
         '\nnamespace infini::ccl {',
         '\nextern "C" {'
     ]
     
     for s in sigs:
+        # We need to transform the raw args to add casts for specific types
+        args_with_casts = []
+        # Split params to analyze types (simplified approach)
+        params_list = s['params'].split(',')
+        
+        for p in params_list:
+            p = p.strip()
+            if not p or p == "void": continue
+            
+            # Get the type and the name
+            parts = p.split()
+            arg_type = parts[0]
+            arg_name = parts[-1].replace('*', '')
+
+            # Apply static_cast for specialized Infini types
+            if arg_type == "infiniDataType_t":
+                args_with_casts.append(f"static_cast<DataType>({arg_name})")
+            elif arg_type == "infiniRedOp_t":
+                args_with_casts.append(f"static_cast<ReductionOpType>({arg_name})")
+            else:
+                args_with_casts.append(arg_name)
+
+        casted_args_str = ", ".join(args_with_casts)
+
         bridge_lines.append(
             f"\n{s['ret']} {s['name']}({s['params']}) {{\n"
-            f"    return static_cast<{s['ret']}>(Operation<{s['key']}>::Call({s['args']}));\n"
+            f"    return static_cast<{s['ret']}>(Operation<{s['key']}>::Call({casted_args_str}));\n"
             f"}}"
         )
     

--- a/src/base/all_reduce.h
+++ b/src/base/all_reduce.h
@@ -1,0 +1,58 @@
+#ifndef INFINI_CCL_BASE_ALL_REDUCE_H_
+#define INFINI_CCL_BASE_ALL_REDUCE_H_
+
+#include "comm_impl.h"
+#include "communicator.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct AllReduceImpl;
+
+class AllReduce : public Operation<AllReduce> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(const void *send_buff, void *recv_buff,
+                              size_t count, DataType datatype,
+                              ReductionOpType op, void *comm_handle,
+                              void *stream) {
+    if (HasInvalidArgs(send_buff, recv_buff, datatype, op, comm_handle)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    return AllReduceImpl<backend_type, device_type>::Apply(
+        send_buff, recv_buff, count, datatype, op, comm, stream);
+  }
+
+private:
+  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
+                             DataType datatype, ReductionOpType op,
+                             void *comm_handle) {
+    if (!comm_handle) {
+      // TODO(lzm): change to use `glog`.
+      LOG("Invalid communicator handle for AllReduce.");
+      return true;
+    }
+    if (!send_buff || !recv_buff) {
+      LOG("Invalid buffer pointer for AllReduce.");
+      return true;
+    }
+    if (op < ReductionOpType::kSum || op >= ReductionOpType::kNumRedOps) {
+      LOG("Invalid reduction operation for AllReduce.");
+      return true;
+    }
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for AllReduce.");
+      return true;
+    }
+    return false;
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_ALL_REDUCE_H_

--- a/src/base/comm_destroy.h
+++ b/src/base/comm_destroy.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_BASE_COMM_DESTROY_H_
+#define INFINI_CCL_BASE_COMM_DESTROY_H_
+
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct CommDestroyImpl;
+
+class CommDestroy : public Operation<CommDestroy> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(Args &&...args) {
+    return CommDestroyImpl<backend_type, device_type>::Apply(
+        std::forward<Args>(args)...);
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_COMM_DESTROY_H_

--- a/src/base/comm_init_all.h
+++ b/src/base/comm_init_all.h
@@ -17,8 +17,8 @@ public:
   static ReturnStatus Execute(void **comm_handle, Args &&...args) {
     Communicator *&comm = *reinterpret_cast<Communicator **>(comm_handle);
     if (comm) {
-      // TODO(lzm): change to logging with log levels.
-      Logger::PrintMsg("Invalid communicator handle for CommInitAll.");
+      // TODO(lzm): change to use `glog`.
+      LOG("Invalid communicator handle for CommInitAll.");
       return ReturnStatus::kInvalidArgument;
     }
 

--- a/src/base/comm_init_all.h
+++ b/src/base/comm_init_all.h
@@ -1,6 +1,7 @@
 #ifndef INFINI_CCL_BASE_COMM_INIT_ALL_H_
 #define INFINI_CCL_BASE_COMM_INIT_ALL_H_
 
+#include "logging.h"
 #include "operation.h"
 #include "return_status_impl.h"
 
@@ -17,9 +18,7 @@ public:
     Communicator *&comm = *reinterpret_cast<Communicator **>(comm_handle);
     if (comm) {
       // TODO(lzm): change to logging with log levels.
-      std::cerr << "[InfiniCCL Error] Communicator handle "
-                   "must be null for `CommInitAll`."
-                << std::endl;
+      Logger::PrintMsg("Invalid communicator handle for CommInitAll.");
       return ReturnStatus::kInvalidArgument;
     }
 

--- a/src/base/comm_init_all.h
+++ b/src/base/comm_init_all.h
@@ -1,0 +1,38 @@
+#ifndef INFINI_CCL_BASE_COMM_INIT_ALL_H_
+#define INFINI_CCL_BASE_COMM_INIT_ALL_H_
+
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct CommInitAllImpl;
+
+class CommInitAll : public Operation<CommInitAll> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(void **comm_handle, Args &&...args) {
+    Communicator *&comm = *reinterpret_cast<Communicator **>(comm_handle);
+    if (comm) {
+      // TODO(lzm): change to logging with log levels.
+      std::cerr << "[InfiniCCL Error] Communicator handle "
+                   "must be null for `CommInitAll`."
+                << std::endl;
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
+
+    comm = new Communicator(kDev, 0);
+
+    return CommInitAllImpl<backend_type, device_type>::Apply(
+        comm, std::forward<Args>(args)...);
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_COMM_INIT_ALL_H_

--- a/src/base/finalize.h
+++ b/src/base/finalize.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_BASE_FINALIZE_H_
+#define INFINI_CCL_BASE_FINALIZE_H_
+
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct FinalizeImpl;
+
+class Finalize : public Operation<Finalize> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(Args &&...args) {
+    return FinalizeImpl<backend_type, device_type>::Apply(
+        std::forward<Args>(args)...);
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_FINALIZE_H_

--- a/src/base/get_rank.h
+++ b/src/base/get_rank.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_BASE_GET_RANK_H_
+#define INFINI_CCL_BASE_GET_RANK_H_
+
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct GetRankImpl;
+
+class GetRank : public Operation<GetRank> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(Args &&...args) {
+    return GetRankImpl<backend_type, device_type>::Apply(
+        std::forward<Args>(args)...);
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_GET_RANK_H_

--- a/src/base/get_size.h
+++ b/src/base/get_size.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_BASE_GET_SIZE_H_
+#define INFINI_CCL_BASE_GET_SIZE_H_
+
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct GetSizeImpl;
+
+class GetSize : public Operation<GetSize> {
+public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(Args &&...args) {
+    return GetSizeImpl<backend_type, device_type>::Apply(
+        std::forward<Args>(args)...);
+  }
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_BASE_GET_SIZE_H_

--- a/src/comm_impl.h
+++ b/src/comm_impl.h
@@ -1,0 +1,21 @@
+#ifndef INFINI_CCL_COMM_IMPL_H_
+#define INFINI_CCL_COMM_IMPL_H_
+
+#include <cstdint>
+
+#include "comm.h"
+
+namespace infini::ccl {
+
+enum class ReductionOpType : int8_t {
+  kSum = infiniSum,
+  kProd = infiniProd,
+  kMax = infiniMax,
+  kMin = infiniMin,
+  kAvg = infiniAvg,
+  kNumRedOps = infiniNumOps,
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_COMM_IMPL_H_

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -28,6 +28,14 @@ public:
 
   auto inter_comm() const { return inter_comm_.get(); }
 
+  void set_intra_comm(std::unique_ptr<BackendCommInstance> inst) {
+    intra_comm_ = std::move(inst);
+  }
+
+  void set_inter_comm(std::unique_ptr<BackendCommInstance> inst) {
+    inter_comm_ = std::move(inst);
+  }
+
   BackendType intra_comm_backend() const {
     return intra_comm_ ? intra_comm_->type : BackendType::kCount;
   }
@@ -41,6 +49,8 @@ public:
   int size() const { return global_size_; }
 
   int device_id() const { return device_id_; }
+
+  void set_device_id(int id) { device_id_ = id; }
 
   Device::Type device_type() const { return device_type_; }
 

--- a/src/constexpr_map.h
+++ b/src/constexpr_map.h
@@ -17,7 +17,7 @@ template <typename Key, typename Value, std::size_t size> struct ConstexprMap {
       if (pr.first == key)
         return pr.second;
     }
-    // TODO(lzm): change to logging.
+    // TODO(lzm): change to use `glog`.
     assert("the key is not found in the `ConstexprMap`");
     // Unreachable, provided to satisfy the compiler's requirement.
     std::abort();

--- a/src/dispatcher.h
+++ b/src/dispatcher.h
@@ -42,7 +42,7 @@ auto DispatchFuncImpl(ValueType value, Functor &&func,
                          : false));
 
     if (!handled) {
-      // TODO(lzm): change to logging.
+      // TODO(lzm): change to use `glog`.
       std::cerr << "dispatch error (void): value " << static_cast<int>(value)
                 << " not supported in the context: " << context_str << "\n";
       std::abort();
@@ -66,7 +66,7 @@ auto DispatchFuncImpl(ValueType value, Functor &&func,
     if (handled) {
       return *result;
     }
-    // TODO(lzm): change to logging.
+    // TODO(lzm): change to use `glog`.
     std::cerr << "dispatch error (non-void): value " << static_cast<int>(value)
               << " not supported in the context: " << context_str << "\n";
     std::abort();
@@ -96,7 +96,7 @@ template <typename ValueType, typename Functor, typename... Args>
 struct DispatchFuncUnwrap<ValueType, Functor, List<>, std::tuple<Args...>> {
   static auto call(ValueType value, Functor &&, std::string_view context_str,
                    Args &&...) {
-    // TODO(lzm): change to logging.
+    // TODO(lzm): change to use `glog`.
     std::cerr << "dispatch error: no allowed values registered for value "
               << static_cast<int64_t>(value)
               << " in the context: " << context_str << "\n";

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,0 +1,35 @@
+#ifndef INFINI_CCL_UTILS_H_
+#define INFINI_CCL_UTILS_H_
+
+#include "constexpr_map.h"
+#include <iostream>
+
+namespace infini::ccl {
+
+class Logger {
+public:
+  enum class LogLevel : int8_t { kInfo, kWarning, kError, kFatal, kCount };
+
+  static void PrintMsg(const char *msg, LogLevel level = LogLevel::kError,
+                       const char *file = __FILE__, int line = __LINE__) {
+    std::cerr << "[InfiniCCL " << kLogLevelToDesc.at(level) << "] " << file
+              << ":" << line << " - " << msg << std::endl;
+    if (level == LogLevel::kFatal) {
+      std::abort();
+    }
+  }
+
+private:
+  static constexpr ConstexprMap<LogLevel, std::string_view,
+                                static_cast<std::size_t>(LogLevel::kCount)>
+      kLogLevelToDesc{{{
+          {LogLevel::kInfo, "INFO"},
+          {LogLevel::kWarning, "WARNING"},
+          {LogLevel::kError, "ERROR"},
+          {LogLevel::kFatal, "FATAL"},
+      }}};
+};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_UTILS_H_

--- a/src/logging.h
+++ b/src/logging.h
@@ -4,6 +4,19 @@
 #include "constexpr_map.h"
 #include <iostream>
 
+// Internal helper macros to count arguments
+#define GET_LOG_MACRO(_1, _2, NAME, ...) NAME
+
+#define LOG_1(msg)                                                             \
+  ::infini::ccl::Logger::PrintMsg(                                             \
+      (msg), ::infini::ccl::Logger::LogLevel::kError, __FILE__, __LINE__)
+
+#define LOG_2(msg, level)                                                      \
+  ::infini::ccl::Logger::PrintMsg((msg), (level), __FILE__, __LINE__)
+
+// Temporary logging macro. To be replaced by `glog` in the future.
+#define LOG(...) GET_LOG_MACRO(__VA_ARGS__, LOG_2, LOG_1)(__VA_ARGS__)
+
 namespace infini::ccl {
 
 class Logger {

--- a/src/nvidia/runtime_.h
+++ b/src/nvidia/runtime_.h
@@ -32,6 +32,8 @@ struct Runtime<Device::Type::kNvidia>
   static constexpr auto MemcpyDeviceToHost = cudaMemcpyDeviceToHost;
 
   static constexpr auto Memset = cudaMemset;
+
+  static constexpr auto SetDevice = cudaSetDevice;
 };
 
 static_assert(Runtime<Device::Type::kNvidia>::Validate());

--- a/src/nvidia/runtime_.h
+++ b/src/nvidia/runtime_.h
@@ -34,6 +34,10 @@ struct Runtime<Device::Type::kNvidia>
   static constexpr auto Memset = cudaMemset;
 
   static constexpr auto SetDevice = cudaSetDevice;
+
+  static constexpr auto DeviceSynchronize = cudaDeviceSynchronize;
+
+  static constexpr auto StreamSynchronize = cudaStreamSynchronize;
 };
 
 static_assert(Runtime<Device::Type::kNvidia>::Validate());

--- a/src/ompi/checks.h
+++ b/src/ompi/checks.h
@@ -14,7 +14,7 @@ namespace infini::ccl {
 namespace detail {
 
 inline ReturnStatus CheckMpiImpl(int mpi_result, const char *file, int line) {
-  if (mpi_result != 0) {
+  if (mpi_result != MPI_SUCCESS) {
     std::cerr << "backend(ompi) MPI error code: " << mpi_result << " at line "
               << line << " in " << file << std::endl;
     std::abort();

--- a/src/ompi/checks.h
+++ b/src/ompi/checks.h
@@ -1,13 +1,13 @@
 #ifndef INFINI_CCL_OMPI_CHECKS_H_
 #define INFINI_CCL_OMPI_CHECKS_H_
 
-#define INFINI_CHECK_MPI(result)                                               \
-  ::infini::ccl::detail::CheckMpiImpl((result), __FILE__, __LINE__)
-
 #include <iostream>
 #include <mpi.h>
 
 #include "return_status_impl.h"
+
+#define INFINI_CHECK_MPI(result)                                               \
+  ::infini::ccl::detail::CheckMpiImpl((result), __FILE__, __LINE__)
 
 namespace infini::ccl {
 

--- a/src/ompi/comm_instance.h
+++ b/src/ompi/comm_instance.h
@@ -8,8 +8,16 @@
 namespace infini::ccl {
 
 struct OmpiInstance : public BackendCommInstance {
-  MPI_Comm handle;
+  MPI_Comm handle = MPI_COMM_NULL;
+
   OmpiInstance() { type = BackendType::kOmpi; }
+
+  void Destroy() {
+    // Ensure we don't accidentally leak if a backend duplicates a communicator.
+    if (handle != MPI_COMM_WORLD && handle != MPI_COMM_NULL) {
+      MPI_Comm_free(&handle);
+    }
+  }
 };
 
 } // namespace infini::ccl

--- a/src/ompi/impl/all_reduce.h
+++ b/src/ompi/impl/all_reduce.h
@@ -1,0 +1,87 @@
+#ifndef INFINI_CCL_OMPI_IMPL_ALL_REDUCE_H_
+#define INFINI_CCL_OMPI_IMPL_ALL_REDUCE_H_
+
+#include "base/all_reduce.h"
+#include "communicator.h"
+#include "dispatcher.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+#include "ompi/type_map.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class AllReduceImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            ReductionOpType op, Communicator *comm,
+                            void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<AllReduce>{});
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for AllReduce.");
+      return ReturnStatus::kInternalError;
+    }
+
+    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
+    MPI_Op mpi_op = RedOpToOmpiOp(op);
+    size_t type_size = kDataTypeToSize.at(data_type);
+    size_t total_bytes = count * type_size;
+
+    // Handle GPU Memory (Staging Pattern)
+    // Note: we simply use host-staging for now.
+    void *host_sendbuf = malloc(total_bytes);
+    void *host_recvbuf = malloc(total_bytes);
+    if (!host_sendbuf || !host_recvbuf) {
+      free(host_sendbuf);
+      free(host_recvbuf);
+      LOG("Failed to allocate host buffers for AllReduce staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    Runtime<kDev>::Memcpy(host_sendbuf, send_buff, total_bytes,
+                          Runtime<kDev>::MemcpyDeviceToHost);
+
+    Runtime<kDev>::StreamSynchronize(
+        static_cast<Runtime<kDev>::Stream>(stream));
+
+    INFINI_CHECK_MPI(MPI_Allreduce(host_sendbuf, host_recvbuf, count, mpi_type,
+                                   mpi_op, inst->handle));
+
+    if (op == ReductionOpType::kAvg) {
+      int size = comm->size();
+      float scale = 1.0f / static_cast<float>(size);
+
+      DispatchFunc<kDev, AllTypes>(data_type, [&](auto dtype) {
+        using T = typename decltype(dtype)::type;
+
+        T *typed_buf = static_cast<T *>(host_recvbuf);
+
+        // Simply do the averaging on the CPU before the H2D copy.
+        for (size_t i = 0; i < count; ++i) {
+          typed_buf[i] *= static_cast<T>(scale);
+        }
+      });
+    }
+
+    Runtime<kDev>::Memcpy(recv_buff, host_recvbuf, total_bytes,
+                          Runtime<kDev>::MemcpyHostToDevice);
+
+    free(host_sendbuf);
+    free(host_recvbuf);
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<AllReduce, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_ALL_REDUCE_H_

--- a/src/ompi/impl/comm_destroy.h
+++ b/src/ompi/impl/comm_destroy.h
@@ -1,0 +1,35 @@
+#ifndef INFINI_CCL_OMPI_IMPL_COMM_DESTROY_H_
+#define INFINI_CCL_OMPI_IMPL_COMM_DESTROY_H_
+
+#include "base/comm_destroy.h"
+#include "communicator.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class CommDestroyImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply(void *comm) {
+    auto *comm_internal = static_cast<Communicator *>(comm);
+    if (!comm_internal) {
+      return ReturnStatus::kInternalError;
+    }
+
+    if (auto *inter =
+            static_cast<OmpiInstance *>(comm_internal->inter_comm())) {
+      inter->Destroy();
+    }
+    comm_internal->set_inter_comm(nullptr);
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<CommDestroy, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_COMM_DESTROY_H_

--- a/src/ompi/impl/comm_init_all.h
+++ b/src/ompi/impl/comm_init_all.h
@@ -18,9 +18,9 @@ public:
         ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
 
     if (!comm) {
-      // TODO(lzm): change to logging with log levels.
-      Logger::PrintMsg("Failed to initialize OpenMPI communicator: invalid "
-                       "communicator pointer.");
+      // TODO(lzm): change to use `glog`.
+      LOG("Failed to initialize OpenMPI communicator: invalid "
+          "communicator pointer.");
       return ReturnStatus::kInternalError;
     }
 

--- a/src/ompi/impl/comm_init_all.h
+++ b/src/ompi/impl/comm_init_all.h
@@ -1,0 +1,60 @@
+#ifndef INFINI_CCL_OMPI_IMPL_COMM_INIT_ALL_H_
+#define INFINI_CCL_OMPI_IMPL_COMM_INIT_ALL_H_
+
+#include "base/comm_init_all.h"
+#include "communicator.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class CommInitAllImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply(Communicator *comm, int n_dev,
+                            const int *dev_list) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
+
+    if (!comm) {
+      // TODO(lzm): change to logging with log levels.
+      std::cerr << "[InfiniCCL Error] Failed to initialize OpenMPI "
+                   "communicator: invalid communicator pointer."
+                << std::endl;
+      return ReturnStatus::kInternalError;
+    }
+
+    int rank, size;
+    auto inst = std::make_unique<OmpiInstance>();
+    INFINI_CHECK_MPI(MPI_Comm_dup(MPI_COMM_WORLD, &inst->handle));
+    INFINI_CHECK_MPI(MPI_Comm_rank(inst->handle, &rank));
+    INFINI_CHECK_MPI(MPI_Comm_size(inst->handle, &size));
+
+    comm->set_world_info(rank, size);
+    comm->set_inter_comm(std::move(inst));
+
+    int local_rank = 0;
+    char *local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    if (local_rank_str) {
+      local_rank = atoi(local_rank_str);
+    }
+
+    // Use device from devlist or local_rank
+    if (dev_list && local_rank < n_dev) {
+      comm->set_device_id(dev_list[local_rank]);
+    } else {
+      comm->set_device_id(local_rank);
+    }
+
+    Runtime<kDev>::SetDevice(comm->device_id());
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<CommInitAll, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_COMM_INIT_ALL_H_

--- a/src/ompi/impl/comm_init_all.h
+++ b/src/ompi/impl/comm_init_all.h
@@ -3,6 +3,7 @@
 
 #include "base/comm_init_all.h"
 #include "communicator.h"
+#include "logging.h"
 #include "ompi/checks.h"
 #include "ompi/comm_instance.h"
 
@@ -18,9 +19,8 @@ public:
 
     if (!comm) {
       // TODO(lzm): change to logging with log levels.
-      std::cerr << "[InfiniCCL Error] Failed to initialize OpenMPI "
-                   "communicator: invalid communicator pointer."
-                << std::endl;
+      Logger::PrintMsg("Failed to initialize OpenMPI communicator: invalid "
+                       "communicator pointer.");
       return ReturnStatus::kInternalError;
     }
 

--- a/src/ompi/impl/finalize.h
+++ b/src/ompi/impl/finalize.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_OMPI_IMPL_FINALIZE_H_
+#define INFINI_CCL_OMPI_IMPL_FINALIZE_H_
+
+#include "base/finalize.h"
+#include "ompi/checks.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class FinalizeImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply() {
+    int finalized;
+    INFINI_CHECK_MPI(MPI_Finalized(&finalized));
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<Finalize, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_FINALIZE_H_

--- a/src/ompi/impl/get_rank.h
+++ b/src/ompi/impl/get_rank.h
@@ -1,0 +1,23 @@
+#ifndef INFINI_CCL_OMPI_IMPL_GET_RANK_H_
+#define INFINI_CCL_OMPI_IMPL_GET_RANK_H_
+
+#include "base/get_rank.h"
+#include "ompi/checks.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class GetRankImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply(int *rank) {
+    INFINI_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, rank));
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<GetRank, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_GET_RANK_H_

--- a/src/ompi/impl/get_size.h
+++ b/src/ompi/impl/get_size.h
@@ -1,0 +1,23 @@
+#ifndef INFINI_CCL_OMPI_IMPL_GET_SIZE_H_
+#define INFINI_CCL_OMPI_IMPL_GET_SIZE_H_
+
+#include "base/get_size.h"
+#include "ompi/checks.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class GetSizeImpl<BackendType::kOmpi, device_type> {
+public:
+  static ReturnStatus Apply(int *size) {
+    INFINI_CHECK_MPI(MPI_Comm_size(MPI_COMM_WORLD, size));
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<GetSize, BackendType::kOmpi> : std::true_type {};
+
+} // namespace infini::ccl
+
+#endif // INFINI_CCL_OMPI_IMPL_GET_SIZE_H_

--- a/src/ompi/impl/init.h
+++ b/src/ompi/impl/init.h
@@ -19,7 +19,7 @@ public:
       INFINI_CHECK_MPI(MPI_Init_thread(argc, argv, required_level_, &provided));
 
       if (provided < required_level_) {
-        // TODO(lzm): change to logging with log levels.
+        // TODO(lzm): change to use `glog`.
         std::cerr
             << "[InfiniCCL Warning] MPI implementation does not fully support "
             << "`MPI_THREAD_SERIALIZED` (provided: " << provided << "). "

--- a/src/ompi/impl/init.h
+++ b/src/ompi/impl/init.h
@@ -16,19 +16,21 @@ public:
     if (!initialized) {
       int provided;
       // Use `MPI_Init_thread` to support multi-threaded GPU streams.
-      INFINI_CHECK_MPI(
-          MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE, &provided));
+      INFINI_CHECK_MPI(MPI_Init_thread(argc, argv, required_level_, &provided));
 
-      if (provided < MPI_THREAD_MULTIPLE) {
+      if (provided < required_level_) {
         // TODO(lzm): change to logging with log levels.
         std::cerr
             << "[InfiniCCL Warning] MPI implementation does not fully support "
-            << "MPI_THREAD_MULTIPLE (provided: " << provided << "). "
+            << "`MPI_THREAD_SERIALIZED` (provided: " << provided << "). "
             << "Concurrent collective operations may be unsafe." << std::endl;
       }
     }
     return ReturnStatus::kSuccess;
   }
+
+private:
+  constexpr static auto required_level_ = MPI_THREAD_FUNNELED;
 };
 
 template <> struct BackendEnabled<Init, BackendType::kOmpi> : std::true_type {};

--- a/src/ompi/type_map.h
+++ b/src/ompi/type_map.h
@@ -3,27 +3,42 @@
 
 #include <mpi.h>
 
+#include "comm_impl.h"
 #include "data_type_impl.h"
 
 namespace infini::ccl {
 
 static const ConstexprMap<DataType, MPI_Datatype, 12> kOmpiTypeMap{{{
-    {kInt8, MPI_INT8_T},
-    {kInt16, MPI_INT16_T},
-    {kInt32, MPI_INT32_T},
-    {kInt64, MPI_INT64_T},
-    {kUInt8, MPI_UINT8_T},
-    {kUInt16, MPI_UINT16_T},
-    {kUInt32, MPI_UINT32_T},
-    {kUInt64, MPI_UINT64_T},
-    {kFloat32, MPI_FLOAT},
-    {kFloat64, MPI_DOUBLE},
-    {kFloat16, MPI_BYTE},
-    {kBFloat16, MPI_BYTE},
+    {DataType::kInt8, MPI_INT8_T},
+    {DataType::kInt16, MPI_INT16_T},
+    {DataType::kInt32, MPI_INT32_T},
+    {DataType::kInt64, MPI_INT64_T},
+    {DataType::kUInt8, MPI_UINT8_T},
+    {DataType::kUInt16, MPI_UINT16_T},
+    {DataType::kUInt32, MPI_UINT32_T},
+    {DataType::kUInt64, MPI_UINT64_T},
+    {DataType::kFloat32, MPI_FLOAT},
+    {DataType::kFloat64, MPI_DOUBLE},
+    {DataType::kFloat16, MPI_BYTE},
+    {DataType::kBFloat16, MPI_BYTE},
+}}};
+
+static const ConstexprMap<ReductionOpType, MPI_Op, 5> kOmpiOpMap{{{
+    {ReductionOpType::kSum, MPI_SUM},
+    {ReductionOpType::kProd, MPI_PROD},
+    {ReductionOpType::kMax, MPI_MAX},
+    {ReductionOpType::kMin, MPI_MIN},
+    // OpenMPI does not support native average reduction, so we map it to sum
+    // and handle the scaling manually.
+    {ReductionOpType::kAvg, MPI_SUM},
 }}};
 
 inline MPI_Datatype DataTypeToOmpiType(DataType dtype) {
   return kOmpiTypeMap.at(dtype);
+}
+
+inline MPI_Op RedOpToOmpiOp(ReductionOpType red_op) {
+  return kOmpiOpMap.at(red_op);
 }
 
 } // namespace infini::ccl


### PR DESCRIPTION
## Summary
This PR adds support for six communication operations required by the AllReduce example (i.e., `examples/all_reduce.cc`), enabling InfiniCCL to perform AllReduce using an OpenMPI backend. 
In addition, this PR introduces a lightweight logging module and refactors the AllReduce example to improve structure, usability, and maintainability. 

## Changes
 - **Communication Operation Support**
   - add the basic OpenMPI implementation for: 
     - `infiniGetRank()`
     - `infiniGetSize()`
     - `infiniFinalize()`
     - `infiniCommInitAll()`
     - `infiniCommDestroy()`
     - `infiniAllReduce()`. 
 - **Example Refactor**
   - extract common utilities shared across example programs under `examples/`;
   - add `Timer`, `Metrics`, and `Validator` in `examples/utils.h` for simple profiling and result checking;
   - refactor example build logic to allow access to internal components (e.g., runtime), avoiding redundant boilerplate not relevant to testing.
 - **Logging**
   - add a lightweight logging module in `src/logging.h` for structured information and error reporting.

## Known Issues & Future Work
 - The current AllReduce example has only been tested on a **single node** (NVIDIA environment). Multi-node and heterogeneous setups still require a complete validation.
 - The logging module is temporary and will be replaced with `glog` in the future.
 - In the current test environment, OpenMPI consistently reports the warning: `mpirun has exited due to process rank <RANK#> with PID <PID#> on node <IP> exiting improperly` message. This issue has been investigated but not fully resolved. It does not appear to impact functionality at this time, but should be addressed in future work;
 - The current OpenMPI implementation of the above functions hardcodes `MPI_COMM_WORLD` within the implementation. This should be made configurable in the future;
 - The current OpenMPI implementation of `CommInitAll` directly relies on OpenMPI-specific environment variables (e.g., `OMPI_COMM_WORLD_LOCAL_RANK`). This is planned to be abstracted and mapped into InfiniCCL’s own environment variable interface to provide a cleaner and more complete backend abstraction.
 
## Logs & Screenshots

```bash
cmake .. && make -j$(nproc) && mpirun -n 8 --mca mtl ^ofi --mca btl tcp,self -x UCX_NET_DEVICES=all --allow-run-as-root ./examples/all_reduce
-- No backend specified. Defaulting to WITH_OMPI=ON
-- Auto-detecting available devices...
-- Auto-detected NVIDIA environment.
-- No MetaX GPU detected
-- InfiniCCL Config: Devices [cpu, nvidia] | Backends [ompi]
-- Configuring done (2.0s)
-- Generating done (0.0s)
-- Build files have been written to: /nfs/lizimin/InfiniCCL/build
[ 20%] Generating InfiniCCL bridge and manifest files for Devices: [cpu;nvidia] Backends: [ompi]...
[ 40%] Building CXX object src/CMakeFiles/infiniccl.dir/comm_bridge.cc.o
[ 60%] Linking CXX shared library libinfiniccl.so
[ 60%] Built target infiniccl
[ 80%] Building CXX object examples/CMakeFiles/all_reduce.dir/all_reduce.cc.o
[100%] Linking CXX executable all_reduce
[100%] Built target all_reduce
[1777519993.621796] [server:4161359:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.621796] [server:4161359:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.623801] [server:4161354:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.623801] [server:4161354:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.626339] [server:4161361:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.626339] [server:4161361:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.636061] [server:4161355:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.636061] [server:4161355:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.641585] [server:4161357:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.641585] [server:4161357:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.645557] [server:4161360:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.645557] [server:4161360:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.673396] [server:4161356:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.673396] [server:4161356:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[1777519993.770086] [server:4161358:0]          parser.c:2305 UCX  WARN  unused environment variable: UCX_ROOT (maybe: UCX_PROTOS?)
[1777519993.770086] [server:4161358:0]          parser.c:2305 UCX  WARN  (set UCX_WARN_UNUSED_ENV_VARS=n to suppress this warning)
[Rank 2] Host: server | GPU: nvidia  | Device 2
[Rank 6] Host: server | GPU: nvidia  | Device 6
[Rank 4] Host: server | GPU: nvidia  | Device 4
[Rank 7] Host: server | GPU: nvidia  | Device 7
[Rank 1] Host: server | GPU: nvidia  | Device 1
[Rank 3] Host: server | GPU: nvidia  | Device 3
[Rank 5] Host: server | GPU: nvidia  | Device 5
[Rank 0] Host: server | GPU: nvidia  | Device 0

=== Performing AllReduce on GPU Memory ===
Data size: 1048576 floats (4 MB)
Operation: Sum
Warm-up iterations: 2
Profile iterations: 20

=== AllReduce Results ===
Correct: YES
Expect:  36.00
Actual:  36.00
Time:           12.898 ms
Throughput:     0.53 GB/s (Bus BW)
Alg Bandwidth:  0.30 GB/s
InfiniCCL finalized.
```