### PR TITLE
ci: add `clang-format` and `ruff` GitHub workflows

### DIFF
--- a/.github/workflow/clang-format.yml
+++ b/.github/workflow/clang-format.yml
@@ -1,0 +1,48 @@
+name: clang-format
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format 16
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-16
+
+      - name: Verify clang-format version
+        run: clang-format-16 --version
+
+      - name: Check formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t FILES < <(
+            git ls-files \
+              '*.h' \
+              '*.hpp' \
+              '*.cc' \
+              '*.cpp' \
+              '*.cuh' \
+              '*.cu' \
+              '*.maca' \
+              '*.mlu'
+          )
+
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No C++ source files found."
+            exit 0
+          fi
+
+          clang-format-16 --dry-run --Werror "${FILES[@]}"
+          

--- a/.github/workflow/ruff.yml
+++ b/.github/workflow/ruff.yml
@@ -1,0 +1,30 @@
+name: ruff
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run ruff check
+        run: ruff check .
+
+      - name: Run ruff format check
+        run: ruff format --check .
+        


### PR DESCRIPTION
## Summary
This PR introduces basic CI workflows using GitHub Actions to enforce code quality and formatting standards. It adds automated checks for C++ formatting via `clang-format` and Python linting via `ruff`, ensuring consistency across contributions.

## Changes
- **CI Workflows**
  - add `.github/workflow/clang-format.yml` to automatically check C++ code formatting using `clang-format`;
  - add `.github/workflow/ruff.yml` to run Python linting and style checks using `ruff`.

- **Code Quality Enforcement**
  - ensure all pull requests and pushes to the master branch are validated against formatting and linting rules.

## Known Issues & Future Work
- Current workflows only perform checks and do not automatically fix formatting issues;
- CI coverage is limited to formatting and linting. Contributors are still expected to build and test locally and include relevant logs in the PR description. Additional workflows may be added later to improve robustness.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster
[all_gather.log](https://github.com/user-attachments/files/28255312/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28255321/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28255324/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28255326/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28255327/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28255330/send_recv.log)