### PR TITLE
feat: add Cambricon platform support across runtime, device, build, and launcher stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # =========================================================
 # --- DEVICE OPTIONS (Hardware Runtimes) ---
 # =========================================================
-option(WITH_NVIDIA "Enable NVIDIA GPU support" OFF)
-option(WITH_METAX  "Enable MetaX GPU support"  OFF)
+option(WITH_NVIDIA      "Enable NVIDIA GPU support"     OFF)
+option(WITH_METAX       "Enable MetaX GPU support"      OFF)
+option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
 
 set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
 
@@ -64,7 +65,7 @@ if(AUTO_DETECT_DEVICES)
     # MetaX
     if(DEFINED ENV{MACA_PATH})
         set(WITH_METAX ON)
-        message(STATUS "Auto-detected MetaX environment from MACA_PATH")
+        message(STATUS "Auto-detected MetaX environment from `MACA_PATH`")
     else()
         execute_process(
             COMMAND sh -c "grep -h 9999 /sys/bus/pci/devices/*/vendor 2>/dev/null"
@@ -81,6 +82,35 @@ if(AUTO_DETECT_DEVICES)
             set(WITH_METAX OFF)
             message(STATUS "No MetaX GPU detected")
         endif()
+    endif()
+
+    # Cambricon
+    set(CAMBRICON_FOUND FALSE)
+
+    if(DEFINED ENV{NEUWARE_HOME})
+        set(CAMBRICON_FOUND TRUE)
+        message(STATUS "Auto-detected Cambricon environment from `NEUWARE_HOME`")
+    else()
+        find_program(CNMON_PATH cnmon)
+        if(CNMON_PATH)
+            execute_process(
+                COMMAND ${CNMON_PATH} -l
+                RESULT_VARIABLE CNMON_RESULT
+                OUTPUT_QUIET
+                ERROR_QUIET
+            )
+            if(CNMON_RESULT EQUAL 0)
+                set(CAMBRICON_FOUND TRUE)
+            endif()
+        endif()
+    endif()
+
+    if(CAMBRICON_FOUND)
+        set(WITH_CAMBRICON ON)
+        message(STATUS "Cambricon environment detected.")
+    else()
+        set(WITH_CAMBRICON OFF)
+        message(STATUS "Cambricon environment not detected.")
     endif()
 endif()
 
@@ -163,6 +193,20 @@ if(WITH_METAX)
     link_directories("${MACA_PATH}/lib")
 
     find_library(MACA_RUNTIME_LIB NAMES mcruntime HINTS "${MACA_PATH}/lib" REQUIRED)
+endif()
+
+if(WITH_CAMBRICON)
+    set(NEUWARE_HOME $ENV{NEUWARE_HOME})
+
+    include_directories("${NEUWARE_HOME}/include")
+    link_directories("${NEUWARE_HOME}/lib")
+    link_directories("${NEUWARE_HOME}/lib64")
+
+    # Libraries: `cnrt` / `cnnl` / `cnnl_extra` / `cnpapi`.
+    find_library(CAMBRICON_RUNTIME_LIB    NAMES cnrt       HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
+    find_library(CAMBRICON_CNNL_LIB       NAMES cnnl       HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
+    find_library(CAMBRICON_CNNL_EXTRA_LIB NAMES cnnl_extra HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
+    find_library(CAMBRICON_PAPI_LIB       NAMES cnpapi     HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
 endif()
 
 if(WITH_OMPI OR WITH_MPICH)

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | Option | Description | Default |
 |--------|-------------|---------|
 | **Device (Hardware) Options** |||
-| `WITH_NVIDIA` | Enable NVIDIA GPU support | `OFF` |
-| `WITH_METAX`  | Enable MetaX GPU support  | `OFF` |
-| `WITH_CPU`    | CPU support (always enabled) | `ON` (internal, not user‑settable) |
+| `WITH_NVIDIA`     | Enable NVIDIA GPU support | `OFF` |
+| `WITH_METAX`      | Enable MetaX GPU support  | `OFF` |
+| `WITH_CAMBRICON`  | Enable Cambricon MLU support  | `OFF` |
+| `WITH_CPU`        | CPU support (always enabled) | `ON` (internal, not user‑settable) |
 | **Backend (Communication) Options** |||
 | `WITH_OMPI`   | Enable OpenMPI backend | `ON` if no backend specified, otherwise `OFF` |
 | `WITH_MPICH`  | Enable MPICH backend | `OFF` |
@@ -276,9 +277,10 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 
 | Platform | Support Level | Notes |
 |----------|---------------|-------|
-| **CPU**    | Partial | Runtime available, suppot OpenMPI backend, but no pure CPU collective operations yet. Planned for future releases. |
-| **NVIDIA** | Full | Requires CUDA Toolkit. |
-| **MetaX**  | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
+| **CPU**        | Partial | Runtime available, suppot OpenMPI backend, but no pure CPU collective operations yet. Planned for future releases. |
+| **NVIDIA**     | Full | Requires CUDA Toolkit. |
+| **MetaX**      | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
+| **Cambricon**  | Full | Requires CNToolKit and `NEUWARE_HOME` to be set. |
 
 </details>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,14 @@ foreach(source_file ${EXAMPLE_SOURCES})
     if(WITH_NVIDIA)
         target_link_libraries(${example_name} PRIVATE CUDA::cudart)
     endif()
+
+    if(WITH_METAX)
+        target_link_libraries(${example_name} PRIVATE ${MACA_RUNTIME_LIB})
+    endif()
+
+    if(WITH_CAMBRICON)
+        target_link_libraries(${example_name} PRIVATE ${CAMBRICON_RUNTIME_LIB})
+    endif()
     
     if(WITH_OMPI OR WITH_MPICH)
         target_link_libraries(${example_name} PRIVATE MPI::MPI_CXX)

--- a/examples/all_gather.cc
+++ b/examples/all_gather.cc
@@ -67,8 +67,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   float *d_send, *d_recv;
   size_t send_bytes = kNumElements * sizeof(*d_send);
   size_t recv_bytes = send_bytes * size;
-  CHECK_RT(Rt, Rt::Malloc(&d_send, send_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, recv_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, send_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, recv_bytes));
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), recv_bytes,

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -66,8 +66,8 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
 
   float *d_send, *d_recv;
   size_t total_bytes = kNumElements * sizeof(*d_send);
-  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,

--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -79,8 +79,8 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   float *d_recv = nullptr;
   size_t total_bytes = kTotalCount * sizeof(*d_send);
 
-  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,

--- a/examples/broadcast.cc
+++ b/examples/broadcast.cc
@@ -73,8 +73,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
   // Allocate Device Memory
   float *d_send, *d_recv;
   size_t total_bytes = kNumElements * sizeof(float);
-  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
 
   // Copy data from host to device memory.
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,

--- a/examples/reduce_scatter.cc
+++ b/examples/reduce_scatter.cc
@@ -71,8 +71,8 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   size_t send_bytes = kSendCount * sizeof(*d_send);
   size_t recv_bytes = kRecvCount * sizeof(*d_recv);
 
-  CHECK_RT(Rt, Rt::Malloc(&d_send, send_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, recv_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, send_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, recv_bytes));
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), recv_bytes,

--- a/examples/send_recv.cc
+++ b/examples/send_recv.cc
@@ -71,8 +71,8 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
   float *d_recv = nullptr;
   size_t total_bytes = num_elements * sizeof(*d_send);
 
-  CHECK_RT(Rt, Rt::Malloc(&d_send, total_bytes));
-  CHECK_RT(Rt, Rt::Malloc(&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
   CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -184,4 +184,4 @@ exec "$EXE" "$@"
             print(f"Error: Unsupported launcher environment '{launcher_type}'")
             sys.exit(1)
 
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -121,6 +121,11 @@ class ICCLLauncher:
                     'grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1'
                 )
 
+            elif n_type == "cambricon":
+                condition = (
+                    '[ -n "${NEUWARE_HOME}" ] || command -v cnmon >/dev/null 2>&1'
+                )
+
             # Skip unknown platforms cleanly.
             if condition is None:
                 continue

--- a/scripts/run_wrapper.sh
+++ b/scripts/run_wrapper.sh
@@ -13,6 +13,8 @@ if [ -c "/dev/nvidia0" ] || [ -x "$(command -v nvidia-smi)" ]; then
     ARCH="nvidia"
 elif grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1 || [ -d "/opt/maca" ]; then
     ARCH="metax"
+elif [ -n "${NEUWARE_HOME}" ] || [ -x "$(command -v cnmon)" ]; then
+    ARCH="cambricon"
 else
     ARCH="cpu"
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,82 @@ if(WITH_METAX)
     target_compile_options(infiniccl PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-x maca>)
 endif()
 
+# Cambricon
+if(WITH_CAMBRICON)
+    list(APPEND DEVICE_LIST "cambricon")
+
+    set(CAMBRICON_PATTERNS
+        "cambricon/*.cc"
+        "cambricon/*.cpp"
+        "cambricon/*.mlu"
+    )
+    file(GLOB CAMBRICON_SOURCES ${CAMBRICON_PATTERNS})
+
+    find_program(CNCC_COMPILER cncc HINTS "${NEUWARE_HOME}/bin" "$ENV{NEUWARE_HOME}/bin" /usr/local/neuware/bin)
+
+    if(CNCC_COMPILER)
+        message(STATUS "Found Cambricon `cncc` compiler: ${CNCC_COMPILER}")
+        execute_process(
+            COMMAND ${CNCC_COMPILER} --print-file-name=include
+            OUTPUT_VARIABLE CNCC_INTERNAL_INC_DIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        
+        set(MLU_COMPILE_OPTS
+            -c --bang-mlu-arch=mtp_592 -O3 -fPIC -Wall -Werror -std=c++17 -pthread
+            -I${PROJECT_SOURCE_DIR}
+            -I${PROJECT_SOURCE_DIR}/include
+            -I${CMAKE_CURRENT_SOURCE_DIR}
+            -I${NEUWARE_HOME}/include
+            -I${CNCC_INTERNAL_INC_DIR}
+        )
+
+        # Custom automation function to route `.mlu` sources through `cncc`.
+        function(compile_mlu_file src_file)
+            get_filename_component(name ${src_file} NAME_WE)
+            get_filename_component(path ${src_file} DIRECTORY)
+            set(out_file "${CMAKE_CURRENT_BINARY_DIR}/${path}/${name}.o")
+            file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${path}")
+            
+            add_custom_command(OUTPUT ${out_file}
+                COMMAND ${CNCC_COMPILER} ${MLU_COMPILE_OPTS} -c ${src_file} -o ${out_file}
+                DEPENDS ${src_file}
+                COMMENT "Building MLU kernel: ${src_file}"
+            )
+            set_property(DIRECTORY APPEND PROPERTY CAMBRICON_OBJECTS ${out_file})
+        endfunction()
+
+        foreach(src ${CAMBRICON_SOURCES})
+            if(${src} MATCHES "\\.mlu$")
+                compile_mlu_file(${src})
+            endif()
+        endforeach()
+
+        # Append generated MLU hardware binaries straight into the target.
+        get_directory_property(CAMBRICON_OBJECT_FILES CAMBRICON_OBJECTS)
+        if(CAMBRICON_OBJECT_FILES)
+            target_sources(infiniccl PRIVATE ${CAMBRICON_OBJECT_FILES})
+        endif()
+    else()
+        message(FATAL_ERROR "`cncc` compiler required for Cambricon build but not found.")
+    endif()
+
+    foreach(src ${CAMBRICON_SOURCES})
+        if(${src} MATCHES "\\.(cc|cpp)$")
+            target_sources(infiniccl PRIVATE ${src})
+        endif()
+    endforeach()
+
+    target_include_directories(infiniccl PRIVATE "${NEUWARE_HOME}/include")
+    
+    target_link_libraries(infiniccl PRIVATE 
+        ${CAMBRICON_RUNTIME_LIB} 
+        ${CAMBRICON_CNNL_LIB} 
+        ${CAMBRICON_CNNL_EXTRA_LIB} 
+        ${CAMBRICON_PAPI_LIB}
+    )
+endif()
+
 # =========================================================
 # --- BACKEND SECTIONS (Communication Protocols) ---
 # =========================================================

--- a/src/cambricon/data_type_.h
+++ b/src/cambricon/data_type_.h
@@ -1,0 +1,35 @@
+#ifndef INFINI_CCL_CAMBRICON_DATA_TYPE__H_
+#define INFINI_CCL_CAMBRICON_DATA_TYPE__H_
+
+#if defined(__mlu__) || defined(__BANG__)
+#include "bang_bf16.h"
+#else
+// If compiling on the host side using standard GCC, mock the storage types
+// to prevent header poisoning and avoid `bang_fp16.h` dependency altogether.
+#ifndef HAS_CAMBRICON_HOST_HALF_MOCKS
+#define HAS_CAMBRICON_HOST_HALF_MOCKS
+
+typedef uint16_t half;
+typedef uint16_t bfloat16_t;
+
+#endif
+#endif
+
+#include "cambricon/device_.h"
+#include "data_type_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct TypeMap<Device::Type::kCambricon, DataType::kFloat16> {
+  using type = half;
+};
+
+template <>
+struct TypeMap<Device::Type::kCambricon, DataType::kBFloat16> {
+  using type = bfloat16_t;
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CAMBRICON_DATA_TYPE__H_

--- a/src/cambricon/device_.h
+++ b/src/cambricon/device_.h
@@ -1,0 +1,13 @@
+#ifndef INFINI_CCL_CAMBRICON_DEVICE__H_
+#define INFINI_CCL_CAMBRICON_DEVICE__H_
+
+#include "device.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kCambricon> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CAMBRICON_DEVICE__H_

--- a/src/cambricon/runtime_.h
+++ b/src/cambricon/runtime_.h
@@ -1,0 +1,61 @@
+#ifndef INFINI_CCL_CAMBRICON_RUNTIME_H_
+#define INFINI_CCL_CAMBRICON_RUNTIME_H_
+
+#include <utility>
+
+// clang-format off
+#include <cnrt.h>
+// clang-format on
+
+#include "cambricon/device_.h"
+#include "logging.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kCambricon>
+    : DeviceRuntime<Runtime<Device::Type::kCambricon>> {
+  using Stream = cnrtQueue_t;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kCambricon;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != cnrtSuccess) {
+          LOG(cnrtGetErrorStr(static_cast<cnrtRet_t>(status)));
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](auto &&...args) {
+    return cnrtMalloc(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Memcpy = [](auto dst, auto src, auto &&...args) {
+    return cnrtMemcpy(dst, (void *)src, std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Free = cnrtFree;
+
+  static constexpr auto MemcpyHostToDevice = cnrtMemcpyHostToDev;
+
+  static constexpr auto MemcpyDeviceToHost = cnrtMemcpyDevToHost;
+
+  static constexpr auto Memset = cnrtMemset;
+
+  static constexpr auto GetDevice = cnrtGetDevice;
+
+  static constexpr auto SetDevice = cnrtSetDevice;
+
+  static constexpr auto DeviceSynchronize = cnrtSyncDevice;
+
+  static constexpr auto StreamSynchronize = cnrtQueueSync;
+};
+
+static_assert(Runtime<Device::Type::kCambricon>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CAMBRICON_RUNTIME_H_

--- a/src/cambricon/runtime_.h
+++ b/src/cambricon/runtime_.h
@@ -1,5 +1,5 @@
-#ifndef INFINI_CCL_CAMBRICON_RUNTIME_H_
-#define INFINI_CCL_CAMBRICON_RUNTIME_H_
+#ifndef INFINI_CCL_CAMBRICON_RUNTIME__H_
+#define INFINI_CCL_CAMBRICON_RUNTIME__H_
 
 #include <utility>
 
@@ -58,4 +58,4 @@ static_assert(Runtime<Device::Type::kCambricon>::Validate());
 
 }  // namespace infini::ccl
 
-#endif  // INFINI_CCL_CAMBRICON_RUNTIME_H_
+#endif  // INFINI_CCL_CAMBRICON_RUNTIME__H_

--- a/src/device.h
+++ b/src/device.h
@@ -9,7 +9,7 @@
 namespace infini::ccl {
 
 class Device {
-public:
+ public:
   enum class Type {
     kCpu = 0,
     kNvidia = 1,
@@ -50,7 +50,7 @@ public:
 
   bool operator!=(const Device &other) const { return !(*this == other); }
 
-private:
+ private:
   Type type_{Type::kCpu};
 
   static constexpr ConstexprMap<Device::Type, std::string_view,
@@ -88,7 +88,8 @@ private:
 
 // Primary template: Devices are disabled by default. Platform-specific
 // headers (e.g. `cpu/device_.h`) specialize this to `std::true_type`.
-template <Device::Type> struct DeviceEnabled : std::false_type {};
+template <Device::Type>
+struct DeviceEnabled : std::false_type {};
 
 // Defines the common categories of devices using List.
 using AllDeviceTypes =
@@ -102,37 +103,48 @@ using AllDeviceTypes =
 // specializations from platform `device_.h` headers are visible at
 // instantiation time. Use with a dependent type parameter
 // (e.g. `ActiveDevices<Key>`) to ensure deferred instantiation.
-template <typename> struct ActiveDevicesImpl {
+template <typename>
+struct ActiveDevicesImpl {
   struct Filter {
     template <Device::Type kDev>
-    std::enable_if_t<DeviceEnabled<kDev>::value>
-    operator()(ValueTag<kDev>) const {}
+    std::enable_if_t<DeviceEnabled<kDev>::value> operator()(
+        ValueTag<kDev>) const {}
   };
 
   using type = typename FilterList<Filter, std::tuple<>, AllDeviceTypes>::type;
 };
 
-template <typename T> using ActiveDevices = typename ActiveDevicesImpl<T>::type;
+template <typename T>
+using ActiveDevices = typename ActiveDevicesImpl<T>::type;
 
 /**
  * @brief Priority trait for device selection.
  */
-template <Device::Type device_type> struct DevicePriority {
+template <Device::Type device_type>
+struct DevicePriority {
   static constexpr int value = 0;
 };
 
-template <> struct DevicePriority<Device::Type::kCpu> {
+template <>
+struct DevicePriority<Device::Type::kCpu> {
   static constexpr int value = 1;
 };
 
-template <> struct DevicePriority<Device::Type::kNvidia> {
+template <>
+struct DevicePriority<Device::Type::kNvidia> {
   static constexpr int value = 5;
 };
 
-template <> struct DevicePriority<Device::Type::kMetax> {
+template <>
+struct DevicePriority<Device::Type::kMetax> {
   static constexpr int value = 5;
 };
 
-} // namespace infini::ccl
+template <>
+struct DevicePriority<Device::Type::kCambricon> {
+  static constexpr int value = 5;
+};
 
-#endif // INFINI_CCL_DEVICE_H_
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICE_H_


### PR DESCRIPTION
## Summary
This PR add the support for the Cambricon platform, including runtime integration, device abstraction, data type specialization, and build-system support. It also improves launcher robustness and portability by tightening subprocess error handling and fixing compiler compatibility issues in the example programs.

## Changes
- **Cambricon Platform Support**
  - add Cambricon runtime support in `src/cambricon/runtime_.h`;
  - add Cambricon device abstraction support in:
    - `src/device.h` for device priority;
    - `src/cambricon/device_.h` for enabling the device trait;
  - add Cambricon data type specializations in `src/cambricon/data_type_.h`;
  - extend build and compilation support for Cambricon in:
    - `CMakeLists.txt`;
    - `src/CMakeLists.txt`;
    - `examples/CMakeLists.txt`;
    - `scripts/icclrun_logic.py`;
   - update `scripts/run_wrapper.sh` to support Cambricon execution flows.


- **Example Program Compatibility Fixes**
  - add runtime library linking support for example programs, specifically for Cambricon and MetaX platforms;
  - add explicit `(void **)` casts for `Rt::Malloc()` buffer pointers in all current example programs under `examples/`;
  - prevent compilation warnings or errors on stricter compilers caused by invalid conversions from typed double pointers to `void **`.
 
- **Launcher Robustness Improvements**
  - add `check=True` to `subprocess.run()` in `launch()` in `scripts/icclrun_logic.py` to ensure `icclrun` immediately raises an exception when the underlying command exits with a non-zero status instead of silently continuing after failures.

 - **Documentation Updates**
   - updated `README.md` to document `WITH_CAMBRICON` option and Cambricon supportiveness;

## Known Issues & Future Work
- Currently, the example programs have only been validated on a single Cambricon node. Additional example coverage and validation for heterogeneous accelerator deployments (e.g. NVIDIA + Cambricon + MetaX) should be added in future work;
- When running examples with MPICH, output ordering may differ from OpenMPI due to differences in `stdout` buffering and launcher behavior. This does not affect program correctness. Optional synchronization (e.g., barrier) can be used to produce more deterministic example output for debugging and demonstration purposes.
 
## Logs & Screenshots
 - Cambricon OMPI
[all_gather.log](https://github.com/user-attachments/files/28150623/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28150624/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28150625/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28150626/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28150627/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28150628/send_recv.log)

 - Cambricon MPICH
[all_gather.log](https://github.com/user-attachments/files/28150635/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28150636/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28150637/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28150638/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28150639/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28150640/send_recv.log)