### PR TITLE
feat: add Iluvatar platform support across runtime, device, build, and launcher stack

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,6 +54,7 @@ Please check all the platforms and/or backends this PR affects (i.e., code is to
 
 - [ ] CPU
 - [ ] NVIDIA GPU
+- [ ] Iluvatar GPU
 - [ ] MetaX GPU
 - [ ] Cambricon MLU
 
@@ -99,6 +100,7 @@ See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and
 
 - [ ] CPU
 - [ ] NVIDIA GPU
+- [ ] Iluvatar GPU
 - [ ] MetaX GPU
 - [ ] Cambricon MLU
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # --- DEVICE OPTIONS (Hardware Runtimes) ---
 # =========================================================
 option(WITH_NVIDIA      "Enable NVIDIA GPU support"     OFF)
+option(WITH_ILUVATAR    "Enable ILUVATAR GPU support"   OFF)
 option(WITH_METAX       "Enable MetaX GPU support"      OFF)
 option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
 
@@ -60,6 +61,35 @@ if(AUTO_DETECT_DEVICES)
         message(STATUS "Auto-detected NVIDIA environment.")
     else()
         message(STATUS "NVIDIA environment not detected.")
+    endif()
+
+    # Iluvatar
+    set(ILUVATAR_FOUND FALSE)
+
+    file(GLOB ILUVATAR_DEV_FILES "/dev/iluvatar*")
+
+    if(ILUVATAR_DEV_FILES)
+        set(ILUVATAR_FOUND TRUE)
+    elseif(NOT ILUVATAR_FOUND)
+        find_program(ILUVATAR_SMI_PATH ixsmi)
+        if(ILUVATAR_SMI_PATH)
+            execute_process(
+                COMMAND ${ILUVATAR_SMI_PATH} -L
+                RESULT_VARIABLE SMI_RESULT
+                OUTPUT_QUIET
+                ERROR_QUIET
+            )
+            if(SMI_RESULT EQUAL 0)
+                set(ILUVATAR_FOUND TRUE)
+            endif()
+        endif()
+    endif()
+
+    if(ILUVATAR_FOUND)
+        set(WITH_ILUVATAR ON)
+        message(STATUS "Auto-detected Iluvatar environment.")
+    else()
+        message(STATUS "Iluvatar environment not detected.")
     endif()
 
     # MetaX
@@ -174,6 +204,29 @@ endif()
 if(WITH_NVIDIA)
     enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
+endif()
+
+if(WITH_ILUVATAR)
+    find_program(ILUVATAR_CUDA_COMPILER NAMES clang++ HINTS /usr/local/corex/bin)
+    
+    if(NOT ILUVATAR_CUDA_COMPILER)
+        message(FATAL_ERROR "`WITH_ILUVATAR` is `ON` but CoreX `clang++` was not found.")
+    endif()
+    
+    get_filename_component(ILUVATAR_CUDA_BIN_DIR "${ILUVATAR_CUDA_COMPILER}" DIRECTORY)
+    get_filename_component(ILUVATAR_CUDA_ROOT "${ILUVATAR_CUDA_BIN_DIR}/.." ABSOLUTE)
+    
+    set(CUDAToolkit_ROOT "${ILUVATAR_CUDA_ROOT}" CACHE PATH "Iluvatar CoreX toolkit root" FORCE)
+    find_package(CUDAToolkit REQUIRED)
+
+    set(ILUVATAR_INCLUDE_DIR "${ILUVATAR_CUDA_ROOT}/include")
+    set(ILUVATAR_LIB_DIR "${ILUVATAR_CUDA_ROOT}/lib" "${ILUVATAR_CUDA_ROOT}/lib64")
+
+    set(ILUVATAR_CUDA_FLAGS
+        "-fPIC;-Wno-error=unused-variable;-Wno-error=unused-private-field;-Wno-unused-variable;-std=c++17;--cuda-path=${ILUVATAR_CUDA_ROOT};-x;ivcore"
+        CACHE STRING "Iluvatar CUDA compiler flags")
+
+    message(STATUS "Iluvatar: CUDA compiler ${ILUVATAR_CUDA_COMPILER}, arch ${ILUVATAR_ARCH}, toolkit ${ILUVATAR_CUDA_ROOT}")
 endif()
 
 if(WITH_METAX)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 |--------|-------------|---------|
 | **Device (Hardware) Options** |||
 | `WITH_NVIDIA`     | Enable NVIDIA GPU support | `OFF` |
+| `WITH_ILUVATAR`   | Enable Iluvatar GPU support | `OFF` |
 | `WITH_METAX`      | Enable MetaX GPU support  | `OFF` |
 | `WITH_CAMBRICON`  | Enable Cambricon MLU support  | `OFF` |
 | `WITH_CPU`        | CPU support (always enabled) | `ON` (internal, not user‑settable) |
@@ -279,6 +280,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 |----------|---------------|-------|
 | **CPU**        | Partial | Runtime available, suppot OpenMPI backend, but no pure CPU collective operations yet. Planned for future releases. |
 | **NVIDIA**     | Full | Requires CUDA Toolkit. |
+| **Iluvatar**   | Full | Requires Iluvatar CoreX SDK. |
 | **MetaX**      | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
 | **Cambricon**  | Full | Requires CNToolKit and `NEUWARE_HOME` to be set. |
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(source_file ${EXAMPLE_SOURCES})
     target_link_libraries(${example_name} PRIVATE infiniccl)
 
     # Add runtime and backend dependencies for direct runtime/backend usage.
-    if(WITH_NVIDIA)
+    if(WITH_NVIDIA OR WITH_ILUVATAR)
         target_link_libraries(${example_name} PRIVATE CUDA::cudart)
     endif()
 

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -115,6 +115,9 @@ class ICCLLauncher:
             if n_type == "nvidia":
                 condition = '[ -c "/dev/nvidia0" ] || [ -x "$(command -v nvidia-smi)" ]'
 
+            elif n_type == "iluvatar":
+                condition = '[ -c "/dev/iluvatar0" ] || [ -x "$(command -v ixsmi)" ]'
+
             elif n_type == "metax":
                 condition = (
                     '[ -d "/opt/maca" ] || '

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,30 @@ if(WITH_NVIDIA)
     )
 endif()
 
+# Iluvatar
+if(WITH_ILUVATAR)
+    list(APPEND DEVICE_LIST "iluvatar")
+
+    set(ILUVATAR_PATTERNS
+        "cuda/*.cc"
+        "cuda/*.cpp"
+        "cuda/*.cu"
+        "iluvatar/*.cc"
+        "iluvatar/*.cpp"
+        "iluvatar/*.cu"
+    )
+    file(GLOB_RECURSE ILUVATAR_SOURCES ${ILUVATAR_PATTERNS})
+    target_sources(infiniccl PRIVATE ${ILUVATAR_SOURCES})
+
+    target_include_directories(infiniccl PRIVATE "${ILUVATAR_INCLUDE_DIR}")
+
+    set_source_files_properties(${ILUVATAR_SOURCES} PROPERTIES 
+        COMPILE_OPTIONS "${ILUVATAR_CUDA_FLAGS}"
+    )
+
+    target_link_libraries(infiniccl PRIVATE CUDA::cudart CUDA::cuda_driver)
+endif()
+
 # MetaX
 if(WITH_METAX)
     list(APPEND DEVICE_LIST "metax")

--- a/src/device.h
+++ b/src/device.h
@@ -136,6 +136,11 @@ struct DevicePriority<Device::Type::kNvidia> {
 };
 
 template <>
+struct DevicePriority<Device::Type::kIluvatar> {
+  static constexpr int value = 5;
+};
+
+template <>
 struct DevicePriority<Device::Type::kMetax> {
   static constexpr int value = 5;
 };

--- a/src/iluvatar/data_type_.h
+++ b/src/iluvatar/data_type_.h
@@ -6,8 +6,8 @@
 #include <cuda_fp16.h>
 // clang-format on
 
-#include "iluvatar/device_.h"
 #include "data_type_impl.h"
+#include "iluvatar/device_.h"
 
 namespace infini::ccl {
 

--- a/src/iluvatar/data_type_.h
+++ b/src/iluvatar/data_type_.h
@@ -1,0 +1,26 @@
+#ifndef INFINI_CCL_ILUVATAR_DATA_TYPE__H_
+#define INFINI_CCL_ILUVATAR_DATA_TYPE__H_
+
+// clang-format off
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+// clang-format on
+
+#include "iluvatar/device_.h"
+#include "data_type_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct TypeMap<Device::Type::kIluvatar, DataType::kFloat16> {
+  using type = half;
+};
+
+template <>
+struct TypeMap<Device::Type::kIluvatar, DataType::kBFloat16> {
+  using type = __nv_bfloat16;
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_ILUVATAR_DATA_TYPE__H_

--- a/src/iluvatar/device_.h
+++ b/src/iluvatar/device_.h
@@ -1,0 +1,13 @@
+#ifndef INFINI_CCL_ILUVATAR_DEVICE__H_
+#define INFINI_CCL_ILUVATAR_DEVICE__H_
+
+#include "device.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kIluvatar> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_ILUVATAR_DEVICE__H_

--- a/src/iluvatar/runtime_.h
+++ b/src/iluvatar/runtime_.h
@@ -1,0 +1,58 @@
+#ifndef INFINI_CCL_ILUVATAR_RUNTIME__H_
+#define INFINI_CCL_ILUVATAR_RUNTIME__H_
+
+#include <utility>
+
+// clang-format off
+#include <cuda_runtime.h>
+// clang-format on
+
+#include "cuda/runtime_.h"
+#include "iluvatar/device_.h"
+#include "logging.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kIluvatar>
+    : CudaRuntime<Runtime<Device::Type::kIluvatar>> {
+  using Stream = cudaStream_t;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kIluvatar;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != cudaSuccess) {
+          LOG(cudaGetErrorString(static_cast<cudaError_t>(status)));
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](auto &&...args) {
+    return cudaMalloc(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Memcpy = cudaMemcpy;
+
+  static constexpr auto Free = cudaFree;
+
+  static constexpr auto MemcpyHostToDevice = cudaMemcpyHostToDevice;
+
+  static constexpr auto MemcpyDeviceToHost = cudaMemcpyDeviceToHost;
+
+  static constexpr auto Memset = cudaMemset;
+
+  static constexpr auto SetDevice = cudaSetDevice;
+
+  static constexpr auto DeviceSynchronize = cudaDeviceSynchronize;
+
+  static constexpr auto StreamSynchronize = cudaStreamSynchronize;
+};
+
+static_assert(Runtime<Device::Type::kIluvatar>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_ILUVATAR_RUNTIME__H_


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary
This PR adds support for the Iluavatar platform, enabling both build-time and runtime integration. Existing examples using the OpenMPI backend can now run on Iluvatar hardware with platform-specific specializations.

Changes include build logic, device priority handling, runtime specialization, and example execution support.

## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **Platform Support**
  - Added Iluvatar build logic to CMake and related scripts;
  - Specialized device handling and priority in `src/device.h` for Iluvatar;
  - Implemented platform-specific data type and device APIs in:
    - `src/iluvatar/data_type_.h`
    - `src/iluvatar/device_.h`
    - `src/iluvatar/runtime_.h`
   
- **Example & Runtime Integration**
  - Updated `scripts/icclrun_logic.py` to include an Iluvatar conditional for generating `run_wrapper.sh` for Iluvatar;
  - Ensures that existing OpenMPI-backend examples can run on Iluvatar.

- **Documentation Update**
  - Updated `.github/pull_request_template.md` to include Iluvatar as a supported platform;
  - Updated `README.md` to include Iluvatar as a supported platform.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [x] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work
 - Further testing needed for heterogeneous clusters with Iluvatar nodes.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**Iluvatar (Single Node):**
[all_gather.log](https://github.com/user-attachments/files/28553244/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28553245/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28553247/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28553248/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28553250/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28553252/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28553243/send_recv.log)

**NIVIDA + MetaX with OpenMPI (Heterogeneous Cluster)**:
[all_gather.log](https://github.com/user-attachments/files/28553674/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28553675/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28553676/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28553678/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28553679/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28553680/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28553682/send_recv.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [x] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
