### PR TITLE
feat: support `Send` and `Recv` with OpenMPI backend implementation

### DIFF
--- a/examples/send_recv.cc
+++ b/examples/send_recv.cc
@@ -1,24 +1,14 @@
 /**
- * InfiniCCL Example/Test: Point-to-Point Send/Recv.
+ * InfiniCCL Example: `Send-Recv`
  *
- * Runs a small suite of cases covering blocking P2P:
- *   1. count=0 blocking ping (rank 0 -> 1)
- *   2. blocking ping, rank 0 -> 1
- *   3. blocking ping, rank 0 -> size-1
- *   4. blocking ping-pong, rank 0 <-> 1
- *   5. large count (>INT_MAX bytes), gated by INFINI_SENDRECV_LARGE=1
- *   6. invalid peer (-1 and size) -> infiniInvalidArgument
+ * This example demonstrates point-to-point `infiniSend` and `infiniRecv`
+ * operations between rank 0 and rank 1 on accelerator memory.
  */
 
-#include <mpi.h>
 #include <unistd.h>
 
-#include <cmath>
-#include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <iostream>
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -29,353 +19,13 @@
 #include "traits.h"
 #include "utils.h"
 
-using namespace infini::ccl;
+namespace ccl = infini::ccl;
 
-namespace {
-
-struct CaseResult {
-  bool ok = true;
-  bool skipped = false;
-  std::string note;
-};
-
-bool AllRanksOk(bool local_ok) {
-  int local = local_ok ? 1 : 0;
-  int global = 0;
-  MPI_Allreduce(&local, &global, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
-  return global != 0;
-}
-
-void PrintCase(int rank, const std::string &name, const CaseResult &local,
-               bool global_ok) {
-  if (rank != 0) {
-    return;
-  }
-  const char *GREEN = "\033[32m";
-  const char *YELLOW = "\033[33m";
-  const char *RED = "\033[31m";
-  const char *RESET = "\033[0m";
-
-  std::string status;
-  if (local.skipped) {
-    status = std::string(YELLOW) + "SKIP" + RESET;
-  } else if (global_ok) {
-    status = std::string(GREEN) + "PASS" + RESET;
-  } else {
-    status = std::string(RED) + "FAIL" + RESET;
-  }
-
-  std::cout << "[" << name << "] " << status;
-  if (!local.note.empty()) {
-    std::cout << " (rank0: " << local.note << ")";
-  }
-  std::cout << std::endl;
-}
-
-CaseResult SkipNeed2Ranks(int rank) {
-  return {true, true, (rank == 0) ? "needs at least 2 ranks" : ""};
-}
-
-int GetEnvInt(const char *name, int fallback) {
-  const char *value = std::getenv(name);
-  if (value == nullptr || value[0] == '\0') {
-    return fallback;
-  }
-
-  char *end = nullptr;
-  long parsed = std::strtol(value, &end, 10);
-  if (end == value || *end != '\0') {
-    return fallback;
-  }
-
-  return static_cast<int>(parsed);
-}
-
-int GetLocalRank() {
-  int local_rank = GetEnvInt("OMPI_COMM_WORLD_LOCAL_RANK", -1);
-  if (local_rank >= 0) {
-    return local_rank;
-  }
-
-  local_rank = GetEnvInt("MPI_LOCALRANKID", -1);
-  if (local_rank >= 0) {
-    return local_rank;
-  }
-
-  local_rank = GetEnvInt("SLURM_LOCALID", -1);
-  if (local_rank >= 0) {
-    return local_rank;
-  }
-
-  return 0;
-}
-
-template <Device::Type kDev>
-void PrintRankMapping(int rank, int size) {
-  for (int r = 0; r < size; ++r) {
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    if (rank == r) {
-      char host[256] = {};
-      if (gethostname(host, sizeof(host)) != 0) {
-        std::snprintf(host, sizeof(host), "unknown");
-      }
-
-      std::cout << "[Rank " << rank << "] Host: " << host
-                << " | GPU: " << Device::StringFromType(kDev) << " | Device "
-                << GetLocalRank() << std::endl;
-    }
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-// Allocate a device buffer holding `count` floats == `value`.
-template <Device::Type kDev>
-float *AllocFilled(size_t count, float value) {
-  float *d = nullptr;
-  Runtime<kDev>::Malloc(&d, count * sizeof(float));
-  std::vector<float> h(count, value);
-  Runtime<kDev>::Memcpy(d, h.data(), count * sizeof(float),
-                        Runtime<kDev>::MemcpyHostToDevice);
-  return d;
-}
-
-// Verify `count` floats on device equal `expected`.
-template <Device::Type kDev>
-bool DeviceEqualsFloat(const float *d, size_t count, float expected) {
-  std::vector<float> h(count);
-  Runtime<kDev>::Memcpy(h.data(), d, count * sizeof(float),
-                        Runtime<kDev>::MemcpyDeviceToHost);
-  for (size_t i = 0; i < count; ++i) {
-    if (std::fabs(h[i] - expected) > 1e-3) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// ---------------------------------------------------------------------------
-// Case 1: count=0 blocking ping
-// ---------------------------------------------------------------------------
-CaseResult Case_Count0Ping(infiniComm_t comm, int rank, int size) {
-  if (size < 2) {
-    return SkipNeed2Ranks(rank);
-  }
-  if (rank == 0) {
-    infiniResult_t s = infiniSend(nullptr, 0, infiniFloat32, 1, comm, nullptr);
-    if (s != infiniSuccess) {
-      return {false, false,
-              "send returned " + std::to_string(static_cast<int>(s))};
-    }
-  } else if (rank == 1) {
-    infiniResult_t s = infiniRecv(nullptr, 0, infiniFloat32, 0, comm, nullptr);
-    if (s != infiniSuccess) {
-      return {false, false,
-              "recv returned " + std::to_string(static_cast<int>(s))};
-    }
-  }
-  return {};
-}
-
-// ---------------------------------------------------------------------------
-// Helper: run a basic blocking ping `sender → receiver` for `count` floats
-// of value `value`, and have the receiver verify on the device side.
-// ---------------------------------------------------------------------------
-template <Device::Type kDev>
-CaseResult RunBlockingPing(infiniComm_t comm, int rank, int sender,
-                           int receiver, size_t count, float value) {
-  if (rank == sender) {
-    float *d_send = AllocFilled<kDev>(count, value);
-    infiniResult_t s =
-        infiniSend(d_send, count, infiniFloat32, receiver, comm, nullptr);
-    Runtime<kDev>::Free(d_send);
-    if (s != infiniSuccess) {
-      return {false, false,
-              "send returned " + std::to_string(static_cast<int>(s))};
-    }
-  } else if (rank == receiver) {
-    float *d_recv = AllocFilled<kDev>(count, -1.0f);
-    infiniResult_t s =
-        infiniRecv(d_recv, count, infiniFloat32, sender, comm, nullptr);
-    if (s != infiniSuccess) {
-      Runtime<kDev>::Free(d_recv);
-      return {false, false,
-              "recv returned " + std::to_string(static_cast<int>(s))};
-    }
-    bool ok = DeviceEqualsFloat<kDev>(d_recv, count, value);
-    Runtime<kDev>::Free(d_recv);
-    if (!ok) {
-      return {false, false, "received data did not match expected value"};
-    }
-  }
-  return {};
-}
-
-// ---------------------------------------------------------------------------
-// Case 2/3: blocking ping rank 0 → 1, rank 0 → size-1
-// ---------------------------------------------------------------------------
-template <Device::Type kDev>
-CaseResult Case_BlockingPing01(infiniComm_t comm, int rank, int size) {
-  if (size < 2) return SkipNeed2Ranks(rank);
-  return RunBlockingPing<kDev>(comm, rank, /*sender=*/0, /*receiver=*/1,
-                               /*count=*/1024, /*value=*/3.5f);
-}
-
-template <Device::Type kDev>
-CaseResult Case_BlockingPing0Last(infiniComm_t comm, int rank, int size) {
-  if (size < 2) return SkipNeed2Ranks(rank);
-  return RunBlockingPing<kDev>(comm, rank, /*sender=*/0,
-                               /*receiver=*/size - 1,
-                               /*count=*/2048, /*value=*/-7.25f);
-}
-
-// ---------------------------------------------------------------------------
-// Case 4: blocking ping-pong, rank 0 ↔ 1
-// ---------------------------------------------------------------------------
-template <Device::Type kDev>
-CaseResult Case_BlockingPingPong01(infiniComm_t comm, int rank, int size) {
-  if (size < 2) return SkipNeed2Ranks(rank);
-  constexpr size_t kCount = 512;
-  constexpr float kForward = 11.0f;
-  constexpr float kReply = -22.0f;
-
-  if (rank == 0) {
-    float *d_out = AllocFilled<kDev>(kCount, kForward);
-    float *d_in = AllocFilled<kDev>(kCount, -1.0f);
-
-    infiniResult_t s =
-        infiniSend(d_out, kCount, infiniFloat32, 1, comm, nullptr);
-    if (s != infiniSuccess) {
-      Runtime<kDev>::Free(d_out);
-      Runtime<kDev>::Free(d_in);
-      return {false, false,
-              "rank0 send returned " + std::to_string(static_cast<int>(s))};
-    }
-    s = infiniRecv(d_in, kCount, infiniFloat32, 1, comm, nullptr);
-    if (s != infiniSuccess) {
-      Runtime<kDev>::Free(d_out);
-      Runtime<kDev>::Free(d_in);
-      return {false, false,
-              "rank0 recv returned " + std::to_string(static_cast<int>(s))};
-    }
-    bool ok = DeviceEqualsFloat<kDev>(d_in, kCount, kReply);
-    Runtime<kDev>::Free(d_out);
-    Runtime<kDev>::Free(d_in);
-    if (!ok) return {false, false, "rank0 reply mismatch"};
-  } else if (rank == 1) {
-    float *d_in = AllocFilled<kDev>(kCount, -1.0f);
-    infiniResult_t s =
-        infiniRecv(d_in, kCount, infiniFloat32, 0, comm, nullptr);
-    if (s != infiniSuccess) {
-      Runtime<kDev>::Free(d_in);
-      return {false, false,
-              "rank1 recv returned " + std::to_string(static_cast<int>(s))};
-    }
-    bool ok = DeviceEqualsFloat<kDev>(d_in, kCount, kForward);
-    Runtime<kDev>::Free(d_in);
-    if (!ok) return {false, false, "rank1 forward mismatch"};
-
-    float *d_out = AllocFilled<kDev>(kCount, kReply);
-    s = infiniSend(d_out, kCount, infiniFloat32, 0, comm, nullptr);
-    Runtime<kDev>::Free(d_out);
-    if (s != infiniSuccess) {
-      return {false, false,
-              "rank1 send returned " + std::to_string(static_cast<int>(s))};
-    }
-  }
-  return {};
-}
-
-// ---------------------------------------------------------------------------
-// Case 7: large count chunking (blocking, gated)
-// ---------------------------------------------------------------------------
-template <Device::Type kDev>
-CaseResult Case_LargeCount(infiniComm_t comm, int rank, int size) {
-  if (size < 2) return SkipNeed2Ranks(rank);
-  if (std::getenv("INFINI_SENDRECV_LARGE") == nullptr) {
-    return {
-        true, true,
-        (rank == 0) ? "set INFINI_SENDRECV_LARGE=1 to enable (~2GB/rank)" : ""};
-  }
-  const size_t count = static_cast<size_t>(std::numeric_limits<int>::max()) +
-                       static_cast<size_t>(1024);
-  const std::int8_t expected = 0x5A;
-  const size_t total_bytes = count * sizeof(std::int8_t);
-
-  if (rank == 0) {
-    std::int8_t *d_out = nullptr;
-    Runtime<kDev>::Malloc(&d_out, total_bytes);
-    std::vector<std::int8_t> h_out(count, expected);
-    Runtime<kDev>::Memcpy(d_out, h_out.data(), total_bytes,
-                          Runtime<kDev>::MemcpyHostToDevice);
-    infiniResult_t s = infiniSend(d_out, count, infiniChar, 1, comm, nullptr);
-    Runtime<kDev>::Free(d_out);
-    if (s != infiniSuccess) {
-      return {false, false,
-              "Send returned " + std::to_string(static_cast<int>(s))};
-    }
-  } else if (rank == 1) {
-    std::int8_t *d_in = nullptr;
-    Runtime<kDev>::Malloc(&d_in, total_bytes);
-    infiniResult_t s = infiniRecv(d_in, count, infiniChar, 0, comm, nullptr);
-    if (s != infiniSuccess) {
-      Runtime<kDev>::Free(d_in);
-      return {false, false,
-              "Recv returned " + std::to_string(static_cast<int>(s))};
-    }
-    std::int8_t probes[3] = {-1, -1, -1};
-    Runtime<kDev>::Memcpy(&probes[0], d_in, sizeof(std::int8_t),
-                          Runtime<kDev>::MemcpyDeviceToHost);
-    Runtime<kDev>::Memcpy(&probes[1], d_in + (count / 2), sizeof(std::int8_t),
-                          Runtime<kDev>::MemcpyDeviceToHost);
-    Runtime<kDev>::Memcpy(&probes[2], d_in + (count - 1), sizeof(std::int8_t),
-                          Runtime<kDev>::MemcpyDeviceToHost);
-    Runtime<kDev>::Free(d_in);
-    if (probes[0] != expected || probes[1] != expected ||
-        probes[2] != expected) {
-      return {false, false, "head/mid/tail mismatch"};
-    }
-  }
-  return {};
-}
-
-// ---------------------------------------------------------------------------
-// Case 8: invalid peer
-// ---------------------------------------------------------------------------
-CaseResult Case_InvalidPeer(infiniComm_t comm, int rank, int size) {
-  if (size < 2) return SkipNeed2Ranks(rank);
-  // Only rank 0 attempts the bad calls; the impl rejects them at the base
-  // validator before any MPI traffic, so other ranks don't need to mirror.
-  if (rank != 0) {
-    return {};
-  }
-  float dummy = 0.f;
-  for (int bad_peer : {-1, size}) {
-    infiniResult_t s =
-        infiniSend(&dummy, 1, infiniFloat32, bad_peer, comm, nullptr);
-    if (s != infiniInvalidArgument) {
-      return {false, false,
-              "Send peer=" + std::to_string(bad_peer) + " expected " +
-                  std::to_string(static_cast<int>(infiniInvalidArgument)) +
-                  ", got " + std::to_string(static_cast<int>(s))};
-    }
-    s = infiniRecv(&dummy, 1, infiniFloat32, bad_peer, comm, nullptr);
-    if (s != infiniInvalidArgument) {
-      return {false, false,
-              "Recv peer=" + std::to_string(bad_peer) + " expected " +
-                  std::to_string(static_cast<int>(infiniInvalidArgument)) +
-                  ", got " + std::to_string(static_cast<int>(s))};
-    }
-  }
-  return {};
-}
-
-}  // namespace
-
-int main(int argc, char **argv) {
-  constexpr Device::Type kDevType =
-      ListGetBest<DevicePriority>(EnabledDevices{});
+void RunSendRecvExample(int argc, char **argv, int warmup_iter,
+                        int profile_iter, size_t num_elements) {
+  constexpr ccl::Device::Type kDevType =
+      ccl::ListGetBest<ccl::DevicePriority>(ccl::EnabledDevices{});
+  using Rt = ccl::Runtime<kDevType>;
 
   CHECK_INFINI(infiniInit(&argc, &argv));
 
@@ -384,49 +34,148 @@ int main(int argc, char **argv) {
   CHECK_INFINI(infiniGetRank(&rank));
   CHECK_INFINI(infiniGetSize(&size));
 
-  if (rank == 0) {
-    std::cout << "=== Send/Recv Test Suite ===" << std::endl;
-    std::cout << "Device: " << Device::StringFromType(kDevType) << std::endl;
-    std::cout << "Ranks:  " << size << std::endl;
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_str != nullptr) {
+    local_rank = std::atoi(local_rank_str);
   }
 
-  PrintRankMapping<kDevType>(rank, size);
+  std::cout << "[Rank " << rank << "] Host: " << hostname
+            << " | GPU: " << ccl::Device::StringFromType(kDevType) << " "
+            << " | Device " << local_rank << std::endl;
+
+  constexpr int kSender = 0;
+  constexpr int kReceiver = 1;
+  constexpr int kRequiredRanks = 2;
+  constexpr float kSendValue = 7.0f;
+
+  if (size < kRequiredRanks) {
+    if (rank == kSender) {
+      std::cerr << "Send/Recv example requires at least 2 ranks." << std::endl;
+    }
+
+    CHECK_INFINI(infiniFinalize());
+    return;
+  }
 
   infiniComm_t comm = nullptr;
   CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
 
-  bool overall_ok = true;
+  std::vector<float> h_send(num_elements, kSendValue);
+  std::vector<float> h_recv(num_elements, 0.0f);
 
-  auto run = [&](const std::string &name, CaseResult local) {
-    bool global_ok = AllRanksOk(local.ok);
-    PrintCase(rank, name, local, global_ok);
-    if (!local.skipped) {
-      overall_ok = overall_ok && global_ok;
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  size_t total_bytes = num_elements * sizeof(*d_send);
+
+  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  if (rank == kSender) {
+    std::cout << "\n=== Performing Send/Recv on GPU Memory ===" << std::endl;
+    std::cout << "Sender rank: " << kSender << std::endl;
+    std::cout << "Receiver rank: " << kReceiver << std::endl;
+    std::cout << "Data size: " << num_elements << " floats ("
+              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
+    std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
+    std::cout << "Profile iterations: " << profile_iter << std::endl;
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  auto send_recv_call = [&]() {
+    if (rank == kSender) {
+      return infiniSend(d_send, num_elements, infiniFloat32, kReceiver, comm,
+                        nullptr);
     }
+
+    if (rank == kReceiver) {
+      return infiniRecv(d_recv, num_elements, infiniFloat32, kSender, comm,
+                        nullptr);
+    }
+
+    return infiniSuccess;
   };
 
-  run("count=0 ping (blocking)", Case_Count0Ping(comm, rank, size));
-  run("blocking ping, 0 -> 1", Case_BlockingPing01<kDevType>(comm, rank, size));
-  run("blocking ping, 0 -> size-1",
-      Case_BlockingPing0Last<kDevType>(comm, rank, size));
-  run("blocking ping-pong, 0 <-> 1",
-      Case_BlockingPingPong01<kDevType>(comm, rank, size));
-  run("large count (>INT_MAX bytes)",
-      Case_LargeCount<kDevType>(comm, rank, size));
-  run("invalid peer", Case_InvalidPeer(comm, rank, size));
-
-  if (rank == 0) {
-    const char *GREEN = "\033[32m";
-    const char *RED = "\033[31m";
-    const char *RESET = "\033[0m";
-    std::cout << "\n=== Summary ===" << std::endl;
-    std::cout << (overall_ok ? (std::string(GREEN) + "ALL PASS" + RESET)
-                             : (std::string(RED) + "FAILED" + RESET))
-              << std::endl;
+  CHECK_INFINI(send_recv_call());
+  if (rank == kReceiver) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                            Rt::MemcpyDeviceToHost));
   }
+
+  for (int i = 1; i < warmup_iter; ++i) {
+    CHECK_INFINI(send_recv_call());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+
+  for (int i = 0; i < profile_iter; ++i) {
+    CHECK_INFINI(send_recv_call());
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  if (rank == kReceiver) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+  }
+
+  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+
+  if (rank == kReceiver) {
+    bool correct = Validator::ValidateResult(
+        h_recv.data(), num_elements, kSendValue, rank, false, "SendRecv");
+
+    const char *kGreen = "\033[32m";
+    const char *kRed = "\033[31m";
+    const char *kReset = "\033[0m";
+
+    std::cout << "\n=== Send/Recv Results ===" << std::endl;
+    std::cout << "Correct: "
+              << (correct ? (kGreen + std::string("YES") + kReset)
+                          : (kRed + std::string("NO") + kReset))
+              << std::endl;
+    std::cout << "Expect:  " << kSendValue << std::endl;
+    std::cout << "Actual:  " << h_recv[0] << std::endl;
+
+    if (!correct) {
+      CHECK_RT(Rt, Rt::Free(d_send));
+      CHECK_RT(Rt, Rt::Free(d_recv));
+      CHECK_INFINI(infiniCommDestroy(comm));
+      CHECK_INFINI(infiniFinalize());
+      std::exit(EXIT_FAILURE);
+    }
+  }
+
+  if (rank == kSender) {
+    Metrics metrics{elapsed, total_bytes, kRequiredRanks};
+    metrics.Print();
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
 
   CHECK_INFINI(infiniCommDestroy(comm));
   CHECK_INFINI(infiniFinalize());
 
-  return overall_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+  if (rank == kSender) {
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  RunSendRecvExample(argc, argv, warmup_iters, profile_iters, num_elements);
+
+  return EXIT_SUCCESS;
 }

--- a/examples/send_recv.cc
+++ b/examples/send_recv.cc
@@ -1,0 +1,432 @@
+/**
+ * InfiniCCL Example/Test: Point-to-Point Send/Recv.
+ *
+ * Runs a small suite of cases covering blocking P2P:
+ *   1. count=0 blocking ping (rank 0 -> 1)
+ *   2. blocking ping, rank 0 -> 1
+ *   3. blocking ping, rank 0 -> size-1
+ *   4. blocking ping-pong, rank 0 <-> 1
+ *   5. large count (>INT_MAX bytes), gated by INFINI_SENDRECV_LARGE=1
+ *   6. invalid peer (-1 and size) -> infiniInvalidArgument
+ */
+
+#include <mpi.h>
+#include <unistd.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "device.h"
+#include "infiniccl.h"
+#include "runtime.h"
+#include "traits.h"
+#include "utils.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+struct CaseResult {
+  bool ok = true;
+  bool skipped = false;
+  std::string note;
+};
+
+bool AllRanksOk(bool local_ok) {
+  int local = local_ok ? 1 : 0;
+  int global = 0;
+  MPI_Allreduce(&local, &global, 1, MPI_INT, MPI_LAND, MPI_COMM_WORLD);
+  return global != 0;
+}
+
+void PrintCase(int rank, const std::string &name, const CaseResult &local,
+               bool global_ok) {
+  if (rank != 0) {
+    return;
+  }
+  const char *GREEN = "\033[32m";
+  const char *YELLOW = "\033[33m";
+  const char *RED = "\033[31m";
+  const char *RESET = "\033[0m";
+
+  std::string status;
+  if (local.skipped) {
+    status = std::string(YELLOW) + "SKIP" + RESET;
+  } else if (global_ok) {
+    status = std::string(GREEN) + "PASS" + RESET;
+  } else {
+    status = std::string(RED) + "FAIL" + RESET;
+  }
+
+  std::cout << "[" << name << "] " << status;
+  if (!local.note.empty()) {
+    std::cout << " (rank0: " << local.note << ")";
+  }
+  std::cout << std::endl;
+}
+
+CaseResult SkipNeed2Ranks(int rank) {
+  return {true, true, (rank == 0) ? "needs at least 2 ranks" : ""};
+}
+
+int GetEnvInt(const char *name, int fallback) {
+  const char *value = std::getenv(name);
+  if (value == nullptr || value[0] == '\0') {
+    return fallback;
+  }
+
+  char *end = nullptr;
+  long parsed = std::strtol(value, &end, 10);
+  if (end == value || *end != '\0') {
+    return fallback;
+  }
+
+  return static_cast<int>(parsed);
+}
+
+int GetLocalRank() {
+  int local_rank = GetEnvInt("OMPI_COMM_WORLD_LOCAL_RANK", -1);
+  if (local_rank >= 0) {
+    return local_rank;
+  }
+
+  local_rank = GetEnvInt("MPI_LOCALRANKID", -1);
+  if (local_rank >= 0) {
+    return local_rank;
+  }
+
+  local_rank = GetEnvInt("SLURM_LOCALID", -1);
+  if (local_rank >= 0) {
+    return local_rank;
+  }
+
+  return 0;
+}
+
+template <Device::Type kDev>
+void PrintRankMapping(int rank, int size) {
+  for (int r = 0; r < size; ++r) {
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == r) {
+      char host[256] = {};
+      if (gethostname(host, sizeof(host)) != 0) {
+        std::snprintf(host, sizeof(host), "unknown");
+      }
+
+      std::cout << "[Rank " << rank << "] Host: " << host
+                << " | GPU: " << Device::StringFromType(kDev) << " | Device "
+                << GetLocalRank() << std::endl;
+    }
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Allocate a device buffer holding `count` floats == `value`.
+template <Device::Type kDev>
+float *AllocFilled(size_t count, float value) {
+  float *d = nullptr;
+  Runtime<kDev>::Malloc(&d, count * sizeof(float));
+  std::vector<float> h(count, value);
+  Runtime<kDev>::Memcpy(d, h.data(), count * sizeof(float),
+                        Runtime<kDev>::MemcpyHostToDevice);
+  return d;
+}
+
+// Verify `count` floats on device equal `expected`.
+template <Device::Type kDev>
+bool DeviceEqualsFloat(const float *d, size_t count, float expected) {
+  std::vector<float> h(count);
+  Runtime<kDev>::Memcpy(h.data(), d, count * sizeof(float),
+                        Runtime<kDev>::MemcpyDeviceToHost);
+  for (size_t i = 0; i < count; ++i) {
+    if (std::fabs(h[i] - expected) > 1e-3) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: count=0 blocking ping
+// ---------------------------------------------------------------------------
+CaseResult Case_Count0Ping(infiniComm_t comm, int rank, int size) {
+  if (size < 2) {
+    return SkipNeed2Ranks(rank);
+  }
+  if (rank == 0) {
+    infiniResult_t s = infiniSend(nullptr, 0, infiniFloat32, 1, comm, nullptr);
+    if (s != infiniSuccess) {
+      return {false, false,
+              "send returned " + std::to_string(static_cast<int>(s))};
+    }
+  } else if (rank == 1) {
+    infiniResult_t s = infiniRecv(nullptr, 0, infiniFloat32, 0, comm, nullptr);
+    if (s != infiniSuccess) {
+      return {false, false,
+              "recv returned " + std::to_string(static_cast<int>(s))};
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Helper: run a basic blocking ping `sender → receiver` for `count` floats
+// of value `value`, and have the receiver verify on the device side.
+// ---------------------------------------------------------------------------
+template <Device::Type kDev>
+CaseResult RunBlockingPing(infiniComm_t comm, int rank, int sender,
+                           int receiver, size_t count, float value) {
+  if (rank == sender) {
+    float *d_send = AllocFilled<kDev>(count, value);
+    infiniResult_t s =
+        infiniSend(d_send, count, infiniFloat32, receiver, comm, nullptr);
+    Runtime<kDev>::Free(d_send);
+    if (s != infiniSuccess) {
+      return {false, false,
+              "send returned " + std::to_string(static_cast<int>(s))};
+    }
+  } else if (rank == receiver) {
+    float *d_recv = AllocFilled<kDev>(count, -1.0f);
+    infiniResult_t s =
+        infiniRecv(d_recv, count, infiniFloat32, sender, comm, nullptr);
+    if (s != infiniSuccess) {
+      Runtime<kDev>::Free(d_recv);
+      return {false, false,
+              "recv returned " + std::to_string(static_cast<int>(s))};
+    }
+    bool ok = DeviceEqualsFloat<kDev>(d_recv, count, value);
+    Runtime<kDev>::Free(d_recv);
+    if (!ok) {
+      return {false, false, "received data did not match expected value"};
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Case 2/3: blocking ping rank 0 → 1, rank 0 → size-1
+// ---------------------------------------------------------------------------
+template <Device::Type kDev>
+CaseResult Case_BlockingPing01(infiniComm_t comm, int rank, int size) {
+  if (size < 2) return SkipNeed2Ranks(rank);
+  return RunBlockingPing<kDev>(comm, rank, /*sender=*/0, /*receiver=*/1,
+                               /*count=*/1024, /*value=*/3.5f);
+}
+
+template <Device::Type kDev>
+CaseResult Case_BlockingPing0Last(infiniComm_t comm, int rank, int size) {
+  if (size < 2) return SkipNeed2Ranks(rank);
+  return RunBlockingPing<kDev>(comm, rank, /*sender=*/0,
+                               /*receiver=*/size - 1,
+                               /*count=*/2048, /*value=*/-7.25f);
+}
+
+// ---------------------------------------------------------------------------
+// Case 4: blocking ping-pong, rank 0 ↔ 1
+// ---------------------------------------------------------------------------
+template <Device::Type kDev>
+CaseResult Case_BlockingPingPong01(infiniComm_t comm, int rank, int size) {
+  if (size < 2) return SkipNeed2Ranks(rank);
+  constexpr size_t kCount = 512;
+  constexpr float kForward = 11.0f;
+  constexpr float kReply = -22.0f;
+
+  if (rank == 0) {
+    float *d_out = AllocFilled<kDev>(kCount, kForward);
+    float *d_in = AllocFilled<kDev>(kCount, -1.0f);
+
+    infiniResult_t s =
+        infiniSend(d_out, kCount, infiniFloat32, 1, comm, nullptr);
+    if (s != infiniSuccess) {
+      Runtime<kDev>::Free(d_out);
+      Runtime<kDev>::Free(d_in);
+      return {false, false,
+              "rank0 send returned " + std::to_string(static_cast<int>(s))};
+    }
+    s = infiniRecv(d_in, kCount, infiniFloat32, 1, comm, nullptr);
+    if (s != infiniSuccess) {
+      Runtime<kDev>::Free(d_out);
+      Runtime<kDev>::Free(d_in);
+      return {false, false,
+              "rank0 recv returned " + std::to_string(static_cast<int>(s))};
+    }
+    bool ok = DeviceEqualsFloat<kDev>(d_in, kCount, kReply);
+    Runtime<kDev>::Free(d_out);
+    Runtime<kDev>::Free(d_in);
+    if (!ok) return {false, false, "rank0 reply mismatch"};
+  } else if (rank == 1) {
+    float *d_in = AllocFilled<kDev>(kCount, -1.0f);
+    infiniResult_t s =
+        infiniRecv(d_in, kCount, infiniFloat32, 0, comm, nullptr);
+    if (s != infiniSuccess) {
+      Runtime<kDev>::Free(d_in);
+      return {false, false,
+              "rank1 recv returned " + std::to_string(static_cast<int>(s))};
+    }
+    bool ok = DeviceEqualsFloat<kDev>(d_in, kCount, kForward);
+    Runtime<kDev>::Free(d_in);
+    if (!ok) return {false, false, "rank1 forward mismatch"};
+
+    float *d_out = AllocFilled<kDev>(kCount, kReply);
+    s = infiniSend(d_out, kCount, infiniFloat32, 0, comm, nullptr);
+    Runtime<kDev>::Free(d_out);
+    if (s != infiniSuccess) {
+      return {false, false,
+              "rank1 send returned " + std::to_string(static_cast<int>(s))};
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Case 7: large count chunking (blocking, gated)
+// ---------------------------------------------------------------------------
+template <Device::Type kDev>
+CaseResult Case_LargeCount(infiniComm_t comm, int rank, int size) {
+  if (size < 2) return SkipNeed2Ranks(rank);
+  if (std::getenv("INFINI_SENDRECV_LARGE") == nullptr) {
+    return {
+        true, true,
+        (rank == 0) ? "set INFINI_SENDRECV_LARGE=1 to enable (~2GB/rank)" : ""};
+  }
+  const size_t count = static_cast<size_t>(std::numeric_limits<int>::max()) +
+                       static_cast<size_t>(1024);
+  const std::int8_t expected = 0x5A;
+  const size_t total_bytes = count * sizeof(std::int8_t);
+
+  if (rank == 0) {
+    std::int8_t *d_out = nullptr;
+    Runtime<kDev>::Malloc(&d_out, total_bytes);
+    std::vector<std::int8_t> h_out(count, expected);
+    Runtime<kDev>::Memcpy(d_out, h_out.data(), total_bytes,
+                          Runtime<kDev>::MemcpyHostToDevice);
+    infiniResult_t s = infiniSend(d_out, count, infiniChar, 1, comm, nullptr);
+    Runtime<kDev>::Free(d_out);
+    if (s != infiniSuccess) {
+      return {false, false,
+              "Send returned " + std::to_string(static_cast<int>(s))};
+    }
+  } else if (rank == 1) {
+    std::int8_t *d_in = nullptr;
+    Runtime<kDev>::Malloc(&d_in, total_bytes);
+    infiniResult_t s = infiniRecv(d_in, count, infiniChar, 0, comm, nullptr);
+    if (s != infiniSuccess) {
+      Runtime<kDev>::Free(d_in);
+      return {false, false,
+              "Recv returned " + std::to_string(static_cast<int>(s))};
+    }
+    std::int8_t probes[3] = {-1, -1, -1};
+    Runtime<kDev>::Memcpy(&probes[0], d_in, sizeof(std::int8_t),
+                          Runtime<kDev>::MemcpyDeviceToHost);
+    Runtime<kDev>::Memcpy(&probes[1], d_in + (count / 2), sizeof(std::int8_t),
+                          Runtime<kDev>::MemcpyDeviceToHost);
+    Runtime<kDev>::Memcpy(&probes[2], d_in + (count - 1), sizeof(std::int8_t),
+                          Runtime<kDev>::MemcpyDeviceToHost);
+    Runtime<kDev>::Free(d_in);
+    if (probes[0] != expected || probes[1] != expected ||
+        probes[2] != expected) {
+      return {false, false, "head/mid/tail mismatch"};
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Case 8: invalid peer
+// ---------------------------------------------------------------------------
+CaseResult Case_InvalidPeer(infiniComm_t comm, int rank, int size) {
+  if (size < 2) return SkipNeed2Ranks(rank);
+  // Only rank 0 attempts the bad calls; the impl rejects them at the base
+  // validator before any MPI traffic, so other ranks don't need to mirror.
+  if (rank != 0) {
+    return {};
+  }
+  float dummy = 0.f;
+  for (int bad_peer : {-1, size}) {
+    infiniResult_t s =
+        infiniSend(&dummy, 1, infiniFloat32, bad_peer, comm, nullptr);
+    if (s != infiniInvalidArgument) {
+      return {false, false,
+              "Send peer=" + std::to_string(bad_peer) + " expected " +
+                  std::to_string(static_cast<int>(infiniInvalidArgument)) +
+                  ", got " + std::to_string(static_cast<int>(s))};
+    }
+    s = infiniRecv(&dummy, 1, infiniFloat32, bad_peer, comm, nullptr);
+    if (s != infiniInvalidArgument) {
+      return {false, false,
+              "Recv peer=" + std::to_string(bad_peer) + " expected " +
+                  std::to_string(static_cast<int>(infiniInvalidArgument)) +
+                  ", got " + std::to_string(static_cast<int>(s))};
+    }
+  }
+  return {};
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+
+  CHECK_INFINI(infiniInit(&argc, &argv));
+
+  int rank = 0;
+  int size = 0;
+  CHECK_INFINI(infiniGetRank(&rank));
+  CHECK_INFINI(infiniGetSize(&size));
+
+  if (rank == 0) {
+    std::cout << "=== Send/Recv Test Suite ===" << std::endl;
+    std::cout << "Device: " << Device::StringFromType(kDevType) << std::endl;
+    std::cout << "Ranks:  " << size << std::endl;
+  }
+
+  PrintRankMapping<kDevType>(rank, size);
+
+  infiniComm_t comm = nullptr;
+  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+
+  bool overall_ok = true;
+
+  auto run = [&](const std::string &name, CaseResult local) {
+    bool global_ok = AllRanksOk(local.ok);
+    PrintCase(rank, name, local, global_ok);
+    if (!local.skipped) {
+      overall_ok = overall_ok && global_ok;
+    }
+  };
+
+  run("count=0 ping (blocking)", Case_Count0Ping(comm, rank, size));
+  run("blocking ping, 0 -> 1", Case_BlockingPing01<kDevType>(comm, rank, size));
+  run("blocking ping, 0 -> size-1",
+      Case_BlockingPing0Last<kDevType>(comm, rank, size));
+  run("blocking ping-pong, 0 <-> 1",
+      Case_BlockingPingPong01<kDevType>(comm, rank, size));
+  run("large count (>INT_MAX bytes)",
+      Case_LargeCount<kDevType>(comm, rank, size));
+  run("invalid peer", Case_InvalidPeer(comm, rank, size));
+
+  if (rank == 0) {
+    const char *GREEN = "\033[32m";
+    const char *RED = "\033[31m";
+    const char *RESET = "\033[0m";
+    std::cout << "\n=== Summary ===" << std::endl;
+    std::cout << (overall_ok ? (std::string(GREEN) + "ALL PASS" + RESET)
+                             : (std::string(RED) + "FAILED" + RESET))
+              << std::endl;
+  }
+
+  CHECK_INFINI(infiniCommDestroy(comm));
+  CHECK_INFINI(infiniFinalize());
+
+  return overall_ok ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/include/comm.h
+++ b/include/comm.h
@@ -61,6 +61,14 @@ infiniResult_t infiniAllToAll(const void *sendbuff, void *recvbuff,
                               size_t count, infiniDataType_t datatype,
                               infiniComm_t comm, void *stream);
 
+infiniResult_t infiniSend(const void *sendbuff, size_t count,
+                          infiniDataType_t datatype, int peer,
+                          infiniComm_t comm, void *stream);
+
+infiniResult_t infiniRecv(void *recvbuff, size_t count,
+                          infiniDataType_t datatype, int peer,
+                          infiniComm_t comm, void *stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/recv.h
+++ b/src/base/recv.h
@@ -1,0 +1,61 @@
+#ifndef INFINI_CCL_BASE_RECV_H_
+#define INFINI_CCL_BASE_RECV_H_
+
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct RecvImpl;
+
+class Recv : public Operation<Recv> {
+ public:
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(void *recv_buff, size_t count, DataType datatype,
+                              int peer, void *comm_handle, void *stream) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for Recv.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (HasInvalidArgs(recv_buff, count, datatype, peer, comm)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
+    return RecvImpl<backend_type, device_type>::Apply(
+        recv_buff, count, datatype, peer, comm, stream);
+  }
+
+ private:
+  static bool HasInvalidArgs(const void *recv_buff, size_t count,
+                             DataType datatype, int peer, Communicator *comm) {
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for Recv.");
+      return true;
+    }
+    if (peer < 0 || peer >= comm->size()) {
+      LOG("Invalid peer rank for Recv.");
+      return true;
+    }
+    if (count == 0) {
+      return false;
+    }
+    if (!recv_buff) {
+      LOG("Invalid receive buffer pointer for Recv.");
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BASE_RECV_H_

--- a/src/base/recv.h
+++ b/src/base/recv.h
@@ -18,7 +18,7 @@ class Recv : public Operation<Recv> {
   static ReturnStatus Execute(void *recv_buff, size_t count, DataType datatype,
                               int peer, void *comm_handle, void *stream) {
     if (!comm_handle) {
-      LOG("Invalid communicator handle for Recv.");
+      LOG("Invalid communicator handle for `Recv`.");
       return ReturnStatus::kInvalidArgument;
     }
 
@@ -38,18 +38,18 @@ class Recv : public Operation<Recv> {
   static bool HasInvalidArgs(const void *recv_buff, size_t count,
                              DataType datatype, int peer, Communicator *comm) {
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
-      LOG("Invalid data type for Recv.");
+      LOG("Invalid data type for `Recv`.");
       return true;
     }
     if (peer < 0 || peer >= comm->size()) {
-      LOG("Invalid peer rank for Recv.");
+      LOG("Invalid peer rank for `Recv`.");
       return true;
     }
     if (count == 0) {
       return false;
     }
     if (!recv_buff) {
-      LOG("Invalid receive buffer pointer for Recv.");
+      LOG("Invalid receive buffer pointer for `Recv`.");
       return true;
     }
     return false;

--- a/src/base/send.h
+++ b/src/base/send.h
@@ -1,0 +1,62 @@
+#ifndef INFINI_CCL_BASE_SEND_H_
+#define INFINI_CCL_BASE_SEND_H_
+
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct SendImpl;
+
+class Send : public Operation<Send> {
+ public:
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(const void *send_buff, size_t count,
+                              DataType datatype, int peer, void *comm_handle,
+                              void *stream) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for Send.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (HasInvalidArgs(send_buff, count, datatype, peer, comm)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
+    return SendImpl<backend_type, device_type>::Apply(
+        send_buff, count, datatype, peer, comm, stream);
+  }
+
+ private:
+  static bool HasInvalidArgs(const void *send_buff, size_t count,
+                             DataType datatype, int peer, Communicator *comm) {
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for Send.");
+      return true;
+    }
+    if (peer < 0 || peer >= comm->size()) {
+      LOG("Invalid peer rank for Send.");
+      return true;
+    }
+    if (count == 0) {
+      return false;
+    }
+    if (!send_buff) {
+      LOG("Invalid send buffer pointer for Send.");
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BASE_SEND_H_

--- a/src/base/send.h
+++ b/src/base/send.h
@@ -19,7 +19,7 @@ class Send : public Operation<Send> {
                               DataType datatype, int peer, void *comm_handle,
                               void *stream) {
     if (!comm_handle) {
-      LOG("Invalid communicator handle for Send.");
+      LOG("Invalid communicator handle for `Send`.");
       return ReturnStatus::kInvalidArgument;
     }
 
@@ -39,18 +39,18 @@ class Send : public Operation<Send> {
   static bool HasInvalidArgs(const void *send_buff, size_t count,
                              DataType datatype, int peer, Communicator *comm) {
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
-      LOG("Invalid data type for Send.");
+      LOG("Invalid data type for `Send`.");
       return true;
     }
     if (peer < 0 || peer >= comm->size()) {
-      LOG("Invalid peer rank for Send.");
+      LOG("Invalid peer rank for `Send`.");
       return true;
     }
     if (count == 0) {
       return false;
     }
     if (!send_buff) {
-      LOG("Invalid send buffer pointer for Send.");
+      LOG("Invalid send buffer pointer for `Send`.");
       return true;
     }
     return false;

--- a/src/ompi/impl/recv.h
+++ b/src/ompi/impl/recv.h
@@ -1,0 +1,72 @@
+#ifndef INFINI_CCL_OMPI_IMPL_RECV_H_
+#define INFINI_CCL_OMPI_IMPL_RECV_H_
+
+#include <cstdlib>
+#include <limits>
+
+#include "base/recv.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class RecvImpl<BackendType::kOmpi, device_type> {
+ public:
+  static ReturnStatus Apply(void *recv_buff, size_t count, DataType data_type,
+                            int peer, Communicator *comm, void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<Recv>{});
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for Recv.");
+      return ReturnStatus::kInternalError;
+    }
+
+    size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Recv byte size overflow.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    size_t total_bytes = count * type_size;
+    void *host_buf = std::malloc(total_bytes);
+    if (!host_buf) {
+      LOG("Failed to allocate host buffer for Recv staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    auto *bytes = static_cast<char *>(host_buf);
+    size_t offset = 0;
+    constexpr size_t kMaxMpiCount =
+        static_cast<size_t>(std::numeric_limits<int>::max());
+    constexpr int kTag = 0;
+    while (offset < total_bytes) {
+      size_t chunk = total_bytes - offset;
+      if (chunk > kMaxMpiCount) {
+        chunk = kMaxMpiCount;
+      }
+      INFINI_CHECK_MPI(MPI_Recv(bytes + offset, static_cast<int>(chunk),
+                                MPI_BYTE, peer, kTag, inst->handle,
+                                MPI_STATUS_IGNORE));
+      offset += chunk;
+    }
+
+    Runtime<kDev>::Memcpy(recv_buff, host_buf, total_bytes,
+                          Runtime<kDev>::MemcpyHostToDevice);
+
+    std::free(host_buf);
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<Recv, BackendType::kOmpi> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_OMPI_IMPL_RECV_H_

--- a/src/ompi/impl/recv.h
+++ b/src/ompi/impl/recv.h
@@ -20,6 +20,7 @@ class RecvImpl<BackendType::kOmpi, device_type> {
                             int peer, Communicator *comm, void *stream) {
     constexpr Device::Type kDev =
         ListGetBest<DevicePriority>(ActiveDevices<Recv>{});
+    using Rt = Runtime<kDev>;
 
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
     if (!inst || inst->handle == MPI_COMM_NULL) {
@@ -56,8 +57,8 @@ class RecvImpl<BackendType::kOmpi, device_type> {
       offset += chunk;
     }
 
-    Runtime<kDev>::Memcpy(recv_buff, host_buf, total_bytes,
-                          Runtime<kDev>::MemcpyHostToDevice);
+    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_buf, total_bytes,
+                                Rt::MemcpyHostToDevice));
 
     std::free(host_buf);
     return ReturnStatus::kSuccess;

--- a/src/ompi/impl/recv.h
+++ b/src/ompi/impl/recv.h
@@ -23,20 +23,20 @@ class RecvImpl<BackendType::kOmpi, device_type> {
 
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
     if (!inst || inst->handle == MPI_COMM_NULL) {
-      LOG("Invalid OpenMPI communicator instance for Recv.");
+      LOG("Invalid `OpenMPI` communicator instance for `Recv`.");
       return ReturnStatus::kInternalError;
     }
 
     size_t type_size = kDataTypeToSize.at(data_type);
     if (count > std::numeric_limits<size_t>::max() / type_size) {
-      LOG("Recv byte size overflow.");
+      LOG("Byte size overflow for `Recv`.");
       return ReturnStatus::kInvalidArgument;
     }
 
     size_t total_bytes = count * type_size;
     void *host_buf = std::malloc(total_bytes);
     if (!host_buf) {
-      LOG("Failed to allocate host buffer for Recv staging.");
+      LOG("Failed to allocate host buffer for `Recv` staging.");
       return ReturnStatus::kSystemError;
     }
 

--- a/src/ompi/impl/send.h
+++ b/src/ompi/impl/send.h
@@ -1,0 +1,74 @@
+#ifndef INFINI_CCL_OMPI_IMPL_SEND_H_
+#define INFINI_CCL_OMPI_IMPL_SEND_H_
+
+#include <cstdlib>
+#include <limits>
+
+#include "base/send.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class SendImpl<BackendType::kOmpi, device_type> {
+ public:
+  static ReturnStatus Apply(const void *send_buff, size_t count,
+                            DataType data_type, int peer, Communicator *comm,
+                            void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<Send>{});
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for Send.");
+      return ReturnStatus::kInternalError;
+    }
+
+    size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Send byte size overflow.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    size_t total_bytes = count * type_size;
+    void *host_buf = std::malloc(total_bytes);
+    if (!host_buf) {
+      LOG("Failed to allocate host buffer for Send staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    Runtime<kDev>::Memcpy(host_buf, send_buff, total_bytes,
+                          Runtime<kDev>::MemcpyDeviceToHost);
+    Runtime<kDev>::StreamSynchronize(
+        static_cast<Runtime<kDev>::Stream>(stream));
+
+    auto *bytes = static_cast<char *>(host_buf);
+    size_t offset = 0;
+    constexpr size_t kMaxMpiCount =
+        static_cast<size_t>(std::numeric_limits<int>::max());
+    constexpr int kTag = 0;
+    while (offset < total_bytes) {
+      size_t chunk = total_bytes - offset;
+      if (chunk > kMaxMpiCount) {
+        chunk = kMaxMpiCount;
+      }
+      INFINI_CHECK_MPI(MPI_Send(bytes + offset, static_cast<int>(chunk),
+                                MPI_BYTE, peer, kTag, inst->handle));
+      offset += chunk;
+    }
+
+    std::free(host_buf);
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<Send, BackendType::kOmpi> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_OMPI_IMPL_SEND_H_

--- a/src/ompi/impl/send.h
+++ b/src/ompi/impl/send.h
@@ -24,20 +24,20 @@ class SendImpl<BackendType::kOmpi, device_type> {
 
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
     if (!inst || inst->handle == MPI_COMM_NULL) {
-      LOG("Invalid OpenMPI communicator instance for Send.");
+      LOG("Invalid `OpenMPI` communicator instance for `Send`.");
       return ReturnStatus::kInternalError;
     }
 
     size_t type_size = kDataTypeToSize.at(data_type);
     if (count > std::numeric_limits<size_t>::max() / type_size) {
-      LOG("Send byte size overflow.");
+      LOG("Byte size overflow for `Send`.");
       return ReturnStatus::kInvalidArgument;
     }
 
     size_t total_bytes = count * type_size;
     void *host_buf = std::malloc(total_bytes);
     if (!host_buf) {
-      LOG("Failed to allocate host buffer for Send staging.");
+      LOG("Failed to allocate host buffer for `Send` staging.");
       return ReturnStatus::kSystemError;
     }
 

--- a/src/ompi/impl/send.h
+++ b/src/ompi/impl/send.h
@@ -21,6 +21,7 @@ class SendImpl<BackendType::kOmpi, device_type> {
                             void *stream) {
     constexpr Device::Type kDev =
         ListGetBest<DevicePriority>(ActiveDevices<Send>{});
+    using Rt = Runtime<kDev>;
 
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
     if (!inst || inst->handle == MPI_COMM_NULL) {
@@ -41,10 +42,9 @@ class SendImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kSystemError;
     }
 
-    Runtime<kDev>::Memcpy(host_buf, send_buff, total_bytes,
-                          Runtime<kDev>::MemcpyDeviceToHost);
-    Runtime<kDev>::StreamSynchronize(
-        static_cast<Runtime<kDev>::Stream>(stream));
+    CHECK_STATUS(Rt, Rt::Memcpy(host_buf, send_buff, total_bytes,
+                                Rt::MemcpyDeviceToHost));
+    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
     auto *bytes = static_cast<char *>(host_buf);
     size_t offset = 0;


### PR DESCRIPTION
## Summary

This PR introduces blocking point-to-point `Send` / `Recv` support for InfiniCCL with an OpenMPI-based backend implementation, along with an example program for functionality verification and basic performance evaluation.

The public APIs follow the NCCL point-to-point parameter order through `infiniSend()` and `infiniRecv()`. The current implementation uses host-staging for device buffers and blocking `MPI_Send` / `MPI_Recv` internally.

## Changes

- **Public Send/Recv API**
  - add public API declarations for:
    - `infiniSend()`;
    - `infiniRecv()`.
  - expose point-to-point communication through the common communicator interface.

- **Base Send/Recv Wrappers**
  - add `src/base/send.h`;
  - add `src/base/recv.h`;
  - validate communicator handles, datatype values, peer rank ranges, and non-null buffers for non-zero counts before dispatching to backend implementations;
  - return `infiniInvalidArgument` for invalid user inputs.

- **OpenMPI-based Send/Recv Implementation**
  - add `src/ompi/impl/send.h`;
  - add `src/ompi/impl/recv.h`;
  - implement blocking point-to-point communication with `MPI_Send` and `MPI_Recv`;
  - use temporary host-staging buffers for device memory transfer;
  - split large byte counts into `INT_MAX`-bounded MPI chunks.

- **Send/Recv Example**
  - add `examples/send_recv.cc`;
  - align the example structure and output style with the existing example programs such as `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, and `all_to_all`;
  - verify accelerator-memory `Send/Recv` correctness from rank 0 to rank 1;
  - report basic timing and bandwidth metrics in the same style as other examples.

## Known Issues & Future Work

- The current OpenMPI `Send/Recv` implementation is blocking and does not overlap communication with computation. Future work may introduce non-blocking point-to-point APIs and stream-aware asynchronous execution.
- The current implementation allocates temporary host-staging buffers using `malloc/free` on every invocation. This may introduce overhead in high-frequency workloads. Future work may add reusable buffer pools, allocator caching, and pinned host memory support to improve transfer efficiency and reduce allocation overhead.
- The current implementation uses a fixed MPI tag (`0`) internally. Future extensions may expose tags or add request-based APIs if more advanced point-to-point patterns are needed.
- The current implementation performs GPU-to-Host and Host-to-GPU copies for point-to-point communication. While functionally correct, this is not optimal for GPU-intensive workloads. Future work may implement zero-copy GPU-GPU transfers or GPUDirect RDMA where supported.
- The current example intentionally follows the lightweight style of the existing example programs. Future dedicated tests may add broader point-to-point coverage such as ping-pong, invalid peer validation, zero-count calls, and large-count stress cases.

## Logs & Screenshots

all_reduce test (MetaX-NVIDIA heterogeneous)
[all_reduce.log](https://github.com/user-attachments/files/28144574/all_reduce.log)


all_gather test (MetaX-NVIDIA heterogeneous)
[all_gather.log](https://github.com/user-attachments/files/28144576/all_gather.log)

reduce_scatter test (MetaX-NVIDIA heterogeneous)
[reduce_scatter.log](https://github.com/user-attachments/files/28144588/reduce_scatter.log)


broadcast test (MetaX-NVIDIA heterogeneous)
[broadcast.log](https://github.com/user-attachments/files/28144590/broadcast.log)


all_to_all test (MetaX-NVIDIA heterogeneous)
[all_to_all.log](https://github.com/user-attachments/files/28144592/all_to_all.log)


send_recv test (MetaX-NVIDIA heterogeneous)
[send_recv.log](https://github.com/user-attachments/files/28144593/send_recv.log)


