### PR TITLE
feat: support MPICH backend and unify MPI abstraction layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(AUTO_DETECT_BACKENDS)
     find_program(MPICC_PATH NAMES mpicc)
     
     if(MPIRUN_PATH AND MPICC_PATH)
-        # Query the active `mpirun` variant
+        # Query the active `mpirun` variant.
         execute_process(
             COMMAND ${MPIRUN_PATH} --version
             OUTPUT_VARIABLE MPI_VERSION_OUT
@@ -110,7 +110,7 @@ if(AUTO_DETECT_BACKENDS)
             set(WITH_MPICH ON)
             message(STATUS "Auto-detected MPICH/Hydra environment.")
         else()
-            # Fallback to OMPI if it's an unrecognized wrapper
+            # Fallback to OMPI if it's an unrecognized wrapper.
             set(WITH_OMPI ON)
             message(STATUS "Unknown MPI implementation. Defaulting to `WITH_OMPI=ON`")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,15 +89,30 @@ endif()
 if(AUTO_DETECT_BACKENDS)
     message(STATUS "Auto-detecting available communication backends...")
 
-    # Detect OpenMPI Dependencies
+    # Detect MPI Dependencies
     find_program(MPIRUN_PATH NAMES mpirun mpiexec)
     find_program(MPICC_PATH NAMES mpicc)
     
     if(MPIRUN_PATH AND MPICC_PATH)
-        set(WITH_OMPI ON)
-        message(STATUS "Auto-detected OpenMPI environment.")
-    else()
-        message(STATUS "OpenMPI environment not detected.")
+        # Query the active `mpirun` variant
+        execute_process(
+            COMMAND ${MPIRUN_PATH} --version
+            OUTPUT_VARIABLE MPI_VERSION_OUT
+            ERROR_VARIABLE MPI_VERSION_ERR
+        )
+        set(MPI_VERSION_INFO "${MPI_VERSION_OUT}${MPI_VERSION_ERR}")
+
+        if(MPI_VERSION_INFO MATCHES "Open MPI" OR MPI_VERSION_INFO MATCHES "PRRTE")
+            set(WITH_OMPI ON)
+            message(STATUS "Auto-detected OpenMPI environment.")
+        elseif(MPI_VERSION_INFO MATCHES "MPICH" OR MPI_VERSION_INFO MATCHES "Hydra" OR MPI_VERSION_INFO MATCHES "Intel\\(R\\) MPI")
+            set(WITH_MPICH ON)
+            message(STATUS "Auto-detected MPICH/Hydra environment.")
+        else()
+            # Fallback to OMPI if it's an unrecognized wrapper
+            set(WITH_OMPI ON)
+            message(STATUS "Unknown MPI implementation. Defaulting to `WITH_OMPI=ON`")
+        endif()
     endif()
 
     # Detect NCCL Dependencies
@@ -117,7 +132,7 @@ if(AUTO_DETECT_BACKENDS)
 endif()
 
 # Fallback: If no backends are enabled or auto-detected, fall back to OpenMPI as the default bootstrap profile.
-if(NOT WITH_OMPI AND NOT WITH_NCCL)
+if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL)
     set(WITH_OMPI ON)
     message(STATUS "No backend specified or detected. Defaulting to `WITH_OMPI=ON`")
 endif()
@@ -149,7 +164,7 @@ if(WITH_METAX)
     find_library(MACA_RUNTIME_LIB NAMES mcruntime HINTS "${MACA_PATH}/lib" REQUIRED)
 endif()
 
-if(WITH_OMPI)
+if(WITH_OMPI OR WITH_MPICH)
     find_package(MPI REQUIRED)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
 # --- BACKEND OPTIONS (Communication Protocols) ---
 # =========================================================
 option(WITH_OMPI "Enable OpenMPI backend" OFF)
+option(WITH_MPICH "Enable MPICH backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
 
 # =========================================================

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | `WITH_CPU`    | CPU support (always enabled) | `ON` (internal, not user‑settable) |
 | **Backend (Communication) Options** |||
 | `WITH_OMPI`   | Enable OpenMPI backend | `ON` if no backend specified, otherwise `OFF` |
+| `WITH_MPICH`  | Enable MPICH backend | `OFF` |
 | `WITH_NCCL`   | Enable NCCL backend | `OFF` |
 | **Miscellaneous** |||
 | `AUTO_DETECT_DEVICES` | Automatically detect available devices and enable corresponding support | `ON` |
@@ -154,6 +155,7 @@ These options are available in any CMake project and can be passed during config
 
 > **Notes**:
 > - `AUTO_DETECT_DEVICES` overrides device options like `WITH_NVIDIA` when detection succeeds.
+> - `AUTO_DETECT_BACKENDS` overrides backend options like `WITH_OMPI` when detection succeeds.
 
 </details>
 
@@ -286,6 +288,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 | Backend | Support Level | Required CMake Option | Dependencies |
 |---------|---------------|----------------------|---------------|
 | **OpenMPI** | Full | `WITH_OMPI=ON` | The default backend. Requires the OpenMPI development package.|
+| **MPICH** | Full | `WITH_MPICH=ON` | Requires the MPICH development package.|
 
 </details>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(source_file ${EXAMPLE_SOURCES})
         target_link_libraries(${example_name} PRIVATE CUDA::cudart)
     endif()
     
-    if(WITH_OMPI)
+    if(WITH_OMPI OR WITH_MPICH)
         target_link_libraries(${example_name} PRIVATE MPI::MPI_CXX)
     endif()
 

--- a/scripts/backends/mpi_base.py
+++ b/scripts/backends/mpi_base.py
@@ -1,0 +1,60 @@
+import os
+
+
+class BaseMpiBackend:
+    def get_hostfile_line(self, ip, slots):
+        """Must return the string format for a hostfile line."""
+        raise NotImplementedError
+
+    def get_base_mpi_args(self, hostfile_path, total_slots):
+        """Must return the initial mpirun execution arguments list."""
+        raise NotImplementedError
+
+    def get_env_args(self, env_key, env_val):
+        """Must return the flags used to forward environment variables."""
+        raise NotImplementedError
+
+    def get_launch_command(self, config, executable, user_args, launcher_obj):
+        common_dir = config["common_dir"]
+        build_dir = os.path.join(common_dir, "build")
+        os.makedirs(build_dir, exist_ok=True)
+
+        # Shared Hostfile Generation
+        hostfile_name = (
+            f"hosts_{self.__class__.__name__.lower().replace('backend', '')}.txt"
+        )
+        hostfile_path = os.path.join(build_dir, hostfile_name)
+        total_slots = 0
+
+        with open(hostfile_path, "w") as f:
+            for node in config["nodes"]:
+                slots = node.get("slots", 8)
+                total_slots += slots
+                f.write(self.get_hostfile_line(node["ip"], slots))
+
+        # Shared Launcher Script Logic
+        launcher_script = config.get("launcher_script")
+        if not launcher_script:
+            launcher_script = launcher_obj.ensure_launcher_exists()
+
+        # Fetch specific base runner flags (OMPI vs MPICH).
+        cmd = self.get_base_mpi_args(hostfile_path, total_slots)
+
+        # Shared Backend Arguments Parser Loop
+        if "backend_args" in config and config["backend_args"]:
+            for flag, values in config["backend_args"].items():
+                if isinstance(values, list):
+                    for val in values:
+                        cmd.append(flag)
+                        cmd.extend(val.split())
+                else:
+                    cmd.append(flag)
+                    cmd.extend(str(values).split())
+
+        # Environment Forwarding Loop
+        if "backend_env" in config and config["backend_env"]:
+            for env_key, env_val in config["backend_env"].items():
+                cmd.extend(self.get_env_args(env_key, env_val))
+
+        cmd.extend([launcher_script, executable])
+        return cmd + list(user_args)

--- a/scripts/backends/mpi_base.py
+++ b/scripts/backends/mpi_base.py
@@ -3,11 +3,11 @@ import os
 
 class BaseMpiBackend:
     def get_hostfile_line(self, ip, slots):
-        """Must return the string format for a hostfile line."""
+        """Must return the string format for a `hostfile` line."""
         raise NotImplementedError
 
     def get_base_mpi_args(self, hostfile_path, total_slots):
-        """Must return the initial mpirun execution arguments list."""
+        """Must return the initial `mpirun` execution arguments list."""
         raise NotImplementedError
 
     def get_env_args(self, env_key, env_val):

--- a/scripts/backends/mpich.py
+++ b/scripts/backends/mpich.py
@@ -1,0 +1,14 @@
+from backends.mpi_base import BaseMpiBackend
+
+
+class MpichBackend(BaseMpiBackend):
+    def get_hostfile_line(self, ip, slots):
+        return f"{ip}:{slots}\n"
+
+    def get_base_mpi_args(self, hostfile_path, total_slots):
+        # MPICH uses `-f` for hostfile, `-n` for slot allocations, no root check needed.
+        return ["mpirun", "-f", hostfile_path, "-n", str(total_slots)]
+
+    def get_env_args(self, env_key, env_val):
+        # MPICH/Hydra utilizes global genv flags.
+        return ["-genv", env_key, str(env_val)]

--- a/scripts/backends/mpich.py
+++ b/scripts/backends/mpich.py
@@ -10,5 +10,5 @@ class MpichBackend(BaseMpiBackend):
         return ["mpirun", "-f", hostfile_path, "-n", str(total_slots)]
 
     def get_env_args(self, env_key, env_val):
-        # MPICH/Hydra utilizes global genv flags.
+        # MPICH/Hydra utilizes global `genv` flags.
         return ["-genv", env_key, str(env_val)]

--- a/scripts/backends/ompi.py
+++ b/scripts/backends/ompi.py
@@ -1,45 +1,19 @@
 import os
+from backends.mpi_base import BaseMpiBackend
 
 
-class OmpiBackend:
-    def get_launch_command(self, config, executable, user_args, launcher_obj):
-        common_dir = config["common_dir"]
-        build_dir = os.path.join(common_dir, "build")
-        os.makedirs(build_dir, exist_ok=True)
+class OmpiBackend(BaseMpiBackend):
+    def get_hostfile_line(self, ip, slots):
+        return f"{ip} slots={slots}\n"
 
-        # Hostfile Generation
-        hostfile_path = os.path.join(build_dir, "hosts.txt")
-        total_slots = 0
-        with open(hostfile_path, "w") as f:
-            for node in config["nodes"]:
-                slots = node.get("slots", 8)
-                total_slots += slots
-                f.write(f"{node['ip']} slots={slots}\n")
-
-        # Launcher Logic: Use YAML override OR Auto-generate.
-        launcher_script = config.get("launcher_script")
-        if not launcher_script:
-            launcher_script = launcher_obj.ensure_launcher_exists()
-
+    def get_base_mpi_args(self, hostfile_path, total_slots):
         cmd = ["mpirun", "--hostfile", hostfile_path, "-np", str(total_slots)]
 
         # Safety: OpenMPI refuses to run as root unless explicitly told.
         if os.getuid() == 0:
             cmd.append("--allow-run-as-root")
 
-        if "backend_args" in config and config["backend_args"]:
-            for flag, values in config["backend_args"].items():
-                if isinstance(values, list):
-                    for val in values:
-                        cmd.append(flag)
-                        cmd.extend(val.split())
-                else:
-                    cmd.append(flag)
-                    cmd.extend(str(values).split())
+        return cmd
 
-        if "backend_env" in config and config["backend_env"]:
-            for env_key, env_val in config["backend_env"].items():
-                cmd.extend(["-x", f"{env_key}={env_val}"])
-
-        cmd.extend([launcher_script, executable])
-        return cmd + list(user_args)
+    def get_env_args(self, env_key, env_val):
+        return ["-x", f"{env_key}={env_val}"]

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -22,7 +22,7 @@ AUTOGEN_HEADER = """/*
 DEVICE_TRAIT_HEADERS = ["device_.h", "runtime_.h", "data_type_.h"]
 
 # Map logical backend names (from CMake) to their internal source paths.
-BACKEND_PATH_MAP = {"ompi": "ompi/impl", "nccl": "nvidia/nccl"}
+BACKEND_PATH_MAP = {"ompi": "ompi/impl", "mpich": "ompi/impl", "nccl": "nvidia/nccl"}
 
 # =================================================================
 # LOGIC

--- a/scripts/icclrun.py
+++ b/scripts/icclrun.py
@@ -6,11 +6,31 @@ import os
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(SCRIPT_DIR)
 
-# Add the installed private library path (for production runs).
-# `CMAKE_INSTALL_PREFIX/bin` -> `CMAKE_INSTALL_PREFIX/lib/infiniccl`
-INSTALL_LIB_PATH = os.path.join(os.path.dirname(SCRIPT_DIR), "lib", "infiniccl")
-if os.path.exists(INSTALL_LIB_PATH):
-    sys.path.append(INSTALL_LIB_PATH)
+# CMAKE_INSTALL_PREFIX
+PREFIX_DIR = os.path.dirname(SCRIPT_DIR)
+lib_found = False
+
+for lib_dir_name in ["lib64", "lib"]:
+    candidate_path = os.path.join(PREFIX_DIR, lib_dir_name, "infiniccl")
+    if os.path.exists(candidate_path):
+        sys.path.append(candidate_path)
+        lib_found = True
+        break
+
+# Fallback
+if not lib_found:
+    if os.path.exists(os.path.join(PREFIX_DIR, "icclrun_logic.py")):
+        sys.path.append(PREFIX_DIR)
+    else:
+        print(
+            f"[Error]: Could not locate 'icclrun_logic.py' in system library paths or local workspace.",
+            file=sys.stderr,
+        )
+        print(
+            f"Looked under: {os.path.join(PREFIX_DIR, 'lib64/infiniccl')}, {os.path.join(PREFIX_DIR, 'lib/infiniccl')}, and {PREFIX_DIR}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 from icclrun_logic import ICCLLauncher
 

--- a/scripts/icclrun.py
+++ b/scripts/icclrun.py
@@ -6,7 +6,7 @@ import os
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(SCRIPT_DIR)
 
-# CMAKE_INSTALL_PREFIX
+# `CMAKE_INSTALL_PREFIX`
 PREFIX_DIR = os.path.dirname(SCRIPT_DIR)
 lib_found = False
 

--- a/scripts/icclrun.py
+++ b/scripts/icclrun.py
@@ -41,9 +41,9 @@ def main():
     parser.add_argument("--build", action="store_true", help="Compile remote nodes")
     parser.add_argument(
         "--launcher",
-        choices=["ompi", "none"],
+        choices=["ompi", "mpich", "none"],
         default="ompi",
-        help="Orchestration layer: 'ompi' for mpirun cluster apps, 'none' for native threaded single-node apps.",
+        help="Orchestration layer: 'ompi'/'mpich' for mpirun cluster apps, 'none' for native threaded single-node apps.",
     )
 
     launcher_args, remaining = parser.parse_known_args()

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -160,6 +160,14 @@ exec "$EXE" "$@"
                 self.config, executable, args, launcher_obj
             )
 
+        elif launcher_type == "mpich":
+            from backends.mpich import MpichBackend
+
+            backend = MpichBackend()
+            cmd = backend.get_launch_command(
+                self.config, executable, args, launcher_obj
+            )
+
         elif launcher_type == "none":
             launcher_script = self.config.get("launcher_script")
             if not launcher_script:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,17 @@ if(WITH_OMPI)
     endif()
 endif()
 
+if(WITH_MPICH)
+    list(APPEND BACKEND_LIST "mpich")
+    # Note: MPICH shares the same internal implementation as OMPI, so we reuse the `ompi/impl` sources for both.
+    # However, later there may be MPICH-specific sources added to the `mpich/` directory.
+    file(GLOB_RECURSE MPICH_SRCS "mpich/*.cc" "mpich/*.cpp" "ompi/*.cc" "ompi/*.cpp") 
+    target_sources(infiniccl PRIVATE ${MPICH_SRCS})
+    if(TARGET MPI::MPI_CXX)
+        target_link_libraries(infiniccl PRIVATE MPI::MPI_CXX)
+    endif()
+endif()
+
 # NCCL
 if(WITH_NCCL)
     list(APPEND BACKEND_LIST "nccl")


### PR DESCRIPTION
## Summary
This PR extends InfiniCCL to support the MPICH backend alongside OpenMPI, and refactors the MPI abstraction layer to improve modularity and maintainability. It introduces a unified MPI backend architecture that cleanly separates shared MPI logic from implementation-specific differences.

## Changes
- **MPICH Backend Support**
  - add support for MPICH as a valid backend in the build system;
  - update `scripts/gen_bridge.py` to include MPICH support in generated bridges;
  - refactor MPI backend architecture:
    - move shared logic between OpenMPI and MPICH into `scripts/backends/mpi_base.py`;
    - keep only backend-specific differences in `scripts/backends/mpich.py` and `scripts/backends/ompi.py`;
    - extend `icclrun` and related runtime scripts to recognize and launch MPICH-based execution flows;

- **Runtime Improvements**
  - update `icclrun` to better support MPI library discovery and linking, particularly improving robustness on 64-bit platforms;
  - enhance backend selection logic to reduce ambiguity when multiple MPI implementations are present.

 - **Documentation Updates**
   - updated `README.md` to document `WITH_MPICH` option;
   - add a note about `AUTO_DETECT_BACKENDS`.

## Known Issues & Future Work
- The current MPICH backend directly reuses the OpenMPI implementation, with no functional divergence between the two. This is acceptable as long as no backend-specific features are introduced. However, if MPICH- or OpenMPI-specific behavior is required in the future, this design will need to be refactored into a proper abstraction layer, with a shared MPI base implementation and separate backend-specific specializations for OpenMPI and MPICH.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster
[all_gather.log](https://github.com/user-attachments/files/28147331/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28147335/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28147337/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28147338/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28147339/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28147340/send_recv.log)
