### PR TITLE
feat: support `AllToAll` with OpenMPI backend implementation

### DIFF
--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -1,0 +1,195 @@
+/**
+ * InfiniCCL Example: AllToAll
+ * * This example demonstrates the planned API for performing a
+ * collective all-to-all exchange across multiple GPUs and nodes.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
+
+void RunAllToAllExample(int argc, char **argv, int warmup_iter,
+                        int profile_iter, const size_t kCountPerPeer) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_INFINI(infiniInit(&argc, &argv));
+
+  int rank, size;
+  CHECK_INFINI(infiniGetRank(&rank));
+  CHECK_INFINI(infiniGetSize(&size));
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  // Map local rank to GPU device.
+  // Note: this is just for info printing. In practice, this part is not needed.
+  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_str != nullptr) {
+    local_rank = std::atoi(local_rank_str);
+  }
+
+  std::cout << "[Rank " << rank << "] Host: " << hostname
+            << " | GPU: " << Device::StringFromType(kDevType) << " "
+            << " | Device " << local_rank << std::endl;
+
+  // Setup communicator
+  infiniComm_t comm = nullptr;
+  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+
+  // Prepare Data
+  // For AllToAll, `total_elements_per_rank = count_per_peer * world_size`.
+  const size_t kTotalCount = kCountPerPeer * static_cast<size_t>(size);
+
+  std::vector<float> h_send(kTotalCount);
+  std::vector<float> h_recv(kTotalCount, 0.0f);
+
+  // Layout: block per destination rank.
+  // block[dst] is what this rank sends to dst.
+  // Fill with value encoding src/dst for easy validation.
+  for (int dst = 0; dst < size; ++dst) {
+    float v = static_cast<float>(rank * 1000 + dst);
+    size_t off = static_cast<size_t>(dst) * kCountPerPeer;
+    for (size_t i = 0; i < kCountPerPeer; ++i) {
+      h_send[off + i] = v;
+    }
+  }
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  size_t total_bytes = kTotalCount * sizeof(*d_send);
+
+  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  if (rank == 0) {
+    std::cout << "\n=== Performing AllToAll on GPU Memory ===" << std::endl;
+    std::cout << "Count per peer: " << kCountPerPeer << " floats" << std::endl;
+    std::cout << "Total per rank: " << kTotalCount << " floats ("
+              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
+    std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
+    std::cout << "Profile iterations: " << profile_iter << std::endl;
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Warm-up and D2H transfer the answer.
+  CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
+                              comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                          Rt::MemcpyDeviceToHost));
+
+  for (int i = 1; i < warmup_iter; ++i) {
+    CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
+                                comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Profiling
+  Timer timer;
+
+  for (int i = 0; i < profile_iter; ++i) {
+    CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
+                                comm, nullptr));
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                          Rt::MemcpyDeviceToHost));
+  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+
+  // Result Validation
+  // recv block[src] on rank r should come from src's send block[dst=r].
+  bool correct = true;
+  int error_count = 0;
+
+  for (int src = 0; src < size; ++src) {
+    float expected = static_cast<float>(src * 1000 + rank);
+    size_t off = static_cast<size_t>(src) * kCountPerPeer;
+
+    for (size_t i = 0; i < kCountPerPeer; ++i) {
+      float actual = h_recv[off + i];
+      if (std::fabs(actual - expected) > 1e-3f) {
+        correct = false;
+        ++error_count;
+        if (rank == 0 && error_count <= 3) {
+          std::cerr << "Error at src=" << src << ", idx=" << i
+                    << ": actual=" << actual << ", expected=" << expected
+                    << std::endl;
+        }
+      }
+    }
+  }
+
+  if (rank == 0) {
+    const char *GREEN = "\033[32m";
+    const char *RED = "\033[31m";
+    const char *RESET = "\033[0m";
+
+    std::cout << "\n=== AllToAll Results ===" << std::endl;
+    std::cout << "Correct: "
+              << (correct ? (GREEN + std::string("YES") + RESET)
+                          : (RED + std::string("NO") + RESET));
+    if (!correct) std::cout << " (" << error_count << " errors)";
+    std::cout << std::endl;
+
+    std::cout << "Sample recv blocks: ";
+    for (int src = 0; src < std::min(size, 4); ++src) {
+      size_t off = static_cast<size_t>(src) * kCountPerPeer;
+      std::cout << "[src" << src << ": " << h_recv[off] << "] ";
+    }
+    std::cout << std::endl;
+  }
+
+  // Metrics Reporting (Only from rank 0 for cleaner output)
+  if (rank == 0) {
+    Metrics metrics{elapsed, total_bytes, size};
+    metrics.Print();
+  }
+
+  // Cleanup
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+
+  CHECK_INFINI(infiniCommDestroy(comm));
+  CHECK_INFINI(infiniFinalize());
+
+  if (rank == 0) {
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t count_per_peer =
+      1 << 18;  // smaller default than all_reduce to limit memory
+
+  RunAllToAllExample(argc, argv, warmup_iters, profile_iters, count_per_peer);
+
+  return EXIT_SUCCESS;
+}

--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -146,7 +146,9 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
     std::cout << "Correct: "
               << (correct ? (GREEN + std::string("YES") + RESET)
                           : (RED + std::string("NO") + RESET));
-    if (!correct) std::cout << " (" << error_count << " errors)";
+    if (!correct) {
+      std::cout << " (" << error_count << " errors)";
+    }
     std::cout << std::endl;
 
     std::cout << "Sample recv blocks: ";
@@ -178,8 +180,7 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
 int main(int argc, char **argv) {
   int warmup_iters = 2;
   int profile_iters = 20;
-  size_t count_per_peer =
-      1 << 18;  // smaller default than all_reduce to limit memory
+  size_t count_per_peer = 1 << 18;
 
   RunAllToAllExample(argc, argv, warmup_iters, profile_iters, count_per_peer);
 

--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -131,18 +131,10 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
     float expected = static_cast<float>(src * 1000 + rank);
     size_t off = static_cast<size_t>(src) * kCountPerPeer;
 
-    for (size_t i = 0; i < kCountPerPeer; ++i) {
-      float actual = h_recv[off + i];
-      if (std::fabs(actual - expected) > 1e-3f) {
-        correct = false;
-        ++error_count;
-        if (rank == 0 && error_count <= 3) {
-          std::cerr << "Error at src=" << src << ", idx=" << i
-                    << ": actual=" << actual << ", expected=" << expected
-                    << std::endl;
-        }
-      }
-    }
+    bool block_ok = Validator::ValidateResult(h_recv.data() + off,
+                                              kCountPerPeer, expected, rank);
+
+    correct = correct && block_ok;
   }
 
   if (rank == 0) {

--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -65,8 +65,8 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   std::vector<float> h_recv(kTotalCount, 0.0f);
 
   // Layout: block per destination rank.
-  // block[dst] is what this rank sends to dst.
-  // Fill with value encoding src/dst for easy validation.
+  // `block[dst]` is what this rank sends to dst.
+  // Fill with value encoding `src`/`dst` for easy validation.
   for (int dst = 0; dst < size; ++dst) {
     float v = static_cast<float>(rank * 1000 + dst);
     size_t off = static_cast<size_t>(dst) * kCountPerPeer;
@@ -123,7 +123,7 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
 
   // Result Validation
-  // recv block[src] on rank r should come from src's send block[dst=r].
+  // recv `block[src]` on rank r should come from `src`'s send `block[dst=r]`.
   bool correct = true;
   int error_count = 0;
 

--- a/include/comm.h
+++ b/include/comm.h
@@ -57,6 +57,10 @@ infiniResult_t infiniReduceScatter(const void *sendbuff, void *recvbuff,
                                    infiniRedOp_t op, infiniComm_t comm,
                                    void *stream);
 
+infiniResult_t infiniAllToAll(const void *sendbuff, void *recvbuff,
+                              size_t count, infiniDataType_t datatype,
+                              infiniComm_t comm, void *stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/base/all_to_all.h
+++ b/src/base/all_to_all.h
@@ -1,0 +1,52 @@
+#ifndef INFINI_CCL_BASE_ALL_TO_ALL_H_
+#define INFINI_CCL_BASE_ALL_TO_ALL_H_
+
+#include "comm_impl.h"
+#include "communicator.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct AllToAllImpl;
+
+class AllToAll : public Operation<AllToAll> {
+ public:
+  template <BackendType backend_type, Device::Type device_type,
+            typename... Args>
+  static ReturnStatus Execute(const void *send_buff, void *recv_buff,
+                              size_t count, DataType datatype,
+                              void *comm_handle, void *stream) {
+    if (HasInvalidArgs(send_buff, recv_buff, datatype, comm_handle)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    return AllToAllImpl<backend_type, device_type>::Apply(
+        send_buff, recv_buff, count, datatype, comm, stream);
+  }
+
+ private:
+  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
+                             DataType datatype, void *comm_handle) {
+    if (!comm_handle) {
+      // TODO(lzm): change to use `glog`.
+      LOG("Invalid communicator handle for `AllToAll`.");
+      return true;
+    }
+    if (!send_buff || !recv_buff) {
+      LOG("Invalid buffer pointer for `AllToAll`.");
+      return true;
+    }
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for `AllToAll`.");
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BASE_ALL_TO_ALL_H_

--- a/src/ompi/impl/all_to_all.h
+++ b/src/ompi/impl/all_to_all.h
@@ -31,7 +31,7 @@ class AllToAllImpl<BackendType::kOmpi, device_type> {
     }
 
     if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
-      LOG("count exceeds MPI int range for `AllToAll`.");
+      LOG("count exceeds MPI `int` range for `AllToAll`.");
       return ReturnStatus::kInvalidArgument;
     }
     int mpi_count = static_cast<int>(count);

--- a/src/ompi/impl/all_to_all.h
+++ b/src/ompi/impl/all_to_all.h
@@ -1,0 +1,79 @@
+#ifndef INFINI_CCL_OMPI_IMPL_ALL_TO_ALL_H_
+#define INFINI_CCL_OMPI_IMPL_ALL_TO_ALL_H_
+
+#include <limits>
+
+#include "base/all_to_all.h"
+#include "communicator.h"
+#include "dispatcher.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+#include "ompi/type_map.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class AllToAllImpl<BackendType::kOmpi, device_type> {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            Communicator *comm, void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<AllToAll>{});
+    using Rt = Runtime<kDev>;
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for `AllToAll`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("count exceeds MPI int range for `AllToAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    int mpi_count = static_cast<int>(count);
+
+    size_t world_size = static_cast<size_t>(comm->size());
+    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
+    size_t type_size = kDataTypeToSize.at(data_type);
+    size_t total_count = count * world_size;
+    size_t total_bytes = total_count * type_size;
+
+    // Handle GPU Memory (Staging Pattern)
+    // Note: we simply use host-staging for now.
+    void *host_sendbuf = malloc(total_bytes);
+    void *host_recvbuf = malloc(total_bytes);
+    if (!host_sendbuf || !host_recvbuf) {
+      free(host_sendbuf);
+      free(host_recvbuf);
+      LOG("Failed to allocate host buffers for `AllToAll` staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, total_bytes,
+                                Rt::MemcpyDeviceToHost));
+
+    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
+
+    INFINI_CHECK_MPI(MPI_Alltoall(host_sendbuf, mpi_count, mpi_type,
+                                  host_recvbuf, mpi_count, mpi_type,
+                                  inst->handle));
+
+    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, total_bytes,
+                                Rt::MemcpyHostToDevice));
+
+    free(host_sendbuf);
+    free(host_recvbuf);
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<AllToAll, BackendType::kOmpi> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_OMPI_IMPL_ALL_TO_ALL_H_


### PR DESCRIPTION
## Summary
This PR introduces an OpenMPI-based implementation of `AllToAll`, along with a complete example program for functionality verification and basic performance evaluation. 

## Changes
- **OpenMPI-based `AllToAll` Implementation**
  - add the basic OpenMPI implementation for `infiniAllToAll()`, including:
    - the core interface `src/base/all_to_all.h`;
    - the OpenMPI backend implementation in `src/ompi/impl/all_to_all.h`;
    - the public API declaration in `include/infiniccl.h`.
  - add an example program `examples/all_to_all.cc` similar to `examples/all_reduce.cc` for correctness verification and simple performance testing.

## Known Issues & Future Work
 - The current OpenMPI `AllToAll` implementation uses blocking `MPI_Alltoall`, which prevents overlap between communication and computation. Future work may introduce non-blocking collectives (`MPI_Alltoall`) and stream-aware asynchronous execution to improve concurrency and performance.
 - The current implementation allocates temporary host staging buffers using `malloc/free` on every invocation. This may introduce noticeable overhead in high-frequency workloads. Future work may add reusable buffer pools, allocator caching, and pinned host memory support to improve transfer efficiency and reduce allocation overhead.
 - For the heterogeneous UCX + InfiniBand cluster used in testing, large `AllToAll` messages (e.g., `1 << 20` elements) may fail with mlx5 RC RDMA_READ errors due to UCX rendezvous RDMA_READ path limitations. This requires setting `UCX_RNDV_SCHEME=put_zcopy` to force a safe put-based transfer protocol. Without this setting, large-message `AllToAll` execution is unstable on some NIC configurations.
 - For extremely large `AllToAll` messages exceeding `INT_MAX` elements, execution is rejected due to MPI int range limitations. Future work may introduce chunked transfers or `MPI_Count` support in MPI-4+ to handle very large tensors safely.
 - The current implementation performs GPU-to-Host and Host-to-GPU copies for all data. While functionally correct, this is not optimal for GPU-intensive workloads. Future work may implement zero-copy GPU-GPU transfers (GPUDirect RDMA) to reduce memory traffic and improve throughput.
 - The operation currently performs a single-block `AllToAll` without pipelining. For large messages, this may lead to high memory consumption and limited scalability. Future work may add chunked or pipelined transfers to reduce peak memory usage and improve scalability across many ranks.
 - Error checking is limited to null pointers and datatype validation. Future work may include more fine-grained validation and enhanced error reporting to improve robustness in heterogeneous or multi-node deployments.


## Logs & Screenshots

all_reduce test (MetaX-NVIDIA heterogeneous)
[all_reduce.log](https://github.com/user-attachments/files/28023317/all_reduce.log)

all_gather test (MetaX-NVIDIA heterogeneous)
[all_gather.log](https://github.com/user-attachments/files/28023320/all_gather.log)

reduce_scatter test (MetaX-NVIDIA heterogeneous)
[reduce_scatter.log](https://github.com/user-attachments/files/28023323/reduce_scatter.log)

broadcast test (MetaX-NVIDIA heterogeneous)
[broadcast.log](https://github.com/user-attachments/files/28023332/broadcast.log)

all_to_all test (MetaX-NVIDIA heterogeneous)
[all_to_all.log](https://github.com/user-attachments/files/28023339/all_to_all.log)

