### PR TITLE
doc: add the first troubleshooting entry in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,4 +200,13 @@ using T = TypeMapType<Device::Type::kCpu, ListGet<0>(list_tag)>;
 ```
 
 ## Troubleshooting
-
+### 1. `icclrun` fails on the first node with a `VAR:type=value` CMake error
+```bash
+[*] Orchestrating nvidia on localhost...
+CMake Error: Parse error in command line argument: ...
+ Should be: VAR:type=value
+CMake Error: Run 'cmake --help' for all supported options.
+Traceback (most recent call last):
+...
+```
+If you encounter this error, make sure you are using the correct `cluster.yaml` and that all required fields are filled in using the proper format.


### PR DESCRIPTION
## Summary
This PR adds an initial troubleshooting entry to `CONTRIBUTING.md` to help users diagnose a common `icclrun` failure related to CMake argument parsing. It improves onboarding and reduces friction by documenting a known misconfiguration scenario and its resolution.

## Changes
- **Documentation Updates**
  - add the first troubleshooting section in `CONTRIBUTING.md`;
  - document the `VAR:type=value` CMake parse error observed when icclrun fails on the first node and give the resolution method. 

## Known Issues & Future Work
- This is the first troubleshooting entry. Additional common errors and debugging guidance should be documented over time as they are identified.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster
[all_gather.log](https://github.com/user-attachments/files/28219962/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28219963/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28219964/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28219965/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28219967/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28219968/send_recv.log)