### PR TITLE
fix(ompi): actually call `MPI_Finalize` in `FinalizeImpl`

### DIFF
--- a/src/ompi/impl/finalize.h
+++ b/src/ompi/impl/finalize.h
@@ -10,8 +10,13 @@ template <Device::Type device_type>
 class FinalizeImpl<BackendType::kOmpi, device_type> {
 public:
   static ReturnStatus Apply() {
-    int finalized;
+    int finalized = 0;
     INFINI_CHECK_MPI(MPI_Finalized(&finalized));
+
+    if (!finalized) {
+      INFINI_CHECK_MPI(MPI_Finalize());
+    }
+
     return ReturnStatus::kSuccess;
   }
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue in `FinalizeImpl<BackendType::kOmpi, ...>::Apply`
where the MPI runtime was never actually shut down.

Previously, the implementation called `MPI_Finalized(&finalized)` to query
whether MPI had already been finalized, but never invoked `MPI_Finalize()`
itself. As a result:

- The MPI runtime was left in an initialized state at process exit
- `MPI_Init_thread` allocations were not properly released
- On some OpenMPI builds this produced shutdown warnings or non-zero exit
  status when the process tore down

## Changes

- **Complete the Finalize Path**
  - In `src/ompi/impl/finalize.h`, after querying `MPI_Finalized`, invoke
    `MPI_Finalize()` when MPI has been initialized but not yet finalized
  - Preserve the existing `INFINI_CHECK_MPI` error-propagation pattern so
    that a non-`MPI_SUCCESS` return is reported through the standard
    OpenMPI check macro
  - No behavior change when MPI was already finalized by user code or by a
    nested call — the guard makes the call idempotent

## Known Issues & Future Work

- The base `CommInitAll` allocates a `Communicator` via `new`, but the
  current `CommDestroy` only clears the inner backend instance and does
  not `delete` the outer object. That separate lifetime issue is out of
  scope for this PR.

## Test Environment

- 4× NVIDIA GPUs (3× H100 PCIe + 1× A100 SXM)
- CUDA 11.8, GCC 11, OpenMPI 4.x (conda environment)
- Build flags: `-DWITH_NVIDIA=ON -DWITH_OMPI=ON`

Verified that the `AllReduce` example exits cleanly with no MPI shutdown
warnings; without this fix the same binary leaves MPI in an unfinalized
state at exit.

 - Heterogeneous Cluster Validation:
[all_reduce.log](https://github.com/user-attachments/files/27981764/all_reduce.log)
[all_gather.log](https://github.com/user-attachments/files/27981769/all_gather.log)