### PR TITLE
feat: support `--launcher` option for `icclrun`

### DIFF
--- a/scripts/icclrun.py
+++ b/scripts/icclrun.py
@@ -19,6 +19,12 @@ def main():
     parser = argparse.ArgumentParser(description="InfiniCCL Unified Launcher")
     parser.add_argument("--config", "-c", dest="cluster", help="Path to cluster.yaml")
     parser.add_argument("--build", action="store_true", help="Compile remote nodes")
+    parser.add_argument(
+        "--launcher",
+        choices=["ompi", "none"],
+        default="ompi",
+        help="Orchestration layer: 'ompi' for mpirun cluster apps, 'none' for native threaded single-node apps.",
+    )
 
     launcher_args, remaining = parser.parse_known_args()
 
@@ -35,7 +41,7 @@ def main():
     if launcher_args.build:
         launcher.orchestrate_build()
 
-    launcher.launch("ompi", executable, app_args, launcher)
+    launcher.launch(launcher_args.launcher, executable, app_args, launcher)
 
 
 if __name__ == "__main__":

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -151,12 +151,24 @@ exec "$EXE" "$@"
         os.chmod(wrapper_path, 0o755)
         return wrapper_path
 
-    def launch(self, backend_name, executable, args, launcher):
-        from backends.ompi import OmpiBackend
+    def launch(self, launcher_type, executable, args, launcher_obj):
+        if launcher_type == "ompi":
+            from backends.ompi import OmpiBackend
 
-        backend = OmpiBackend() if backend_name == "ompi" else None
-        if not backend:
-            return
+            backend = OmpiBackend()
+            cmd = backend.get_launch_command(
+                self.config, executable, args, launcher_obj
+            )
 
-        cmd = backend.get_launch_command(self.config, executable, args, launcher)
+        elif launcher_type == "none":
+            launcher_script = self.config.get("launcher_script")
+            if not launcher_script:
+                launcher_script = launcher_obj.ensure_launcher_exists()
+
+            cmd = [launcher_script, executable] + list(args)
+
+        else:
+            print(f"Error: Unsupported launcher environment '{launcher_type}'")
+            sys.exit(1)
+
         subprocess.run(cmd)


### PR DESCRIPTION
## Summary
This PR adds a `--launcher` option for the unified launcher `icclrun`, allowing users to specify which backend launcher should be used to start the target program.

Previously, `icclrun` was tightly coupled with `mpirun`. However, some environments and use cases do not require — or should not depend on — MPI-based launching. For example, a single-node program using a native collective communication library such as NCCL can run directly without `mpirun`. With the new `--launcher` option, icclrun can now support different launch mechanisms in a more flexible and extensible way.

## Changes
- **Configurable Backend Launcher**
  - add a new `--launcher` option for `icclrun`;
  - currently supported launchers/options:
    - `ompi`: 
      - Uses `mpirun` to launch the program.
      - This remains the default behavior for backward compatibility and this is the most common use case. 
    - `none`: 
      - Directly executes the target executable without invoking any external launcher.
      - Intended for single-node native CCL programs (e.g., NCCL-only workloads).

## Known Issues & Future Work
 - More backend launchers may be added in the future (e.g., `torchrun`).
 
## Logs & Screenshots
[all_gather.log](https://github.com/user-attachments/files/27897574/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/27897575/all_reduce.log)