### PR TITLE
refactor!: rename public API prefix from `infini` to `infiniccl`

### DIFF
--- a/examples/all_gather.cc
+++ b/examples/all_gather.cc
@@ -30,11 +30,11 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -52,8 +52,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup Communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // Prepare Data
   std::vector<float> h_send(kNumElements);
@@ -86,14 +86,14 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer.
-  CHECK_INFINI(infiniAllGather(d_send, d_recv, kNumElements, infiniFloat32,
-                               comm, nullptr));
+  CHECK_INFINI(infinicclAllGather(d_send, d_recv, kNumElements,
+                                  infinicclFloat32, comm, nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
                           Rt::MemcpyDeviceToHost));
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infiniAllGather(d_send, d_recv, kNumElements, infiniFloat32,
-                                 comm, nullptr));
+    CHECK_INFINI(infinicclAllGather(d_send, d_recv, kNumElements,
+                                    infinicclFloat32, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
@@ -101,8 +101,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; i++) {
-    CHECK_INFINI(infiniAllGather(d_send, d_recv, kNumElements, infiniFloat32,
-                                 comm, nullptr));
+    CHECK_INFINI(infinicclAllGather(d_send, d_recv, kNumElements,
+                                    infinicclFloat32, comm, nullptr));
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
@@ -153,8 +153,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/all_reduce.cc
+++ b/examples/all_reduce.cc
@@ -30,11 +30,11 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -52,8 +52,8 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup Communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // Prepare Data
   std::vector<float> h_send(kNumElements);
@@ -85,14 +85,16 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer.
-  CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                               infiniSum, comm, nullptr));
+  CHECK_INFINI(infinicclAllReduce(d_send, d_recv, kNumElements,
+                                  infinicclFloat32, infinicclSum, comm,
+                                  nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, kNumElements * sizeof(float),
                           Rt::MemcpyDeviceToHost));
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                                 infiniSum, comm, nullptr));
+    CHECK_INFINI(infinicclAllReduce(d_send, d_recv, kNumElements,
+                                    infinicclFloat32, infinicclSum, comm,
+                                    nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
@@ -100,8 +102,9 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; i++) {
-    CHECK_INFINI(infiniAllReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                                 infiniSum, comm, nullptr));
+    CHECK_INFINI(infinicclAllReduce(d_send, d_recv, kNumElements,
+                                    infinicclFloat32, infinicclSum, comm,
+                                    nullptr));
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
@@ -126,8 +129,8 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/all_to_all.cc
+++ b/examples/all_to_all.cc
@@ -32,11 +32,11 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -54,8 +54,8 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // Prepare Data
   // For AllToAll, `total_elements_per_rank = count_per_peer * world_size`.
@@ -98,14 +98,14 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer.
-  CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
-                              comm, nullptr));
+  CHECK_INFINI(infinicclAllToAll(d_send, d_recv, kCountPerPeer,
+                                 infinicclFloat32, comm, nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
                           Rt::MemcpyDeviceToHost));
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
-                                comm, nullptr));
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, kCountPerPeer,
+                                   infinicclFloat32, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
@@ -113,8 +113,8 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; ++i) {
-    CHECK_INFINI(infiniAllToAll(d_send, d_recv, kCountPerPeer, infiniFloat32,
-                                comm, nullptr));
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, kCountPerPeer,
+                                   infinicclFloat32, comm, nullptr));
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
@@ -169,8 +169,8 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/broadcast.cc
+++ b/examples/broadcast.cc
@@ -32,11 +32,11 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -52,8 +52,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup Communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // Root of the Broadcast
   constexpr int kRoot = 0;
@@ -131,8 +131,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
   // --------------------------------------------------------------------------
   ProfileAndValidateScenario(
       "Scenario 1: Out-of-Place Broadcast", d_recv, [&]() {
-        return infiniBroadcast(d_send, d_recv, kNumElements, infiniFloat32,
-                               kRoot, comm, nullptr);
+        return infinicclBroadcast(d_send, d_recv, kNumElements,
+                                  infinicclFloat32, kRoot, comm, nullptr);
       });
 
   // --------------------------------------------------------------------------
@@ -143,8 +143,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
 
   ProfileAndValidateScenario(
       "Scenario 2: In-Place Broadcast", d_inplace_buf, [&]() {
-        return infiniBroadcast(d_inplace_buf, d_inplace_buf, kNumElements,
-                               infiniFloat32, kRoot, comm, nullptr);
+        return infinicclBroadcast(d_inplace_buf, d_inplace_buf, kNumElements,
+                                  infinicclFloat32, kRoot, comm, nullptr);
       });
 
   // --------------------------------------------------------------------------
@@ -154,8 +154,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
 
   ProfileAndValidateScenario(
       "Scenario 3: Legacy In-Place Bcast", d_inplace_buf, [&]() {
-        return infiniBcast(d_inplace_buf, kNumElements, infiniFloat32, kRoot,
-                           comm, nullptr);
+        return infinicclBcast(d_inplace_buf, kNumElements, infinicclFloat32,
+                              kRoot, comm, nullptr);
       });
 
   // --------------------------------------------------------------------------
@@ -164,8 +164,8 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == kRoot) {
     std::cout << "\nInfiniCCL finalized." << std::endl;

--- a/examples/reduce.cc
+++ b/examples/reduce.cc
@@ -32,11 +32,11 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -54,8 +54,8 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup Communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // Root of the Reduce
   constexpr int kRoot = 0;
@@ -91,16 +91,16 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer on `root`.
-  CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                            infiniSum, kRoot, comm, nullptr));
+  CHECK_INFINI(infinicclReduce(d_send, d_recv, kNumElements, infinicclFloat32,
+                               infinicclSum, kRoot, comm, nullptr));
   if (rank == kRoot) {
     CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
                             Rt::MemcpyDeviceToHost));
   }
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                              infiniSum, kRoot, comm, nullptr));
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, kNumElements, infinicclFloat32,
+                                 infinicclSum, kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
@@ -108,8 +108,8 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; ++i) {
-    CHECK_INFINI(infiniReduce(d_send, d_recv, kNumElements, infiniFloat32,
-                              infiniSum, kRoot, comm, nullptr));
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, kNumElements, infinicclFloat32,
+                                 infinicclSum, kRoot, comm, nullptr));
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
@@ -133,8 +133,8 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == kRoot) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/reduce_scatter.cc
+++ b/examples/reduce_scatter.cc
@@ -30,11 +30,11 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank, size;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -52,8 +52,8 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
             << " | Device " << local_rank << std::endl;
 
   // Setup Communicator
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   // ReduceScatter requires `send_count = recv_count * world_size`.
   const size_t kSendCount = kRecvCount * static_cast<size_t>(size);
@@ -93,14 +93,16 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer.
-  CHECK_INFINI(infiniReduceScatter(d_send, d_recv, kRecvCount, infiniFloat32,
-                                   infiniSum, comm, nullptr));
+  CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+                                      infinicclFloat32, infinicclSum, comm,
+                                      nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
                           Rt::MemcpyDeviceToHost));
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infiniReduceScatter(d_send, d_recv, kRecvCount, infiniFloat32,
-                                     infiniSum, comm, nullptr));
+    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+                                        infinicclFloat32, infinicclSum, comm,
+                                        nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
@@ -108,8 +110,9 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; ++i) {
-    CHECK_INFINI(infiniReduceScatter(d_send, d_recv, kRecvCount, infiniFloat32,
-                                     infiniSum, comm, nullptr));
+    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+                                        infinicclFloat32, infinicclSum, comm,
+                                        nullptr));
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
@@ -137,8 +140,8 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/send_recv.cc
+++ b/examples/send_recv.cc
@@ -1,7 +1,7 @@
 /**
  * InfiniCCL Example: `Send-Recv`
  *
- * This example demonstrates point-to-point `infiniSend` and `infiniRecv`
+ * This example demonstrates point-to-point `infinicclSend` and `infinicclRecv`
  * operations between rank 0 and rank 1 on accelerator memory.
  */
 
@@ -27,12 +27,12 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
       ccl::ListGetBest<ccl::DevicePriority>(ccl::EnabledDevices{});
   using Rt = ccl::Runtime<kDevType>;
 
-  CHECK_INFINI(infiniInit(&argc, &argv));
+  CHECK_INFINI(infinicclInit(&argc, &argv));
 
   int rank = 0;
   int size = 0;
-  CHECK_INFINI(infiniGetRank(&rank));
-  CHECK_INFINI(infiniGetSize(&size));
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
 
   char hostname[256];
   gethostname(hostname, sizeof(hostname));
@@ -57,12 +57,12 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
       std::cerr << "Send/Recv example requires at least 2 ranks." << std::endl;
     }
 
-    CHECK_INFINI(infiniFinalize());
+    CHECK_INFINI(infinicclFinalize());
     return;
   }
 
-  infiniComm_t comm = nullptr;
-  CHECK_INFINI(infiniCommInitAll(&comm, size, nullptr));
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   std::vector<float> h_send(num_elements, kSendValue);
   std::vector<float> h_recv(num_elements, 0.0f);
@@ -92,16 +92,16 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
 
   auto send_recv_call = [&]() {
     if (rank == kSender) {
-      return infiniSend(d_send, num_elements, infiniFloat32, kReceiver, comm,
-                        nullptr);
+      return infinicclSend(d_send, num_elements, infinicclFloat32, kReceiver,
+                           comm, nullptr);
     }
 
     if (rank == kReceiver) {
-      return infiniRecv(d_recv, num_elements, infiniFloat32, kSender, comm,
-                        nullptr);
+      return infinicclRecv(d_recv, num_elements, infinicclFloat32, kSender,
+                           comm, nullptr);
     }
 
-    return infiniSuccess;
+    return infinicclSuccess;
   };
 
   CHECK_INFINI(send_recv_call());
@@ -148,8 +148,8 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
     if (!correct) {
       CHECK_RT(Rt, Rt::Free(d_send));
       CHECK_RT(Rt, Rt::Free(d_recv));
-      CHECK_INFINI(infiniCommDestroy(comm));
-      CHECK_INFINI(infiniFinalize());
+      CHECK_INFINI(infinicclCommDestroy(comm));
+      CHECK_INFINI(infinicclFinalize());
       std::exit(EXIT_FAILURE);
     }
   }
@@ -162,8 +162,8 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Free(d_send));
   CHECK_RT(Rt, Rt::Free(d_recv));
 
-  CHECK_INFINI(infiniCommDestroy(comm));
-  CHECK_INFINI(infiniFinalize());
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
 
   if (rank == kSender) {
     std::cout << "InfiniCCL finalized." << std::endl;

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -11,8 +11,8 @@
 // Simple check macro for the C-API.
 #define CHECK_INFINI(cmd)                                                   \
   do {                                                                      \
-    infiniResult_t res = (cmd);                                             \
-    if (res != infiniSuccess) {                                             \
+    infinicclResult_t res = (cmd);                                          \
+    if (res != infinicclSuccess) {                                          \
       std::cerr << "[InfiniCCL Error] example program received error code " \
                 << res << " at line " << __LINE__ << std::endl;             \
       exit(EXIT_FAILURE);                                                   \
@@ -20,7 +20,7 @@
   } while (0)
 
 #define CHECK_RT(runtime_type, cmd) \
-  CHECK_INFINI(static_cast<infiniResult_t>(runtime_type::Check(cmd)))
+  CHECK_INFINI(static_cast<infinicclResult_t>(runtime_type::Check(cmd)))
 
 // Simple Timer for Profiling
 class Timer {

--- a/include/comm.h
+++ b/include/comm.h
@@ -10,68 +10,71 @@
 extern "C" {
 #endif
 
-typedef void *infiniComm_t;
+typedef void *infinicclComm_t;
 
 // Initialization
-infiniResult_t infiniInit(int *argc, char ***argv);
-infiniResult_t infiniFinalize(void);
+infinicclResult_t infinicclInit(int *argc, char ***argv);
+infinicclResult_t infinicclFinalize(void);
 
 // Rank/Size Query
-infiniResult_t infiniGetRank(int *rank);
-infiniResult_t infiniGetSize(int *size);
+infinicclResult_t infinicclGetRank(int *rank);
+infinicclResult_t infinicclGetSize(int *size);
 
 // Communicator Management
-infiniResult_t infiniCommInitAll(infiniComm_t *comm, int ndev,
-                                 const int *devlist);
-infiniResult_t infiniCommDestroy(infiniComm_t comm);
+infinicclResult_t infinicclCommInitAll(infinicclComm_t *comm, int ndev,
+                                       const int *devlist);
+infinicclResult_t infinicclCommDestroy(infinicclComm_t comm);
 
 // --- Reduction Operations ---
 typedef enum {
-  infiniSum = 0,
-  infiniProd = 1,
-  infiniMax = 2,
-  infiniMin = 3,
-  infiniAvg = 4,
-  infiniNumOps
-} infiniRedOp_t;
+  infinicclSum = 0,
+  infinicclProd = 1,
+  infinicclMax = 2,
+  infinicclMin = 3,
+  infinicclAvg = 4,
+  infinicclNumOps
+} infinicclRedOp_t;
 
 // Collective Communication Functions
-infiniResult_t infiniAllReduce(const void *sendbuff, void *recvbuff,
-                               size_t count, infiniDataType_t datatype,
-                               infiniRedOp_t op, infiniComm_t comm,
-                               void *stream);
+infinicclResult_t infinicclAllReduce(const void *sendbuff, void *recvbuff,
+                                     size_t count, infinicclDataType_t datatype,
+                                     infinicclRedOp_t op, infinicclComm_t comm,
+                                     void *stream);
 
-infiniResult_t infiniBroadcast(const void *sendbuff, void *recvbuff,
-                               size_t count, infiniDataType_t datatype,
-                               int root, infiniComm_t comm, void *stream);
+infinicclResult_t infinicclBroadcast(const void *sendbuff, void *recvbuff,
+                                     size_t count, infinicclDataType_t datatype,
+                                     int root, infinicclComm_t comm,
+                                     void *stream);
 
-infiniResult_t infiniBcast(void *buff, size_t count, infiniDataType_t datatype,
-                           int root, infiniComm_t comm, void *stream);
+infinicclResult_t infinicclBcast(void *buff, size_t count,
+                                 infinicclDataType_t datatype, int root,
+                                 infinicclComm_t comm, void *stream);
 
 infiniResult_t infiniReduce(const void *sendbuff, void *recvbuff, size_t count,
                             infiniDataType_t datatype, infiniRedOp_t op,
                             int root, infiniComm_t comm, void *stream);
 
-infiniResult_t infiniAllGather(const void *sendbuff, void *recvbuff,
-                               size_t count, infiniDataType_t datatype,
-                               infiniComm_t comm, void *stream);
+infinicclResult_t infinicclAllGather(const void *sendbuff, void *recvbuff,
+                                     size_t count, infinicclDataType_t datatype,
+                                     infinicclComm_t comm, void *stream);
 
-infiniResult_t infiniReduceScatter(const void *sendbuff, void *recvbuff,
-                                   size_t recvcount, infiniDataType_t datatype,
-                                   infiniRedOp_t op, infiniComm_t comm,
-                                   void *stream);
+infinicclResult_t infinicclReduceScatter(const void *sendbuff, void *recvbuff,
+                                         size_t recvcount,
+                                         infinicclDataType_t datatype,
+                                         infinicclRedOp_t op,
+                                         infinicclComm_t comm, void *stream);
 
-infiniResult_t infiniAllToAll(const void *sendbuff, void *recvbuff,
-                              size_t count, infiniDataType_t datatype,
-                              infiniComm_t comm, void *stream);
+infinicclResult_t infinicclAllToAll(const void *sendbuff, void *recvbuff,
+                                    size_t count, infinicclDataType_t datatype,
+                                    infinicclComm_t comm, void *stream);
 
-infiniResult_t infiniSend(const void *sendbuff, size_t count,
-                          infiniDataType_t datatype, int peer,
-                          infiniComm_t comm, void *stream);
+infinicclResult_t infinicclSend(const void *sendbuff, size_t count,
+                                infinicclDataType_t datatype, int peer,
+                                infinicclComm_t comm, void *stream);
 
-infiniResult_t infiniRecv(void *recvbuff, size_t count,
-                          infiniDataType_t datatype, int peer,
-                          infiniComm_t comm, void *stream);
+infinicclResult_t infinicclRecv(void *recvbuff, size_t count,
+                                infinicclDataType_t datatype, int peer,
+                                infinicclComm_t comm, void *stream);
 
 #ifdef __cplusplus
 }

--- a/include/comm.h
+++ b/include/comm.h
@@ -50,9 +50,10 @@ infinicclResult_t infinicclBcast(void *buff, size_t count,
                                  infinicclDataType_t datatype, int root,
                                  infinicclComm_t comm, void *stream);
 
-infiniResult_t infiniReduce(const void *sendbuff, void *recvbuff, size_t count,
-                            infiniDataType_t datatype, infiniRedOp_t op,
-                            int root, infiniComm_t comm, void *stream);
+infinicclResult_t infinicclReduce(const void *sendbuff, void *recvbuff,
+                                  size_t count, infinicclDataType_t datatype,
+                                  infinicclRedOp_t op, int root,
+                                  infinicclComm_t comm, void *stream);
 
 infinicclResult_t infinicclAllGather(const void *sendbuff, void *recvbuff,
                                      size_t count, infinicclDataType_t datatype,

--- a/include/data_type.h
+++ b/include/data_type.h
@@ -6,25 +6,25 @@ extern "C" {
 #endif
 
 typedef enum {
-  infiniChar = 0,
-  infiniInt8 = 0,
-  infiniInt16 = 1,
-  infiniInt = 2,
-  infiniInt32 = 2,
-  infiniInt64 = 3,
-  infiniUInt8 = 4,
-  infiniUInt16 = 5,
-  infiniUInt32 = 6,
-  infiniUInt64 = 7,
-  infiniHalf = 8,
-  infiniFloat16 = 8,
-  infiniBFloat16 = 9,
-  infiniFloat = 10,
-  infiniFloat32 = 10,
-  infiniDouble = 11,
-  infiniFloat64 = 11,
-  infiniNumTypes = 12,
-} infiniDataType_t;
+  infinicclChar = 0,
+  infinicclInt8 = 0,
+  infinicclInt16 = 1,
+  infinicclInt = 2,
+  infinicclInt32 = 2,
+  infinicclInt64 = 3,
+  infinicclUInt8 = 4,
+  infinicclUInt16 = 5,
+  infinicclUInt32 = 6,
+  infinicclUInt64 = 7,
+  infinicclHalf = 8,
+  infinicclFloat16 = 8,
+  infinicclBFloat16 = 9,
+  infinicclFloat = 10,
+  infinicclFloat32 = 10,
+  infinicclDouble = 11,
+  infinicclFloat64 = 11,
+  infinicclNumTypes = 12,
+} infinicclDataType_t;
 
 #ifdef __cplusplus
 }

--- a/include/return_status.h
+++ b/include/return_status.h
@@ -6,16 +6,16 @@ extern "C" {
 #endif
 
 typedef enum {
-  infiniSuccess = 0,
-  infiniUnhandledError = 1,
-  infiniSystemError = 2,
-  infiniInternalError = 3,
-  infiniInvalidArgument = 4,
-  infiniInvalidUsage = 5,
-  infiniRemoteError = 6,
-  infiniInProgress = 7,
-  infiniNumResults = 8
-} infiniResult_t;
+  infinicclSuccess = 0,
+  infinicclUnhandledError = 1,
+  infinicclSystemError = 2,
+  infinicclInternalError = 3,
+  infinicclInvalidArgument = 4,
+  infinicclInvalidUsage = 5,
+  infinicclRemoteError = 6,
+  infinicclInProgress = 7,
+  infinicclNumResults = 8
+} infinicclResult_t;
 
 #ifdef __cplusplus
 }

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -30,8 +30,8 @@ BACKEND_PATH_MAP = {"ompi": "ompi/impl", "mpich": "ompi/impl", "nccl": "nvidia/n
 
 
 def snake_to_camel(name):
-    """Converts infini_all_reduce or infiniAllReduce to AllReduce."""
-    clean_name = re.sub(r"^infini", "", name)
+    """Converts infiniccl_all_reduce or infinicclAllReduce to AllReduce."""
+    clean_name = re.sub(r"^infiniccl", "", name)
     if "_" in clean_name:
         return "".join(x.capitalize() for x in clean_name.split("_"))
     return clean_name[0].upper() + clean_name[1:]
@@ -40,7 +40,7 @@ def snake_to_camel(name):
 def parse_signatures(header_path):
     """Extracts function metadata from the public C header."""
     signatures = []
-    regex = r"(infiniResult_t)\s+(infini\w+)\s*\((.*?)\);"
+    regex = r"(infinicclResult_t)\s+(infiniccl\w+)\s*\((.*?)\);"
     if not os.path.exists(header_path):
         return signatures
 
@@ -162,9 +162,9 @@ def generate(project_root, output_dir, devices, backends):
             arg_name = parts[-1].replace("*", "")
 
             # Apply `static_cast` for specialized `Infini` types.
-            if arg_type == "infiniDataType_t":
+            if arg_type == "infinicclDataType_t":
                 args_with_casts.append(f"static_cast<DataType>({arg_name})")
-            elif arg_type == "infiniRedOp_t":
+            elif arg_type == "infinicclRedOp_t":
                 args_with_casts.append(f"static_cast<ReductionOpType>({arg_name})")
             else:
                 args_with_casts.append(arg_name)

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -30,7 +30,7 @@ BACKEND_PATH_MAP = {"ompi": "ompi/impl", "mpich": "ompi/impl", "nccl": "nvidia/n
 
 
 def snake_to_camel(name):
-    """Converts infiniccl_all_reduce or infinicclAllReduce to AllReduce."""
+    """Converts `infiniccl_all_reduce` or `infinicclAllReduce` to `AllReduce`."""
     clean_name = re.sub(r"^infiniccl", "", name)
     if "_" in clean_name:
         return "".join(x.capitalize() for x in clean_name.split("_"))

--- a/src/comm_impl.h
+++ b/src/comm_impl.h
@@ -8,12 +8,12 @@
 namespace infini::ccl {
 
 enum class ReductionOpType : int8_t {
-  kSum = infiniSum,
-  kProd = infiniProd,
-  kMax = infiniMax,
-  kMin = infiniMin,
-  kAvg = infiniAvg,
-  kNumRedOps = infiniNumOps,
+  kSum = infinicclSum,
+  kProd = infinicclProd,
+  kMax = infinicclMax,
+  kMin = infinicclMin,
+  kAvg = infinicclAvg,
+  kNumRedOps = infinicclNumOps,
 };
 
 }  // namespace infini::ccl

--- a/src/data_type_impl.h
+++ b/src/data_type_impl.h
@@ -12,20 +12,20 @@
 namespace infini::ccl {
 
 enum class DataType : int8_t {
-  kChar = infiniChar,
-  kInt8 = infiniInt8,
-  kInt16 = infiniInt16,
-  kInt32 = infiniInt32,
-  kInt64 = infiniInt64,
-  kUInt8 = infiniUInt8,
-  kUInt16 = infiniUInt16,
-  kUInt32 = infiniUInt32,
-  kUInt64 = infiniUInt64,
-  kFloat16 = infiniFloat16,
-  kBFloat16 = infiniBFloat16,
-  kFloat32 = infiniFloat32,
-  kFloat64 = infiniFloat64,
-  kNumTypes = infiniNumTypes,
+  kChar = infinicclChar,
+  kInt8 = infinicclInt8,
+  kInt16 = infinicclInt16,
+  kInt32 = infinicclInt32,
+  kInt64 = infinicclInt64,
+  kUInt8 = infinicclUInt8,
+  kUInt16 = infinicclUInt16,
+  kUInt32 = infinicclUInt32,
+  kUInt64 = infinicclUInt64,
+  kFloat16 = infinicclFloat16,
+  kBFloat16 = infinicclBFloat16,
+  kFloat32 = infinicclFloat32,
+  kFloat64 = infinicclFloat64,
+  kNumTypes = infinicclNumTypes,
 };
 
 constexpr ConstexprMap<DataType, std::size_t, 12> kDataTypeToSize{{{

--- a/src/return_status_impl.h
+++ b/src/return_status_impl.h
@@ -8,15 +8,15 @@
 namespace infini::ccl {
 
 enum class ReturnStatus : int8_t {
-  kSuccess = infiniSuccess,
-  kUnhandledError = infiniUnhandledError,
-  kSystemError = infiniSystemError,
-  kInternalError = infiniInternalError,
-  kInvalidArgument = infiniInvalidArgument,
-  kInvalidUsage = infiniInvalidUsage,
-  kRemoteError = infiniRemoteError,
-  kInProgress = infiniInProgress,
-  kNumResults = infiniNumResults,
+  kSuccess = infinicclSuccess,
+  kUnhandledError = infinicclUnhandledError,
+  kSystemError = infinicclSystemError,
+  kInternalError = infinicclInternalError,
+  kInvalidArgument = infinicclInvalidArgument,
+  kInvalidUsage = infinicclInvalidUsage,
+  kRemoteError = infinicclRemoteError,
+  kInProgress = infinicclInProgress,
+  kNumResults = infinicclNumResults,
 };
 
 }  // namespace infini::ccl


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR refactors the public API by renaming the interface prefix from `infini` to `infiniccl` across the codebase. This change aligns naming with NCCL and consistency with the project identity.

**Breaking change**: All public APIs previously using the `infini` prefix are now renamed to `infiniccl`, requiring downstream users to update their code accordingly to use the latest version of InfiniCCL.

## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **Public API Refactor**
  - Renamed all public interface prefixes from `infini` → `infiniccl`;
  - Ensures consistency with project naming;
  - Affects all exposed APIs and user-facing symbols.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] MetaX GPU
- [x] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work
- Downstream projects depending on the old `infini*` APIs will break and must migrate. 

## Test Results

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] MetaX GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

[all_gather.log](https://github.com/user-attachments/files/28507424/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28507426/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28507428/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28507429/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28507430/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28507431/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28507432/send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
