### PR TITLE
fix: correct styling issues indicated by `clang-format` and `ruff` and refactor `scripts/icclrun.py`

### DIFF
--- a/scripts/backends/ompi.py
+++ b/scripts/backends/ompi.py
@@ -1,4 +1,5 @@
 import os
+
 from backends.mpi_base import BaseMpiBackend
 
 

--- a/scripts/icclrun.py
+++ b/scripts/icclrun.py
@@ -1,41 +1,46 @@
 #!/usr/bin/env python3
 import argparse
-import sys
 import os
+import sys
 
-SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(SCRIPT_DIR)
 
-# `CMAKE_INSTALL_PREFIX`
-PREFIX_DIR = os.path.dirname(SCRIPT_DIR)
-lib_found = False
+def configure_system_paths():
+    """Dynamically resolves and injects necessary framework search paths."""
+    SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+    sys.path.append(SCRIPT_DIR)
 
-for lib_dir_name in ["lib64", "lib"]:
-    candidate_path = os.path.join(PREFIX_DIR, lib_dir_name, "infiniccl")
-    if os.path.exists(candidate_path):
-        sys.path.append(candidate_path)
-        lib_found = True
-        break
+    # `CMAKE_INSTALL_PREFIX`
+    PREFIX_DIR = os.path.dirname(SCRIPT_DIR)
+    lib_found = False
 
-# Fallback
-if not lib_found:
-    if os.path.exists(os.path.join(PREFIX_DIR, "icclrun_logic.py")):
-        sys.path.append(PREFIX_DIR)
-    else:
-        print(
-            f"[Error]: Could not locate 'icclrun_logic.py' in system library paths or local workspace.",
-            file=sys.stderr,
-        )
-        print(
-            f"Looked under: {os.path.join(PREFIX_DIR, 'lib64/infiniccl')}, {os.path.join(PREFIX_DIR, 'lib/infiniccl')}, and {PREFIX_DIR}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+    for lib_dir_name in ["lib64", "lib"]:
+        candidate_path = os.path.join(PREFIX_DIR, lib_dir_name, "infiniccl")
+        if os.path.exists(candidate_path):
+            sys.path.append(candidate_path)
+            lib_found = True
+            break
 
-from icclrun_logic import ICCLLauncher
+    # Fallback
+    if not lib_found:
+        if os.path.exists(os.path.join(PREFIX_DIR, "icclrun_logic.py")):
+            sys.path.append(PREFIX_DIR)
+        else:
+            print(
+                "[Error]: Could not locate 'icclrun_logic.py' in system library paths or local workspace.",
+                file=sys.stderr,
+            )
+            print(
+                f"Looked under: {os.path.join(PREFIX_DIR, 'lib64/infiniccl')}, {os.path.join(PREFIX_DIR, 'lib/infiniccl')}, and {PREFIX_DIR}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 def main():
+    configure_system_paths()
+
+    from icclrun_logic import ICCLLauncher
+
     parser = argparse.ArgumentParser(description="InfiniCCL Unified Launcher")
     parser.add_argument("--config", "-c", dest="cluster", help="Path to cluster.yaml")
     parser.add_argument("--build", action="store_true", help="Compile remote nodes")

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -39,7 +39,7 @@ class ICCLLauncher:
             local_ips = socket.gethostbyname_ex(socket.gethostname())[2]
             local_ips += ["127.0.0.1", "localhost"]
             return ip in local_ips
-        except:
+        except Exception:
             return False
 
     def orchestrate_build(self):

--- a/scripts/run_examples.py
+++ b/scripts/run_examples.py
@@ -80,7 +80,8 @@ def run_iccl_example(
                 process.wait(timeout=timeout_duration)
                 return_code = process.returncode
                 print(
-                    f"--- [VERBOSE OUTPUT END: `{example_name}`] ---\n" + " " * 56, end=""
+                    f"--- [VERBOSE OUTPUT END: `{example_name}`] ---\n" + " " * 56,
+                    end="",
                 )
             else:
                 # Quiet mode: Redirect straight to the file handle.
@@ -104,7 +105,9 @@ def run_iccl_example(
     except subprocess.TimeoutExpired:
         print(f" ❌ TIMEOUT (Exceeded {timeout_duration} seconds)")
         with open(log_file_path, "a") as f:
-            f.write(f"\n[RUNNER ERROR]: Distributed `icclrun` harness timed out after {timeout_duration} seconds.\n")
+            f.write(
+                f"\n[RUNNER ERROR]: Distributed `icclrun` harness timed out after {timeout_duration} seconds.\n"
+            )
         return False
     except FileNotFoundError:
         print(" ❌ ERROR   (`icclrun` executable not found in `PATH`)")

--- a/src/nvidia/nccl/comm_instance.h
+++ b/src/nvidia/nccl/comm_instance.h
@@ -12,6 +12,6 @@ struct NcclInstance : public BackendCommInstance {
   NcclInstance() { type = BackendType::kNccl; }
 };
 
-} // namespace infini::ccl
+}  // namespace infini::ccl
 
 #endif


### PR DESCRIPTION
## Summary
This PR addresses code formatting and style compliance across the codebase as flagged by `clang-format` and `ruff`. Crucially, to satisfy `ruff`'s module-level import placement rules without breaking runtime dependency resolution, `scripts/icclrun.py` has been refactored to cleanly separate bootstrapping operations from global execution scopes.

## Changes
- **`scripts/icclrun.py` Refactor**
  - extract the dynamic `sys.path` environment scanning and library locating logic into a dedicated lifecycle function `configure_system_paths()`;
  - localize the `from icclrun_logic import ICCLLauncher` statement inside the `main()` entry point, successfully satisfying PEP 8 / Ruff import ordering constraints (`E402`) while preserving the application's runtime path initialization sequence.

- **Style Fix**
  - rectify all formatting, whitespace, and linting non-compliances across the changed workspace files using `clang-format` for C++ components and `ruff` for Python files.

## Known Issues & Future Work
- While localizing dependencies inside functions clears module-level validation constraints, widespread use of dynamic path injection can occasionally confuse static type checkers or IDE auto-completion engines. Future work may explore packaging the internal `icclrun_logic` module standardly or utilizing entry-point hooks to decouple runtime paths completely from raw script execution paths.
 
## Logs & Screenshots
Tested on a NVIDIA + MetaX heterogeneous cluster
[all_gather.log](https://github.com/user-attachments/files/28261024/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28261027/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28261032/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28261034/broadcast.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28261035/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28261037/send_recv.log)