### PR TITLE
build: support automatic backend detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(WITH_NCCL "Enable NCCL backend"    OFF)
 # --- MISC. BUILD OPTIONS ---
 # =========================================================
 option(AUTO_DETECT_DEVICES "Automatically detect available devices" ON)
-option(AUTO_DETECT_BACKENDS "Automatically detect available backends" ON)
+option(AUTO_DETECT_BACKENDS "Automatically detect available backends" OFF)
 option(BUILD_EXAMPLES "Build internal examples" ON)
 
 # =========================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,17 @@ set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
 # =========================================================
 option(WITH_OMPI "Enable OpenMPI backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
-# OMPI is the default bootstrap/CPU backend.
-if(NOT WITH_OMPI AND NOT WITH_NCCL)
-    set(WITH_OMPI ON)
-    message(STATUS "No backend specified. Defaulting to WITH_OMPI=ON")
-endif()
 
 # =========================================================
 # --- MISC. BUILD OPTIONS ---
 # =========================================================
 option(AUTO_DETECT_DEVICES "Automatically detect available devices" ON)
+option(AUTO_DETECT_BACKENDS "Automatically detect available backends" ON)
 option(BUILD_EXAMPLES "Build internal examples" ON)
 
+# =========================================================
+# --- AUTO-DETECTION: DEVICES ---
+# =========================================================
 if(AUTO_DETECT_DEVICES)
     message(STATUS "Auto-detecting available devices...")
 
@@ -82,6 +81,45 @@ if(AUTO_DETECT_DEVICES)
             message(STATUS "No MetaX GPU detected")
         endif()
     endif()
+endif()
+
+# =========================================================
+# --- AUTO-DETECTION: BACKENDS ---
+# =========================================================
+if(AUTO_DETECT_BACKENDS)
+    message(STATUS "Auto-detecting available communication backends...")
+
+    # Detect OpenMPI Dependencies
+    find_program(MPIRUN_PATH NAMES mpirun mpiexec)
+    find_program(MPICC_PATH NAMES mpicc)
+    
+    if(MPIRUN_PATH AND MPICC_PATH)
+        set(WITH_OMPI ON)
+        message(STATUS "Auto-detected OpenMPI environment.")
+    else()
+        message(STATUS "OpenMPI environment not detected.")
+    endif()
+
+    # Detect NCCL Dependencies
+    if(WITH_NVIDIA)
+        find_path(AUTO_NCCL_INC NAMES nccl.h QUIET)
+        find_library(AUTO_NCCL_LIB NAMES nccl QUIET)
+
+        if(AUTO_NCCL_INC AND AUTO_NCCL_LIB)
+            set(WITH_NCCL ON)
+            message(STATUS "Auto-detected NCCL backend.")
+        else()
+            message(STATUS "NCCL library/headers not found in standard paths.")
+        endif()
+    else()
+        message(STATUS "No suitable device environment, skipping NCCL detection.")
+    endif()
+endif()
+
+# Fallback: If no backends are enabled or auto-detected, fall back to OpenMPI as the default bootstrap profile.
+if(NOT WITH_OMPI AND NOT WITH_NCCL)
+    set(WITH_OMPI ON)
+    message(STATUS "No backend specified or detected. Defaulting to `WITH_OMPI=ON`")
 endif()
 
 # =========================================================

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | `WITH_NCCL`   | Enable NCCL backend | `OFF` |
 | **Miscellaneous** |||
 | `AUTO_DETECT_DEVICES` | Automatically detect available devices and enable corresponding support | `ON` |
+| `AUTO_DETECT_BACKENDS` | Automatically detect available communication backends and enable corresponding support | `OFF` |
 | `BUILD_EXAMPLES` | Build internal example programs | `ON` |
 
 ### Standard CMake Options (not InfiniCCL‑specific)
@@ -176,6 +177,7 @@ icclrun --config [path-to-your-cluster.yaml] --build all_reduce [program args]
 
 - `--config / -c` : Path to the cluster YAML file.
 - `--build` : Instructs `icclrun` to compile the library on each node before execution. If omitted, `icclrun` assumes the library is already installed at a consistent location.
+- `--launcher` : Specify the backend launcher to be used. Default to `ompi`.
 
 The executable (e.g., `all_reduce`) and its arguments follow the options.
 
@@ -272,7 +274,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 
 | Platform | Support Level | Notes |
 |----------|---------------|-------|
-| **CPU**    | Partial | Runtime available, but no pure CPU collective operations yet. Planned for future releases. |
+| **CPU**    | Partial | Runtime available, suppot OpenMPI backend, but no pure CPU collective operations yet. Planned for future releases. |
 | **NVIDIA** | Full | Requires CUDA Toolkit. |
 | **MetaX**  | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
 


### PR DESCRIPTION
## Summary
This PR introduces automatic communication backend detection, enabling the library to automatically select and configure the suitable backends (e.g., OpenMPI, NCCL, etc.) based on the available environment. 

## Changes
- **Automatic Backend Detection Mechanism**
  - add `AUTO_DETECT_BACKENDS` option and implement the detection logic in `CMakeLists.txt` to enable discovery of available communication backends.

 - **Documentation Updates**
   - Updated `README.md` to document the `AUTO_DETECT_BACKENDS` option and the `--launcher` flag in `icclrun`, including their usage and behavior.

## Known Issues & Future Work
- `AUTO_DETECT_BACKENDS` is currently disabled by default (OFF). In most of the environments, vendor-provided CCLs may be present, and enabling this option would detect and include them. However, InfiniCCL does not yet support these vendor CCLs, so automatic detection remains opt-in for now.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster
[all_gather.log](https://github.com/user-attachments/files/28142733/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28142734/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28142735/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28142736/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28142737/reduce_scatter.log)
