### PR TITLE
fix: fix the `run_wrapper.sh` generation logic in `if-elif structure` of `icclrun_logic.py`

### DIFF
--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -95,31 +95,59 @@ class ICCLLauncher:
 
         bin_sub = "examples/$1" if is_internal else "$1"
 
-        case_blocks = ""
+        case_blocks = []
+        first = True
+
         for node in self.config["nodes"]:
             n_type = node["type"]
             n_env = node.get("backend_env", {})
 
             # Generic environment injection from YAML.
             exports = f'    export LD_LIBRARY_PATH="{self.infiniccl_root}/install/{n_type}/lib:${{LD_LIBRARY_PATH}}"\n'
+
             for k, v in n_env.items():
-                exports += f'    export {k}="{v if k != "LD_LIBRARY_PATH" else v + ":${LD_LIBRARY_PATH}"}"\n'
+                if k == "LD_LIBRARY_PATH":
+                    v = f"{v}:${{LD_LIBRARY_PATH}}"
+                exports += f'    export {k}="{v}"\n'
+
+            condition = None
 
             if n_type == "nvidia":
-                case_blocks += f'if [ -c "/dev/nvidia0" ] || [ -x "$(command -v nvidia-smi)" ]; then\n{exports}    ARCH="nvidia"\n'
+                condition = '[ -c "/dev/nvidia0" ] || [ -x "$(command -v nvidia-smi)" ]'
+
             elif n_type == "metax":
-                case_blocks += f'elif [ -d "/opt/maca" ] || grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1; then\n{exports}    ARCH="metax"\n'
+                condition = (
+                    '[ -d "/opt/maca" ] || '
+                    'grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1'
+                )
+
+            # Skip unknown platforms cleanly.
+            if condition is None:
+                continue
+
+            keyword = "if" if first else "elif"
+            first = False
+
+            case_blocks.append(
+                f'{keyword} {condition}; then\n{exports}    ARCH="{n_type}"\n'
+            )
+
+        # Fallback when no accelerator matched (or no platforms configured).
+        if case_blocks:
+            case_blocks.append('else\n    ARCH="cpu"\nfi\n')
+        else:
+            case_blocks.append('ARCH="cpu"\n')
 
         content = f"""#!/bin/bash
-{case_blocks}else
-    ARCH="cpu"
-fi
+{"".join(case_blocks)}
 EXE="{self.config["common_dir"]}/build/$ARCH/{bin_sub}"
 shift
 exec "$EXE" "$@"
     """
+
         with open(wrapper_path, "w") as f:
             f.write(content)
+
         os.chmod(wrapper_path, 0o755)
         return wrapper_path
 


### PR DESCRIPTION
## Summary
This PR fixes an issue in the generation of the `run_wrapper.sh` launcher script where the conditional shell logic was incorrectly constructed for heterogeneous or empty platform configurations.

Previously, the script generation assumed that at least NVIDIA backend would always exist, and unconditionally emitted an `else ... fi` block. This caused invalid Bash syntax when:
 - When no NVIDIA accelerator backend was present
 - Or no GPU platforms were specified (CPU-only case)

This PR makes the launcher generation fully robust across all configurations.

## Changes
- **Robust Launcher Script Generation Fix**
  - Fix incorrect Bash conditional generation when no GPU platforms are configured
  - Properly handle three cases:
    - No GPU nodes → emit direct CPU assignment (no `if` block)
    - One or more GPU nodes → generate valid `if / elif / else / fi` chain
    - Prevent invalid shell script output (`else` without `if`)

## Known Issues & Future Work
 - Additional GPU backend support (beyond NVIDIA and MetaX) will require adding new condition blocks following the same pattern.
 
## Logs & Screenshots
[out.log](https://github.com/user-attachments/files/27851797/out.log)

CPU-Only Case:
<img width="324" height="101" alt="image" src="https://github.com/user-attachments/assets/94fc218b-322d-4026-a752-d4b4d15fc23e" />

Only MetaX Case:
<img width="558" height="158" alt="image" src="https://github.com/user-attachments/assets/9e04db0a-1987-493b-af11-34c736cb77c9" />

NVIDIA+MetaX Case:
<img width="581" height="199" alt="image" src="https://github.com/user-attachments/assets/1ffb1eed-4e5f-43f5-934a-37647b2a5121" />
