### PR TITLE
fix: fix the hardcoded "AllReduce" name in `Validator::ValidateResult()`

### DIFF
--- a/examples/all_gather.cc
+++ b/examples/all_gather.cc
@@ -119,18 +119,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
     float expected = static_cast<float>(src_rank + 1);
     size_t offset = static_cast<size_t>(src_rank) * kNumElements;
 
-    for (size_t i = 0; i < kNumElements; ++i) {
-      float actual = h_recv[offset + i];
-      if (std::fabs(actual - expected) > 1e-3f) {
-        correct = false;
-        ++error_count;
-        if (error_count <= 3 && rank == 0) {
-          std::cerr << "Error at block(rank) = " << src_rank
-                    << ", index = " << i << ": " << actual << " != " << expected
-                    << std::endl;
-        }
-      }
-    }
+    Validator::ValidateResult(h_recv.data() + offset, kNumElements, expected,
+                              rank);
   }
 
   if (rank == 0) {

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -4,8 +4,9 @@
  * collective sum-reduction across multiple GPUs and nodes.
  */
 
-#include <iostream>
 #include <unistd.h>
+
+#include <iostream>
 #include <vector>
 
 // Public API
@@ -112,7 +113,8 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
     expected += static_cast<float>(r + 1);
   }
 
-  Validator::ValidateResult(h_recv.data(), kNumElements, expected, rank);
+  Validator::ValidateResult(h_recv.data(), kNumElements, expected, rank, true,
+                            "AllReduce");
 
   // Metrics Reporting (Only from rank 0 for cleaner output)
   if (rank == 0) {

--- a/examples/reduce_scatter.cc
+++ b/examples/reduce_scatter.cc
@@ -124,7 +124,8 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
     expected += static_cast<float>(r + 1);
   }
 
-  Validator::ValidateResult(h_recv.data(), kRecvCount, expected, rank);
+  Validator::ValidateResult(h_recv.data(), kRecvCount, expected, rank, true,
+                            "ReduceScatter");
 
   // Metrics Reporting (Only from rank 0 for cleaner output)
   if (rank == 0) {

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -9,24 +9,24 @@
 #include <vector>
 
 // Simple check macro for the C-API.
-#define CHECK_INFINI(cmd)                                                      \
-  do {                                                                         \
-    infiniResult_t res = (cmd);                                                \
-    if (res != infiniSuccess) {                                                \
-      std::cerr << "[InfiniCCL Error] example program received error code "    \
-                << res << " at line " << __LINE__ << std::endl;                \
-      exit(EXIT_FAILURE);                                                      \
-    }                                                                          \
+#define CHECK_INFINI(cmd)                                                   \
+  do {                                                                      \
+    infiniResult_t res = (cmd);                                             \
+    if (res != infiniSuccess) {                                             \
+      std::cerr << "[InfiniCCL Error] example program received error code " \
+                << res << " at line " << __LINE__ << std::endl;             \
+      exit(EXIT_FAILURE);                                                   \
+    }                                                                       \
   } while (0)
 
-#define CHECK_RT(runtime_type, cmd)                                            \
+#define CHECK_RT(runtime_type, cmd) \
   CHECK_INFINI(static_cast<infiniResult_t>(runtime_type::Check(cmd)))
 
 // Simple Timer for Profiling
 class Timer {
   std::chrono::high_resolution_clock::time_point start;
 
-public:
+ public:
   Timer() : start(std::chrono::high_resolution_clock::now()) {}
   double elapsed_ms() const {
     auto end = std::chrono::high_resolution_clock::now();
@@ -59,10 +59,11 @@ struct Metrics {
 };
 
 class Validator {
-public:
+ public:
   template <typename T>
   static bool ValidateResult(const T *data, size_t count, T expected_val,
-                             int rank) {
+                             int rank, bool verbose = false,
+                             std::string op_name = "\b") {
     bool correct = true;
     int error_count = 0;
 
@@ -78,17 +79,18 @@ public:
       }
     }
 
-    if (rank == 0) {
+    if (verbose && rank == 0) {
       const char *GREEN = "\033[32m";
       const char *RED = "\033[31m";
       const char *RESET = "\033[0m";
 
-      std::cout << "\n=== AllReduce Results ===" << std::endl;
+      std::cout << "\n=== " << op_name << " Results ===" << std::endl;
       std::cout << "Correct: "
                 << (correct ? (GREEN + std::string("YES") + RESET)
                             : (RED + std::string("NO") + RESET));
-      if (!correct)
+      if (!correct) {
         std::cout << " (" << error_count << " errors)";
+      }
       std::cout << std::endl;
 
       std::cout << "Expect:  " << std::fixed << std::setprecision(2)


### PR DESCRIPTION
## Summary
This PR fixes the issue in `examples/utils.h`, specifically `Validator::ValidateResult()` in which it previously hardcoded the operation name "AllReduce" for the validation result printing. This PR fixes this issue by removing the hardcoded string and providing the arguments that can be passed in the operation name to be printed. 

## Changes
- **Configurable Validation Output**
  - add two new parameters to `Validator::ValidateResult()`:
    - `std::string op_name`: 
      - specifies the name of the collective operation (e.g., "AllReduce", "AllGather");
      - replaces the previously hardcoded "AllReduce" label in output logs;
      - default to be `"\b"`.
    - `bool verbose`:
      - controls whether detailed validation results are printed;
      - default to be `false`.

 - **Example Updates**
   - update all existing example programs (i.e., `examples/all_reduce.cc`, `examples/all_gather.cc`, `examples/reduce_scatter.cc`.) to:
     - pass the correct `op_name`;
     - optionally use the new `verbose` flag for cleaner output.

 - **Style Fix**
   - fix the formatting issues for the four changed files. 

## Known Issues & Future Work
 - The current validation API still assumes uniform expected values per buffer segment. Future improvements may include:
   - native support for segmented validation (e.g., AllGather-style layouts);
   - richer validation modes for more complex collectives.
 
## Logs & Screenshots
[all_gather.log](https://github.com/user-attachments/files/28011352/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28011353/all_reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28011349/reduce_scatter.log)