### PR TITLE
fix(base): delete outer `Communicator` in `CommDestroy`

### DIFF
--- a/src/base/comm_destroy.h
+++ b/src/base/comm_destroy.h
@@ -1,6 +1,8 @@
 #ifndef INFINI_CCL_BASE_COMM_DESTROY_H_
 #define INFINI_CCL_BASE_COMM_DESTROY_H_
 
+#include "communicator.h"
+#include "logging.h"
 #include "operation.h"
 #include "return_status_impl.h"
 
@@ -10,15 +12,27 @@ template <BackendType backend_type, Device::Type device_type>
 struct CommDestroyImpl;
 
 class CommDestroy : public Operation<CommDestroy> {
-public:
-  template <BackendType backend_type, Device::Type device_type,
-            typename... Args>
-  static ReturnStatus Execute(Args &&...args) {
-    return CommDestroyImpl<backend_type, device_type>::Apply(
-        std::forward<Args>(args)...);
+ public:
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(void *comm_handle) {
+    if (!comm_handle) {
+      // TODO(lzm): change to use `glog`.
+      LOG("Invalid communicator handle for `CommDestroy`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto status =
+        CommDestroyImpl<backend_type, device_type>::Apply(comm_handle);
+
+    if (status == ReturnStatus::kSuccess) {
+      // Pair with the `new` in `CommInitAll`.
+      delete static_cast<Communicator *>(comm_handle);
+    }
+
+    return status;
   }
 };
 
-} // namespace infini::ccl
+}  // namespace infini::ccl
 
-#endif // INFINI_CCL_BASE_COMM_DESTROY_H_
+#endif  // INFINI_CCL_BASE_COMM_DESTROY_H_


### PR DESCRIPTION
## Summary

Fixes the `Communicator` lifetime leak noted in the "Known Issues & Future Work" section of #10.

`CommInitAll::Execute` allocates the outer `Communicator` via `new`, but the previous `CommDestroy` only tore down the backend instance and never deleted the outer object. Every `infiniCommInitAll` / `infiniCommDestroy` pair leaked one `Communicator`.

## Changes

- `src/base/comm_destroy.h`:
  - Narrow `Execute` to a concrete `void *comm_handle` signature, mirroring `CommInitAll::Execute`'s `void **comm_handle`.
  - Add a null-handle check, consistent with `CommInitAll`.
  - Delete the `Communicator` only after the backend `Apply` returns `kSuccess`.

Backend implementations are intentionally untouched: ownership of the outer `Communicator` now lives entirely in the base layer, symmetric with the allocation in `CommInitAll`. Future backends such as NCCL, MCCL, HCCL, and others get correct lifetime handling without each backend having to remember to `delete` the outer object.

## Test environment

Validated on a heterogeneous 2-node cluster with container-to-container direct connection over RDMA:

| Node | Hardware | Container | IP |
|------|----------|-----------|-----|
| A | NVIDIA A100 | `iccl-nvidia` | `192.168.163.40` |
| B | MetaX C550 | `iccl-metax-clean` | `192.168.162.49` |

- OS / container: `--network host --ipc host --privileged`, `/dev/infiniband` mounted on both sides.
- OpenMPI: 4.1.6 (`/opt/openmpi-4.1.6`), built with `--with-ucx=/opt/ucx-1.17.0`.
- UCX: 1.17.0 (`/opt/ucx-1.17.0`), built with `--with-verbs --with-rdmacm`.
- CUDA Toolkit on Node A; MACA SDK at `/opt/maca` on Node B.
- Inter-container SSH direct connection on port `22222`, with no `docker exec` wrapper required for `mpirun` or `icclrun --build`.
- UCX transport configuration:
  - `UCX_NET_DEVICES=mlx5_0:1`
  - `UCX_TLS=rc,rc_verbs,self,sm`
  - `UCX_RNDV_SCHEME=put_zcopy`
- World size: 16 ranks, 8 NVIDIA + 8 MetaX.

## Logs & Screenshots
all_reduce test (MetaX-NVIDIA heterogeneous)
[all_reduce.log](https://github.com/user-attachments/files/28038382/all_reduce.log)

all_gather test (MetaX-NVIDIA heterogeneous)
[all_gather.log](https://github.com/user-attachments/files/28038385/all_gather.log)

reduce_scatter test (MetaX-NVIDIA heterogeneous)
[reduce_scatter.log](https://github.com/user-attachments/files/28038388/reduce_scatter.log)

broadcast test (MetaX-NVIDIA heterogeneous)
[broadcast.log](https://github.com/user-attachments/files/28038391/broadcast.log)

all_to_all test (MetaX-NVIDIA heterogeneous)
[all_to_all.log](https://github.com/user-attachments/files/28038392/all_to_all.log)
