### PR TITLE
feat: introduce automated example runner script with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There are two methods to build InfiniCCL.
 ### Method 1 - Quick Build with `build.sh` (Recommended)
 
 ```bash
-# Give execute permission to the script
+# Grant execution permission to the script
 chmod +x ./scripts/build.sh
 
 # Build and install to default location (~/.infini)
@@ -165,6 +165,8 @@ To achieve this, a `cluster.yaml` is required to be filled. This is the configur
 After having a successful build and a complete `cluster.yaml`, we are ready for compiling and executing a distributed program across the cluster. 
 
 ### 1. Run Internal Examples
+
+#### 1.1. Run a Single Example
 To run an internal example program (e.g., `examples/all_reduce.cc`), just run: 
 
 ```bash
@@ -184,6 +186,22 @@ icclrun --help
 ```
 
 If everything is correctly set up, the example program should have just been launched and executed across the cluster you specified in `cluster.yaml`!
+
+#### 1.2. Automated Multi-Collective Verification Harness
+To run and log multiple example programs consecutively, use the provided automated batch verification script `scripts/run_examples.py`. This tool runs multiple validation profiles, monitors exit codes, captures chronological trace logs, and optimizes away redundant compilation passes. 
+
+For the first time using the script, grant it execution permission:
+
+```bash
+# Grant execution permission to the script
+chmod +x ./scripts/run_examples.sh
+```
+
+For all the options of the script, see:
+
+```bash
+./run_examples --help
+```
 
 ### 2. Run a Custom User Program
 

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -62,9 +62,9 @@ def run_iccl_example(
             log_file.flush()
 
             if verbose:
-                print(f"\n--- [VERBOSE OUTPUT START: {example_name}] ---")
+                print(f"\n--- [VERBOSE OUTPUT START: `{example_name}`] ---")
 
-                # Execute with `Popen` to stream stdout/stderr live to both terminal and file.
+                # Execute with `Popen` to stream `stdout`/`stderr` live to both terminal and file.
                 process = subprocess.Popen(
                     cmd,
                     stdout=subprocess.PIPE,
@@ -80,7 +80,7 @@ def run_iccl_example(
                 process.wait(timeout=timeout_duration)
                 return_code = process.returncode
                 print(
-                    f"--- [VERBOSE OUTPUT END: {example_name}] ---\n" + " " * 56, end=""
+                    f"--- [VERBOSE OUTPUT END: `{example_name}`] ---\n" + " " * 56, end=""
                 )
             else:
                 # Quiet mode: Redirect straight to the file handle.
@@ -160,7 +160,7 @@ def main():
         "-v",
         "--verbose",
         action="store_true",
-        help="Enable verbose mode: stream execution stdout/stderr directly to terminal while logging.",
+        help="Enable verbose mode: stream execution `stdout`/`stderr` directly to terminal while logging.",
     )
 
     args = parser.parse_args()

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import subprocess
+import sys
+from datetime import datetime
+from typing import Optional
+
+
+# ==============================================================================
+# ENGINE RUNNER
+# ==============================================================================
+def setup_log_directory(directory: str) -> str:
+    """Creates a unique timestamped subdirectory inside the log folder."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    target_path = os.path.join(directory, f"run_{timestamp}")
+    os.makedirs(target_path, exist_ok=True)
+    return target_path
+
+
+def run_iccl_example(
+    example_name: str,
+    config_path: str,
+    launcher_opt: Optional[str],
+    log_dir: str,
+    trigger_build: bool,
+    verbose: bool,
+) -> bool:
+    """Executes an example via `icclrun` orchestration framework."""
+    log_file_path = os.path.join(log_dir, f"{example_name}.log")
+
+    status_msg = (
+        "🚀 Running via `icclrun` (with build):"
+        if trigger_build
+        else "🚀 Running via `icclrun`:             "
+    )
+    print(f"{status_msg:<35} {example_name:<20}", end="", flush=True)
+
+    # Base command assembly
+    cmd = ["icclrun", "--config", config_path]
+    if launcher_opt and launcher_opt.strip():
+        cmd.extend(["--launcher", launcher_opt.strip()])
+
+    if trigger_build:
+        cmd.extend(["--build", example_name])
+    else:
+        cmd.append(example_name)
+
+    # Format the exact command as a clean string for log documentation
+    exact_command_str = " ".join(cmd)
+
+    # Force environment unbuffered stream states for sub-python instances (icclrun_logic.py)
+    custom_env = os.environ.copy()
+    custom_env["PYTHONUNBUFFERED"] = "1"
+
+    try:
+        with open(log_file_path, "w", buffering=1) as log_file:
+            # Write the exact underlying command as the absolute first line of the log
+            log_file.write(f"[COMMAND]: {exact_command_str}\n")
+            log_file.write("=" * 80 + "\n\n")
+            log_file.flush()
+
+            if verbose:
+                print(f"\n--- [VERBOSE OUTPUT START: {example_name}] ---")
+
+                # Execute with Popen to stream stdout/stderr live to both terminal and file
+                process = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    env=custom_env,
+                    text=True,
+                )
+
+                for line in process.stdout:
+                    sys.stdout.write(line)
+                    log_file.write(line)
+
+                process.wait(timeout=600)
+                return_code = process.returncode
+                print(
+                    f"--- [VERBOSE OUTPUT END: {example_name}] ---\n" + " " * 56, end=""
+                )
+            else:
+                # Quiet mode: Redirect straight to the file handle
+                result = subprocess.run(
+                    cmd,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    env=custom_env,
+                    text=True,
+                    timeout=600,
+                )
+                return_code = result.returncode
+
+        if return_code == 0:
+            print(f"  ✓ PASSED  (Log saved to {os.path.basename(log_file_path)})")
+            return True
+        else:
+            print(f" ❌ FAILED  (Exit Code: {return_code})")
+            return False
+
+    except subprocess.TimeoutExpired:
+        print(" ❌ TIMEOUT (Exceeded 10 minutes)")
+        with open(log_file_path, "a") as f:
+            f.write("\n[RUNNER ERROR]: Distributed `icclrun` harness timed out.\n")
+        return False
+    except FileNotFoundError:
+        print(" ❌ ERROR   (`icclrun` executable not found in `PATH`)")
+        return False
+    except Exception as e:
+        print(f" ❌ CRASHED ({str(e)})")
+        return False
+
+
+def main():
+    # Setup CLI Argument Parsing
+    parser = argparse.ArgumentParser(
+        description="InfiniCCL Example Suite Execution Harness",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default="examples/cluster.yaml",
+        help="Path to the cluster topology YAML configuration file (i.e., `cluster.yaml`).",
+    )
+    parser.add_argument(
+        "-l",
+        "--launcher",
+        type=str,
+        default=None,
+        help="Specify the target launcher. If omitted, defaults to `icclrun`'s default. See `icclrun --help` for valid options.",
+    )
+    parser.add_argument(
+        "-e",
+        "--examples",
+        type=str,
+        default="all_reduce",
+        help="Comma-separated list of example target names to execute.",
+    )
+    parser.add_argument(
+        "-o",
+        "--log-path",
+        type=str,
+        default="./example_logs",
+        help="Destination directory where output logs will be stored.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose mode: stream execution stdout/stderr directly to terminal while logging.",
+    )
+
+    args = parser.parse_args()
+
+    # Parse and clean the comma-separated examples list
+    examples_to_run = [ex.strip() for ex in args.examples.split(",") if ex.strip()]
+
+    # Sanity Checks
+    if not os.path.exists(args.config):
+        print(f"❌ Error: Config file matching '{args.config}' could not be located.")
+        sys.exit(1)
+
+    if not examples_to_run:
+        print(
+            "❌ Error: No target programs defined. Please check your --examples list."
+        )
+        sys.exit(1)
+
+    # Initialize Log Infrastructure
+    current_run_log_dir = setup_log_directory(args.log_path)
+    launcher_display = args.launcher if args.launcher else "Internal default"
+
+    print("==================================================================")
+    print("               InfiniCCL Distributed Verification                 ")
+    print(f"Target Configuration File: {args.config}")
+    print(f"Selected Launcher Engine : {launcher_display}")
+    print(f"Logs Target Destination  : {current_run_log_dir}")
+    print(f"Verbose Console Output   : {'ENABLED' if args.verbose else 'DISABLED'}")
+    print("==================================================================")
+
+    passed_count = 0
+    failed_count = 0
+    failed_programs = []
+    is_first_run = True
+
+    for example in examples_to_run:
+        success = run_iccl_example(
+            example_name=example,
+            config_path=args.config,
+            launcher_opt=args.launcher,
+            log_dir=current_run_log_dir,
+            trigger_build=is_first_run,
+            verbose=args.verbose,
+        )
+
+        is_first_run = False
+
+        if success:
+            passed_count += 1
+        else:
+            failed_count += 1
+            failed_programs.append(example)
+
+    # ==============================================================================
+    # METRICS REPORTING
+    # ==============================================================================
+    total_programs = len(examples_to_run)
+    success_rate = (passed_count / total_programs) * 100
+
+    print("\n==================================================================")
+    print("                      EXECUTION SUMMARY                           ")
+    print("==================================================================")
+    print(f"Total Framework Targets  : {total_programs}")
+    print(f"Successfully Passed      : {passed_count}")
+    print(f"Failed / Crashed Targets : {failed_count}")
+    print(f"Overall Success Rate     : {success_rate:.2f}%")
+    print("==================================================================")
+
+    if failed_count > 0:
+        print(
+            f"⚠️  The following collective validation targets failed: {', '.join(failed_programs)}"
+        )
+        sys.exit(1)
+    else:
+        print("🎉 All targets functioned within specification thresholds!")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -36,7 +36,7 @@ def run_iccl_example(
     )
     print(f"{status_msg:<35} {example_name:<20}", end="", flush=True)
 
-    # Base command assembly
+    # Base Command Assembly
     cmd = ["icclrun", "--config", config_path]
     if launcher_opt and launcher_opt.strip():
         cmd.extend(["--launcher", launcher_opt.strip()])
@@ -46,16 +46,16 @@ def run_iccl_example(
     else:
         cmd.append(example_name)
 
-    # Format the exact command as a clean string for log documentation
+    # Format the exact command as a clean string for log documentation.
     exact_command_str = " ".join(cmd)
 
-    # Force environment unbuffered stream states for sub-python instances (icclrun_logic.py)
+    # Force environment unbuffered stream states for sub-python instances.
     custom_env = os.environ.copy()
     custom_env["PYTHONUNBUFFERED"] = "1"
 
     try:
         with open(log_file_path, "w", buffering=1) as log_file:
-            # Write the exact underlying command as the absolute first line of the log
+            # Write the exact underlying command as the absolute first line of the log.
             log_file.write(f"[COMMAND]: {exact_command_str}\n")
             log_file.write("=" * 80 + "\n\n")
             log_file.flush()
@@ -63,7 +63,7 @@ def run_iccl_example(
             if verbose:
                 print(f"\n--- [VERBOSE OUTPUT START: {example_name}] ---")
 
-                # Execute with Popen to stream stdout/stderr live to both terminal and file
+                # Execute with `Popen` to stream stdout/stderr live to both terminal and file.
                 process = subprocess.Popen(
                     cmd,
                     stdout=subprocess.PIPE,
@@ -82,7 +82,7 @@ def run_iccl_example(
                     f"--- [VERBOSE OUTPUT END: {example_name}] ---\n" + " " * 56, end=""
                 )
             else:
-                # Quiet mode: Redirect straight to the file handle
+                # Quiet mode: Redirect straight to the file handle.
                 result = subprocess.run(
                     cmd,
                     stdout=log_file,
@@ -157,7 +157,7 @@ def main():
 
     args = parser.parse_args()
 
-    # Parse and clean the comma-separated examples list
+    # Parse and clean the comma-separated examples list.
     examples_to_run = [ex.strip() for ex in args.examples.split(",") if ex.strip()]
 
     # Sanity Checks
@@ -167,7 +167,7 @@ def main():
 
     if not examples_to_run:
         print(
-            "❌ Error: No target programs defined. Please check your --examples list."
+            "❌ Error: No target programs defined. Please check your `--examples` list."
         )
         sys.exit(1)
 
@@ -227,7 +227,7 @@ def main():
         )
         sys.exit(1)
     else:
-        print("🎉 All targets functioned within specification thresholds!")
+        print("🎉 All targets executed successfully!")
         sys.exit(0)
 
 

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -25,6 +25,7 @@ def run_iccl_example(
     log_dir: str,
     trigger_build: bool,
     verbose: bool,
+    timeout_duration: int,
 ) -> bool:
     """Executes an example via `icclrun` orchestration framework."""
     log_file_path = os.path.join(log_dir, f"{example_name}.log")
@@ -76,7 +77,7 @@ def run_iccl_example(
                     sys.stdout.write(line)
                     log_file.write(line)
 
-                process.wait(timeout=600)
+                process.wait(timeout=timeout_duration)
                 return_code = process.returncode
                 print(
                     f"--- [VERBOSE OUTPUT END: {example_name}] ---\n" + " " * 56, end=""
@@ -89,7 +90,7 @@ def run_iccl_example(
                     stderr=subprocess.STDOUT,
                     env=custom_env,
                     text=True,
-                    timeout=600,
+                    timeout=timeout_duration,
                 )
                 return_code = result.returncode
 
@@ -101,9 +102,9 @@ def run_iccl_example(
             return False
 
     except subprocess.TimeoutExpired:
-        print(" ❌ TIMEOUT (Exceeded 10 minutes)")
+        print(f" ❌ TIMEOUT (Exceeded {timeout_duration} seconds)")
         with open(log_file_path, "a") as f:
-            f.write("\n[RUNNER ERROR]: Distributed `icclrun` harness timed out.\n")
+            f.write(f"\n[RUNNER ERROR]: Distributed `icclrun` harness timed out after {timeout_duration} seconds.\n")
         return False
     except FileNotFoundError:
         print(" ❌ ERROR   (`icclrun` executable not found in `PATH`)")
@@ -147,6 +148,13 @@ def main():
         type=str,
         default="./example_logs",
         help="Destination directory where output logs will be stored.",
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=300,
+        help="Timeout duration in seconds for each individual example execution pass.",
     )
     parser.add_argument(
         "-v",
@@ -196,6 +204,7 @@ def main():
             log_dir=current_run_log_dir,
             trigger_build=is_first_run,
             verbose=args.verbose,
+            timeout_duration=args.timeout,
         )
 
         is_first_run = False

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -95,7 +95,7 @@ def run_iccl_example(
                 return_code = result.returncode
 
         if return_code == 0:
-            print(f"  ✓ PASSED  (Log saved to {os.path.basename(log_file_path)})")
+            print(f"  ✓ PASSED  (Log saved to `{os.path.basename(log_file_path)}`)")
             return True
         else:
             print(f" ❌ FAILED  (Exit Code: {return_code})")


### PR DESCRIPTION
## Summary
This PR introduces an automated multi-collective verification harness (`scripts/run_examples.py`) to systematically run and test InfiniCCL’s example programs in sequence. It eliminates the friction of manually running individual `icclrun` workloads across a cluster and adds clear logging traceability and execution configurations via the CLI. It also updates the project documentation to reflect this change.

## Changes
- **Automated Verification Harness**
  - add `scripts/run_examples.py` script to orchestrate sequential end-to-end testing of native collectives (e.g., broadcast, all_reduce, all_gather, etc.);
  - the script can log the output of each example program and chronologically separate each run;
  - the script optimizes the execution loop to only pass `--build` to the first target workload, successfully bypassing redundant multi-node compilation passes for all subsequent examples.
  - Implement full CLI parameter support: 
    - allowing users to override cluster topology configurations (`-c`/`--config`);
    - explicitly choose backends (`-l`/`--launcher`);
    - scope isolated target arrays (`-e`/`--examples`);
    - specify target output destinations (`-o`/`--log-path`);
    - specify timeout duration for each example program (`-t`/`--timeout`);
    - verbose tracking flag (`-v`/`--verbose`)

 - **Documentation Updates**
   - Update `README.md` under the "Run Internal Examples" subsection to document the execution harness.

## Known Issues & Future Work
- **Orphaned Process Cleanup:**
  - The harness currently uses standard timeout enforcement on the top-level orchestration call. If a distributed job hangs or times out across the cluster, sub-processes spawned on remote worker nodes by `icclrun` or the underlying launcher might occasionally remain orphaned on worker nodes. Future work could introduce an automatic remote process cleanup signal on timeout.
- **Dynamic/Per-Collective Timeout Specifications:**
  - The current implementation applies a uniform `--timeout` threshold across all collective examples. For large-scale testing workloads, allowing an array or matrix mapping specific timeout limits to specific heavier operations (e.g., giving `all_to_all` more headroom than `broadcast`) would be beneficial.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster

[all_gather.log](https://github.com/user-attachments/files/28055504/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28055505/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28055507/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28055508/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28055510/reduce_scatter.log)

Usage Screenshot: 
<img width="593" height="288" alt="image" src="https://github.com/user-attachments/assets/9c63990f-b607-4d9c-bd89-22fd8cc06fe1" />

The listed options from `./run_examples.py --help`: 
<img width="847" height="224" alt="image" src="https://github.com/user-attachments/assets/349039aa-e52d-4421-bb66-7638d0fdaa23" />
