### PR TITLE
feat: support `Reduce` with OpenMPI backend implementation

### DIFF
--- a/examples/reduce.cc
+++ b/examples/reduce.cc
@@ -1,0 +1,152 @@
+/**
+ * InfiniCCL Example: Reduce
+ *
+ * This example demonstrates the API for performing a collective
+ * reduction across multiple accelerators and nodes, where only
+ * `root` receives the reduced result.
+ */
+
+#include <unistd.h>
+
+#include <iostream>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
+
+void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
+                      const size_t kNumElements) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_INFINI(infiniInit(&argc, &argv));
+
+  int rank, size;
+  CHECK_INFINI(infiniGetRank(&rank));
+  CHECK_INFINI(infiniGetSize(&size));
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  // Map local rank to GPU device.
+  // Note: this is just for info printing. In practice, this part is not needed.
+  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_str != nullptr) {
+    local_rank = std::atoi(local_rank_str);
+  }
+
+  std::cout << "[Rank " << rank << "] Host: " << hostname
+            << " | GPU: " << Device::StringFromType(kDevType) << " "
+            << " | Device " << local_rank << std::endl;
+
+  // Setup Communicator
+  infiniComm_t comm = nullptr;
+  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+
+  // Root of the Reduce
+  constexpr int kRoot = 0;
+
+  // Prepare Data
+  std::vector<float> h_send(kNumElements);
+  std::vector<float> h_recv(kNumElements, 0.0f);
+
+  // Initialize: each rank provides its (rank + 1) as data.
+  for (size_t i = 0; i < kNumElements; i++) {
+    h_send[i] = static_cast<float>(rank + 1);
+  }
+
+  float *d_send, *d_recv;
+  size_t total_bytes = kNumElements * sizeof(*d_send);
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  if (rank == kRoot) {
+    std::cout << "\n=== Performing Reduce on GPU Memory ===" << std::endl;
+    std::cout << "Data size: " << kNumElements << " floats ("
+              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
+    std::cout << "Operation: Sum" << std::endl;
+    std::cout << "Root Rank: " << kRoot << std::endl;
+    std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
+    std::cout << "Profile iterations: " << profile_iter << std::endl;
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Warm-up and D2H transfer the answer on `root`.
+  CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                            infiniSum, kRoot, comm, nullptr));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+  }
+
+  for (int i = 1; i < warmup_iter; ++i) {
+    CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                              infiniSum, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Profiling
+  Timer timer;
+
+  for (int i = 0; i < profile_iter; ++i) {
+    CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
+                              infiniSum, kRoot, comm, nullptr));
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+
+  // Result Validation (only meaningful on `root`).
+  if (rank == kRoot) {
+    float expected = 0.0f;
+    for (int r = 0; r < size; ++r) {
+      expected += static_cast<float>(r + 1);
+    }
+
+    Validator::ValidateResult(h_recv.data(), kNumElements, expected, rank, true,
+                              "Reduce");
+
+    Metrics metrics{elapsed, total_bytes, size};
+    metrics.Print();
+  }
+
+  // Cleanup
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+
+  CHECK_INFINI(infiniCommDestroy(comm));
+  CHECK_INFINI(infiniFinalize());
+
+  if (rank == kRoot) {
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  RunReduceExample(argc, argv, warmup_iters, profile_iters, num_elements);
+
+  return EXIT_SUCCESS;
+}

--- a/include/comm.h
+++ b/include/comm.h
@@ -48,6 +48,10 @@ infiniResult_t infiniBroadcast(const void *sendbuff, void *recvbuff,
 infiniResult_t infiniBcast(void *buff, size_t count, infiniDataType_t datatype,
                            int root, infiniComm_t comm, void *stream);
 
+infiniResult_t infiniReduce(const void *sendbuff, void *recvbuff, size_t count,
+                            infiniDataType_t datatype, infiniRedOp_t op,
+                            int root, infiniComm_t comm, void *stream);
+
 infiniResult_t infiniAllGather(const void *sendbuff, void *recvbuff,
                                size_t count, infiniDataType_t datatype,
                                infiniComm_t comm, void *stream);

--- a/src/base/reduce.h
+++ b/src/base/reduce.h
@@ -1,0 +1,70 @@
+#ifndef INFINI_CCL_BASE_REDUCE_H_
+#define INFINI_CCL_BASE_REDUCE_H_
+
+#include "comm_impl.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct ReduceImpl;
+
+class Reduce : public Operation<Reduce> {
+ public:
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(const void *send_buff, void *recv_buff,
+                              size_t count, DataType datatype,
+                              ReductionOpType op, int root, void *comm_handle,
+                              void *stream) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for `Reduce`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (HasInvalidArgs(send_buff, recv_buff, datatype, op, root, comm)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
+    return ReduceImpl<backend_type, device_type>::Apply(
+        send_buff, recv_buff, count, datatype, op, root, comm, stream);
+  }
+
+ private:
+  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
+                             DataType datatype, ReductionOpType op, int root,
+                             Communicator *comm) {
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for `Reduce`.");
+      return true;
+    }
+    if (op < ReductionOpType::kSum || op >= ReductionOpType::kNumRedOps) {
+      LOG("Invalid reduction operation for `Reduce`.");
+      return true;
+    }
+    if (root < 0 || root >= comm->size()) {
+      LOG("Invalid root rank for `Reduce`.");
+      return true;
+    }
+    if (!send_buff) {
+      LOG("Invalid send buffer pointer for `Reduce`.");
+      return true;
+    }
+    if (comm->rank() == root && !recv_buff) {
+      LOG("Invalid root receive buffer pointer for `Reduce`.");
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BASE_REDUCE_H_

--- a/src/ompi/impl/reduce.h
+++ b/src/ompi/impl/reduce.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <limits>
+#include <type_traits>
 
 #include "base/reduce.h"
 #include "communicator.h"
@@ -77,7 +78,14 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
           for (size_t i = 0; i < count; ++i) {
             // TODO(lzm): should later use the unified `Cast` function instead
             // of `static_cast` to support CPU custom types.
-            typed_buf[i] *= static_cast<T>(scale);
+            if constexpr (std::is_integral_v<T>) {
+              // Scale in floating point first; casting `scale` to an integer
+              // type would truncate it to `0` and zero out the result.
+              typed_buf[i] =
+                  static_cast<T>(static_cast<double>(typed_buf[i]) * scale);
+            } else {
+              typed_buf[i] *= static_cast<T>(scale);
+            }
           }
         });
       }

--- a/src/ompi/impl/reduce.h
+++ b/src/ompi/impl/reduce.h
@@ -1,0 +1,101 @@
+#ifndef INFINI_CCL_OMPI_IMPL_REDUCE_H_
+#define INFINI_CCL_OMPI_IMPL_REDUCE_H_
+
+#include <cstdlib>
+#include <limits>
+
+#include "base/reduce.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "dispatcher.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+#include "ompi/type_map.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class ReduceImpl<BackendType::kOmpi, device_type> {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            ReductionOpType op, int root, Communicator *comm,
+                            void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<Reduce>{});
+    using Rt = Runtime<kDev>;
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for `Reduce`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
+    MPI_Op mpi_op = RedOpToOmpiOp(op);
+
+    if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("`count` exceeds MPI int range for `Reduce`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    int mpi_count = static_cast<int>(count);
+
+    size_t type_size = kDataTypeToSize.at(data_type);
+    size_t total_bytes = count * type_size;
+    const bool is_root = comm->rank() == root;
+
+    // Host staging buffers. Only `root` allocates the receive side, since
+    // `MPI_Reduce` writes the output only on `root`.
+    void *host_sendbuf = std::malloc(total_bytes);
+    void *host_recvbuf = is_root ? std::malloc(total_bytes) : nullptr;
+    if (!host_sendbuf || (is_root && !host_recvbuf)) {
+      std::free(host_sendbuf);
+      std::free(host_recvbuf);
+      LOG("Failed to allocate host buffers for `Reduce` staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, total_bytes,
+                                Rt::MemcpyDeviceToHost));
+    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
+
+    INFINI_CHECK_MPI(MPI_Reduce(host_sendbuf, host_recvbuf, mpi_count, mpi_type,
+                                mpi_op, root, inst->handle));
+
+    if (is_root) {
+      if (op == ReductionOpType::kAvg) {
+        float scale = 1.0f / static_cast<float>(comm->size());
+
+        DispatchFunc<kDev, AllTypes>(data_type, [&](auto dtype) {
+          using T = typename decltype(dtype)::type;
+
+          T *typed_buf = static_cast<T *>(host_recvbuf);
+
+          // Simply do the averaging on the CPU before the H2D copy.
+          for (size_t i = 0; i < count; ++i) {
+            // TODO(lzm): should later use the unified `Cast` function instead
+            // of `static_cast` to support CPU custom types.
+            typed_buf[i] *= static_cast<T>(scale);
+          }
+        });
+      }
+
+      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, total_bytes,
+                                  Rt::MemcpyHostToDevice));
+    }
+
+    std::free(host_sendbuf);
+    std::free(host_recvbuf);
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<Reduce, BackendType::kOmpi> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_OMPI_IMPL_REDUCE_H_


### PR DESCRIPTION
## Summary

This PR adds collective `Reduce` support to InfiniCCL with an OpenMPI-based backend implementation, along with an example program for functional verification and basic performance evaluation.

`Reduce` combines the contributions of every rank with a reduction operator and materializes the result only on a single `root` rank. The public API is exposed through `infiniReduce()` with the signature `(sendbuff, recvbuff, count, datatype, op, root, comm, stream)`, matching the NCCL `ncclReduce` parameter order. The current implementation host-stages device buffers and delegates to a blocking `MPI_Reduce` internally.

## Changes

- **Public Reduce API**
  - add the public API declaration for `infiniReduce()` in `include/comm.h`;
  - the collective is exposed through the common communicator interface; the `extern "C"` entry is produced by the existing auto-generated bridge, so no manual wiring is needed.

- **Base Reduce Wrapper**
  - add `src/base/reduce.h`;
  - validate the communicator handle, datatype value, reduction operator, `root` rank range, and buffer pointers before dispatching to the backend implementation;
  - treat a zero `count` as a successful no-op;
  - return `infiniInvalidArgument` for invalid user inputs.

- **OpenMPI-based Reduce Implementation**
  - add `src/ompi/impl/reduce.h`;
  - implement the collective with a blocking `MPI_Reduce`, allocating the host receive buffer only on `root`, where the reduced result lands;
  - map `DataType`/`ReductionOpType` to the corresponding `MPI_Datatype`/`MPI_Op`;
  - emulate the average (`kAvg`) reduction (unsupported natively by OpenMPI) via `MPI_SUM` followed by a CPU-side per-dtype scaling on `root`;
  - use temporary host-staging buffers for device-memory transfer (device-to-host before, host-to-device on `root` after).

- **Reduce Example**
  - add `examples/reduce.cc`;
  - align the example structure and output style with the existing example programs such as `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, and `all_to_all`;
  - reduce each rank's `(rank + 1)` contribution with `Sum` and verify the result on `root`;
  - report basic timing and bandwidth metrics in the same style as the other examples.

## Platform and Backend Affected

### Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] MetaX GPU
- [ ] Cambricon MLU

### Backend

- [x] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

This PR adds a new collective and does not change the performance of existing operations.

## Known Issues & Future Work

- **Half-precision (`Float16` / `BFloat16`) reduction is not yet correct.** These types map to `MPI_BYTE` in `DataTypeToOmpiType()`, so `MPI_Reduce` combines raw bytes rather than half-precision values. This is a pre-existing, codebase-wide limitation shared with the merged `all_reduce` and `reduce_scatter`; a correct implementation awaits the planned unified host-side `Cast` utility and is best addressed for all reduction operators together.
- The current OpenMPI `Reduce` implementation is blocking and does not overlap communication with computation. Future work may introduce stream-aware asynchronous execution.
- The current implementation allocates temporary host-staging buffers using `malloc/free` on every invocation. Future work may add reusable buffer pools, allocator caching, and pinned host memory to reduce per-call overhead.
- The `kAvg` scaling runs as a CPU-side per-element loop on `root`. Future work may move it onto the device.
- The current implementation rejects a `count` larger than `INT_MAX` instead of splitting it into `INT_MAX`-bounded chunks. Future work may add chunking for very large transfers.
- The current implementation performs GPU-to-Host and Host-to-GPU copies. While functionally correct for the supported types, this is not optimal for GPU-intensive workloads. Future work may implement zero-copy GPU-GPU transfers or native GPU collectives (e.g. NCCL / CNCL) where supported.

## Test Results

Validated on a MetaX–NVIDIA heterogeneous cluster over the OpenMPI backend via `scripts/run_examples.py`:

- `server`: NVIDIA, 8 GPUs, ranks 0–7 (built with Devices `[cpu, nvidia]`, Backends `[ompi]`).
- `test`: MetaX, 8 GPUs, ranks 8–15 (built with Devices `[cpu, metax]`, Backends `[ompi]`).
- 16 ranks total; message size 1,048,576 `float32` (4 MB) per rank; 2 warm-up + 20 profiled iterations.
- The `reduce` example exercises the `Float32` + `Sum` path.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] MetaX GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

[all_gather.log](https://github.com/user-attachments/files/28504522/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28504523/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28504525/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28504528/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28504529/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28504532/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28504533/send_recv.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- The only `std::cout` is the example program's intended result/metrics output, matching every existing example. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- `infiniReduce()` is exercised by `examples/reduce.cc`. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- No exceptions are thrown. Recoverable user-input errors return `ReturnStatus` codes via the `LOG(...)` macro (which records file and line), matching the established `all_gather`/`reduce_scatter` convention. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The `reduce` example (`Float32` + `Sum`) passes; half-precision reduction remains a known limitation (see "Known Issues & Future Work"). -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
