### PR TITLE
feat: support `Gather` with OpenMPI backend implementation

### DIFF
--- a/examples/gather.cc
+++ b/examples/gather.cc
@@ -1,0 +1,170 @@
+/**
+ * InfiniCCL Example: Gather
+ * * This example demonstrates the API for performing a collective
+ * data gathering across multiple GPUs and nodes, where only `root`
+ * receives the gathered result.
+ */
+
+#include <unistd.h>
+
+#include <iostream>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
+
+void RunGatherExample(int argc, char **argv, int warmup_iter, int profile_iter,
+                      const size_t kNumElements) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_INFINI(infinicclInit(&argc, &argv));
+
+  int rank, size;
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  // Map local rank to GPU device.
+  // Note: this is just for info printing. In practice, this part is not needed.
+  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_str != nullptr) {
+    local_rank = std::atoi(local_rank_str);
+  }
+
+  std::cout << "[Rank " << rank << "] Host: " << hostname
+            << " | GPU: " << Device::StringFromType(kDevType) << " "
+            << " | Device " << local_rank << std::endl;
+
+  // Setup Communicator
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
+
+  // Root of the Gather
+  constexpr int kRoot = 0;
+
+  // Prepare Data
+  std::vector<float> h_send(kNumElements);
+  std::vector<float> h_recv(kNumElements * size, 0.0f);
+
+  // Initialize: each rank provides its (rank + 1) as data.
+  for (size_t i = 0; i < kNumElements; i++) {
+    h_send[i] = static_cast<float>(rank + 1);
+  }
+
+  float *d_send, *d_recv;
+  size_t send_bytes = kNumElements * sizeof(*d_send);
+  size_t recv_bytes = send_bytes * size;
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, send_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), recv_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  if (rank == kRoot) {
+    std::cout << "\n=== Performing Gather on GPU Memory ===" << std::endl;
+    std::cout << "Data size: " << kNumElements << " floats ("
+              << send_bytes / 1024 / 1024 << " MB)" << std::endl;
+    std::cout << "Operation: Gather" << std::endl;
+    std::cout << "Root Rank: " << kRoot << std::endl;
+    std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
+    std::cout << "Profile iterations: " << profile_iter << std::endl;
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Warm-up
+  CHECK_INFINI(infinicclGather(d_send, d_recv, kNumElements, infinicclFloat32,
+                               kRoot, comm, nullptr));
+
+  for (int i = 1; i < warmup_iter; ++i) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, kNumElements, infinicclFloat32,
+                                 kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Profiling
+  Timer timer;
+
+  for (int i = 0; i < profile_iter; i++) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, kNumElements, infinicclFloat32,
+                                 kRoot, comm, nullptr));
+  }
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+
+  // Result Validation (only meaningful on `root`).
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
+                            Rt::MemcpyDeviceToHost));
+
+    bool correct = true;
+
+    for (int src_rank = 0; src_rank < size; ++src_rank) {
+      float expected = static_cast<float>(src_rank + 1);
+      size_t offset = static_cast<size_t>(src_rank) * kNumElements;
+
+      correct &= Validator::ValidateResult(h_recv.data() + offset, kNumElements,
+                                           expected, rank);
+    }
+
+    const char *GREEN = "\033[32m";
+    const char *RED = "\033[31m";
+    const char *RESET = "\033[0m";
+
+    std::cout << "\n=== Gather Results ===" << std::endl;
+    std::cout << "Correct: "
+              << (correct ? (GREEN + std::string("YES") + RESET)
+                          : (RED + std::string("NO") + RESET))
+              << std::endl;
+
+    std::cout << "Sample blocks: ";
+    for (int src_rank = 0; src_rank < std::min(size, 4); ++src_rank) {
+      size_t offset = static_cast<size_t>(src_rank) * kNumElements;
+      std::cout << "[r" << src_rank << ": " << h_recv[offset] << "] ";
+    }
+    std::cout << std::endl;
+
+    Metrics metrics{elapsed, recv_bytes, size};
+    metrics.Print();
+  }
+
+  // Cleanup
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
+
+  if (rank == kRoot) {
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+}
+
+int main(int argc, char **argv) {
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  RunGatherExample(argc, argv, warmup_iters, profile_iters, num_elements);
+
+  return EXIT_SUCCESS;
+}

--- a/include/comm.h
+++ b/include/comm.h
@@ -59,6 +59,10 @@ infinicclResult_t infinicclAllGather(const void *sendbuff, void *recvbuff,
                                      size_t count, infinicclDataType_t datatype,
                                      infinicclComm_t comm, void *stream);
 
+infinicclResult_t infinicclGather(const void *sendbuff, void *recvbuff,
+                                  size_t count, infinicclDataType_t datatype,
+                                  int root, infinicclComm_t comm, void *stream);
+
 infinicclResult_t infinicclReduceScatter(const void *sendbuff, void *recvbuff,
                                          size_t recvcount,
                                          infinicclDataType_t datatype,

--- a/src/base/gather.h
+++ b/src/base/gather.h
@@ -1,0 +1,63 @@
+#ifndef INFINI_CCL_BASE_GATHER_H_
+#define INFINI_CCL_BASE_GATHER_H_
+
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+#include "operation.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend_type, Device::Type device_type>
+struct GatherImpl;
+
+class Gather : public Operation<Gather> {
+ public:
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(const void *send_buff, void *recv_buff,
+                              size_t count, DataType datatype, int root,
+                              void *comm_handle, void *stream) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (HasInvalidArgs(send_buff, recv_buff, datatype, root, comm)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
+    return GatherImpl<backend_type, device_type>::Apply(
+        send_buff, recv_buff, count, datatype, root, comm, stream);
+  }
+
+ private:
+  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
+                             DataType datatype, int root, Communicator *comm) {
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for `Gather`.");
+      return true;
+    }
+    if (root < 0 || root >= comm->size()) {
+      LOG("Invalid root rank for `Gather`.");
+      return true;
+    }
+    if (!send_buff) {
+      LOG("Invalid send buffer pointer for `Gather`.");
+      return true;
+    }
+    if (comm->rank() == root && !recv_buff) {
+      LOG("Invalid root receive buffer pointer for `Gather`.");
+      return true;
+    }
+    return false;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BASE_GATHER_H_

--- a/src/ompi/impl/gather.h
+++ b/src/ompi/impl/gather.h
@@ -1,0 +1,82 @@
+#ifndef INFINI_CCL_OMPI_IMPL_GATHER_H_
+#define INFINI_CCL_OMPI_IMPL_GATHER_H_
+
+#include <cstdlib>
+#include <limits>
+
+#include "base/gather.h"
+#include "communicator.h"
+#include "logging.h"
+#include "ompi/checks.h"
+#include "ompi/comm_instance.h"
+#include "ompi/type_map.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device_type>
+class GatherImpl<BackendType::kOmpi, device_type> {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type, int root,
+                            Communicator *comm, void *stream) {
+    constexpr Device::Type kDev =
+        ListGetBest<DevicePriority>(ActiveDevices<Gather>{});
+    using Rt = Runtime<kDev>;
+
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (!inst || inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator instance for `Gather`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
+
+    if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("`count` exceeds MPI int range for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    int mpi_count = static_cast<int>(count);
+
+    size_t type_size = kDataTypeToSize.at(data_type);
+    size_t send_bytes = count * type_size;
+    size_t recv_bytes = send_bytes * static_cast<size_t>(comm->size());
+    const bool is_root = comm->rank() == root;
+
+    // Host staging buffers. Only `root` allocates the receive side, since
+    // `MPI_Gather` writes the gathered result only on `root`.
+    void *host_sendbuf = std::malloc(send_bytes);
+    void *host_recvbuf = is_root ? std::malloc(recv_bytes) : nullptr;
+    if (!host_sendbuf || (is_root && !host_recvbuf)) {
+      std::free(host_sendbuf);
+      std::free(host_recvbuf);
+      LOG("Failed to allocate host buffers for `Gather` staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, send_bytes,
+                                Rt::MemcpyDeviceToHost));
+    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
+
+    // Note: `MPI_Gather`'s `recvcount` is the per-rank count, not the total.
+    INFINI_CHECK_MPI(MPI_Gather(host_sendbuf, mpi_count, mpi_type, host_recvbuf,
+                                mpi_count, mpi_type, root, inst->handle));
+
+    if (is_root) {
+      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,
+                                  Rt::MemcpyHostToDevice));
+    }
+
+    std::free(host_sendbuf);
+    std::free(host_recvbuf);
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<Gather, BackendType::kOmpi> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_OMPI_IMPL_GATHER_H_

--- a/src/ompi/impl/gather.h
+++ b/src/ompi/impl/gather.h
@@ -6,10 +6,10 @@
 
 #include "base/gather.h"
 #include "communicator.h"
+#include "data_type_impl.h"
 #include "logging.h"
 #include "ompi/checks.h"
 #include "ompi/comm_instance.h"
-#include "ompi/type_map.h"
 #include "runtime.h"
 
 namespace infini::ccl {
@@ -30,18 +30,22 @@ class GatherImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kInternalError;
     }
 
-    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
-
-    if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
-      LOG("`count` exceeds MPI int range for `Gather`.");
+    size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Byte size overflow for `Gather`.");
       return ReturnStatus::kInvalidArgument;
     }
-    int mpi_count = static_cast<int>(count);
-
-    size_t type_size = kDataTypeToSize.at(data_type);
     size_t send_bytes = count * type_size;
     size_t recv_bytes = send_bytes * static_cast<size_t>(comm->size());
     const bool is_root = comm->rank() == root;
+
+    // Transfer raw bytes so the gather is correct for every data type,
+    // including `kFloat16` / `kBFloat16`, which map to `MPI_BYTE`.
+    if (send_bytes > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("Per-rank byte count exceeds MPI int range for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    int mpi_byte_count = static_cast<int>(send_bytes);
 
     // Host staging buffers. Only `root` allocates the receive side, since
     // `MPI_Gather` writes the gathered result only on `root`.
@@ -59,8 +63,9 @@ class GatherImpl<BackendType::kOmpi, device_type> {
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
     // Note: `MPI_Gather`'s `recvcount` is the per-rank count, not the total.
-    INFINI_CHECK_MPI(MPI_Gather(host_sendbuf, mpi_count, mpi_type, host_recvbuf,
-                                mpi_count, mpi_type, root, inst->handle));
+    INFINI_CHECK_MPI(MPI_Gather(host_sendbuf, mpi_byte_count, MPI_BYTE,
+                                host_recvbuf, mpi_byte_count, MPI_BYTE, root,
+                                inst->handle));
 
     if (is_root) {
       CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,


### PR DESCRIPTION
## Summary

This PR adds collective `Gather` support to InfiniCCL with an OpenMPI-based backend implementation, along with an example program for functional verification and basic performance evaluation.

`Gather` collects one equally-sized block from every rank onto a single `root` rank. The public API is exposed through `infinicclGather()` with the signature `(sendbuff, recvbuff, count, datatype, root, comm, stream)`, consistent with the existing rooted collectives. The current implementation host-stages device buffers and delegates to a blocking `MPI_Gather` internally.

## Changes

- **Public Gather API**
  - add the public API declaration for `infinicclGather()` in `include/comm.h`;
  - the collective is exposed through the common communicator interface; the `extern "C"` entry is produced by the existing auto-generated bridge, so no manual wiring is needed.

- **Base Gather Wrapper**
  - add `src/base/gather.h`;
  - validate the communicator handle, datatype value, `root` rank range, and buffer pointers (the receive buffer is only required on `root`) before dispatching to the backend implementation;
  - treat a zero `count` as a successful no-op;
  - return `infinicclInvalidArgument` for invalid user inputs.

- **OpenMPI-based Gather Implementation**
  - add `src/ompi/impl/gather.h`;
  - implement the collective with a blocking `MPI_Gather`, allocating the host receive buffer only on `root`, where the gathered result lands;
  - use temporary host-staging buffers for device-memory transfer (device-to-host before, host-to-device on `root` after);
  - map `DataType` to the corresponding `MPI_Datatype`, and reject a `count` exceeding `INT_MAX`.

- **Gather Example**
  - add `examples/gather.cc`;
  - align the example structure and output style with the existing example programs such as `all_reduce`, `all_gather`, `reduce_scatter`, `broadcast`, and `all_to_all`;
  - each rank contributes `(rank + 1)`, and the example verifies that `root` receives the `[1, 2, …, size]` blocks in rank order;
  - report basic timing and bandwidth metrics in the same style as the other examples.

## Platform and Backend Affected

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

This PR adds a new collective and does not change the performance of existing operations. For reference, the heterogeneous run (16 ranks, 4 MB per rank) measured `Gather` at 42.343 ms, 2.77 GB/s bus bandwidth, 1.48 GB/s algorithm bandwidth.

## Known Issues & Future Work

- The current OpenMPI `Gather` implementation is blocking and does not overlap communication with computation. Future work may introduce stream-aware asynchronous execution.
- The current implementation allocates temporary host-staging buffers using `malloc/free` on every invocation. Future work may add reusable buffer pools, allocator caching, and pinned host memory to reduce per-call overhead.
- The current implementation rejects a `count` larger than `INT_MAX` instead of splitting it into `INT_MAX`-bounded chunks (as the point-to-point path does). Future work may add chunking for very large transfers.
- The current implementation performs GPU-to-Host and Host-to-GPU copies. While functionally correct, this is not optimal for GPU-intensive workloads. Future work may implement zero-copy GPU-GPU transfers or native GPU collectives (e.g. NCCL / CNCL) where supported.
- The current example intentionally follows the lightweight style of the existing example programs. Future dedicated tests may add broader coverage such as a non-zero `root`, zero-count calls, mismatched-buffer validation, and large-count stress cases.

## Test Results

Validated on a MetaX–NVIDIA heterogeneous cluster over the OpenMPI backend via `scripts/run_examples.py`:

- `server`: NVIDIA, 8 GPUs, ranks 0–7 (built with Devices `[cpu, nvidia]`, Backends `[ompi]`).
- `test`: MetaX, 8 GPUs, ranks 8–15 (built with Devices `[cpu, metax]`, Backends `[ompi]`).
- 16 ranks total; message size 1,048,576 `float32` (4 MB) per rank; 2 warm-up + 20 profiled iterations.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

[all_gather.log](https://github.com/user-attachments/files/28589820/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28589822/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28589825/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28589829/broadcast.log)
[gather.log](https://github.com/user-attachments/files/28589832/gather.log)
[reduce.log](https://github.com/user-attachments/files/28589835/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28589837/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28589839/send_recv.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- The only `std::cout` is the example program's intended result/metrics output, matching every existing example. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- No exceptions are thrown. Recoverable user-input errors return `ReturnStatus` codes via the `LOG(...)` macro (which records file and line), matching the established `all_gather`/`reduce_scatter` convention. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
