### PR TITLE
feat: add Moore Threads platform support across runtime, device, build, and launcher stack

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -56,6 +56,7 @@ Please check all the platforms and/or backends this PR affects (i.e., code is to
 - [ ] NVIDIA GPU
 - [ ] Iluvatar GPU
 - [ ] MetaX GPU
+- [ ] Moore Threads GPU
 - [ ] Cambricon MLU
 
 ### Backend
@@ -102,6 +103,7 @@ See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and
 - [ ] NVIDIA GPU
 - [ ] Iluvatar GPU
 - [ ] MetaX GPU
+- [ ] Moore Threads GPU
 - [ ] Cambricon MLU
 
 ### Test Involved Backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(WITH_NVIDIA      "Enable NVIDIA GPU support"     OFF)
 option(WITH_ILUVATAR    "Enable ILUVATAR GPU support"   OFF)
 option(WITH_METAX       "Enable MetaX GPU support"      OFF)
+option(WITH_MOORE       "Enable Moore GPU support"      OFF)
 option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
 
 set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
@@ -112,6 +113,38 @@ if(AUTO_DETECT_DEVICES)
             set(WITH_METAX OFF)
             message(STATUS "No MetaX GPU detected")
         endif()
+    endif()
+
+    # MThreads (Moore)
+    set(MOORE_FOUND FALSE)
+
+    file(GLOB MOORE_DEV_FILES "/dev/mtgpu*")
+
+    if(DEFINED ENV{MUSA_ROOT} OR DEFINED ENV{MUSA_HOME} OR DEFINED ENV{MUSA_PATH})
+        set(MOORE_FOUND TRUE)
+    elseif(MOORE_DEV_FILES)
+        set(MOORE_FOUND TRUE)
+    elseif(NOT MOORE_FOUND)
+        find_program(MOORE_SMI_PATH mthreads-gmi)
+
+        if(MOORE_SMI_PATH)
+            execute_process(
+                COMMAND ${MOORE_SMI_PATH} -L
+                RESULT_VARIABLE SMI_RESULT
+                OUTPUT_QUIET
+                ERROR_QUIET
+            )
+            if(SMI_RESULT EQUAL 0)
+                set(MOORE_FOUND TRUE)
+            endif()
+        endif()
+    endif()
+
+    if(MOORE_FOUND)
+        set(WITH_MOORE ON)
+        message(STATUS "Auto-detected Moore environment.")
+    else()
+        message(STATUS "Moore environment not detected.")
     endif()
 
     # Cambricon
@@ -246,6 +279,40 @@ if(WITH_METAX)
     link_directories("${MACA_PATH}/lib")
 
     find_library(MACA_RUNTIME_LIB NAMES mcruntime HINTS "${MACA_PATH}/lib" REQUIRED)
+endif()
+
+if(WITH_MOORE)  
+    set(MUSA_ROOT "")
+    foreach(_musa_env MUSA_ROOT MUSA_HOME MUSA_PATH)
+        if(NOT MUSA_ROOT AND DEFINED ENV{${_musa_env}} AND NOT "$ENV{${_musa_env}}" STREQUAL "")
+            set(MUSA_ROOT "$ENV{${_musa_env}}")
+        endif()
+    endforeach()
+
+    if(NOT MUSA_ROOT AND EXISTS "/usr/local/musa")
+        set(MUSA_ROOT "/usr/local/musa")
+    endif()
+
+    if(NOT MUSA_ROOT)
+        message(FATAL_ERROR "`WITH_MOORE` is `ON` but `MUSA_ROOT`/`MUSA_HOME`/`MUSA_PATH` is not set and `/usr/local/musa` was not found.")
+    endif()
+
+    if(NOT EXISTS "${MUSA_ROOT}/bin/mcc")
+        message(FATAL_ERROR "Could not find `mcc` under `${MUSA_ROOT}/bin`.")
+    endif()
+
+    get_filename_component(MCC_WRAPPER_ABS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/devices/mcc_wrapper.sh" ABSOLUTE)
+    file(CHMOD "${MCC_WRAPPER_ABS}"
+     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    set(CMAKE_C_COMPILER   "${MCC_WRAPPER_ABS}")
+    set(CMAKE_CXX_COMPILER "${MCC_WRAPPER_ABS}")
+
+    include_directories("${MUSA_ROOT}/include")
+    link_directories("${MUSA_ROOT}/lib")
+
+    find_library(MUSA_LIB   NAMES musa   HINTS "${MUSA_ROOT}/lib" REQUIRED)
+    find_library(MUSART_LIB NAMES musart HINTS "${MUSA_ROOT}/lib" REQUIRED)
+    find_library(MUBLAS_LIB NAMES mublas HINTS "${MUSA_ROOT}/lib" REQUIRED)
 endif()
 
 if(WITH_CAMBRICON)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | `WITH_NVIDIA`     | Enable NVIDIA GPU support | `OFF` |
 | `WITH_ILUVATAR`   | Enable Iluvatar GPU support | `OFF` |
 | `WITH_METAX`      | Enable MetaX GPU support  | `OFF` |
+| `WITH_MOORE`      | Enable Moore Threads GPU support  | `OFF` |
 | `WITH_CAMBRICON`  | Enable Cambricon MLU support  | `OFF` |
 | `WITH_CPU`        | CPU support (always enabled) | `ON` (internal, not user‑settable) |
 | **Backend (Communication) Options** |||
@@ -282,6 +283,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 | **NVIDIA**     | Full | Requires CUDA Toolkit. |
 | **Iluvatar**   | Full | Requires Iluvatar CoreX SDK. |
 | **MetaX**      | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
+| **Moore Threads** | Full | Requires MUSA SDK and at least one of `MACA_ROOT` (default `/usr/local/musa`), `MACA_PATH`, and `MUSA_HOME` to be set. |
 | **Cambricon**  | Full | Requires CNToolKit and `NEUWARE_HOME` to be set. |
 
 </details>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,11 @@ foreach(source_file ${EXAMPLE_SOURCES})
         target_link_libraries(${example_name} PRIVATE ${MACA_RUNTIME_LIB})
     endif()
 
+    if(WITH_MOORE)
+        target_link_libraries(${example_name} PRIVATE ${MUSART_LIB})
+        target_compile_options(${example_name} PRIVATE "-x" "musa")
+    endif()
+
     if(WITH_CAMBRICON)
         target_link_libraries(${example_name} PRIVATE ${CAMBRICON_RUNTIME_LIB})
     endif()

--- a/scripts/devices/mcc_wrapper.sh
+++ b/scripts/devices/mcc_wrapper.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Filter out flags unsupported by `mcc`.
+ARGS=()
+skip_next=0
+linking=1
+for arg in "$@"; do
+    if [ $skip_next -eq 1 ]; then
+        skip_next=0
+        continue
+    fi
+    case "$arg" in
+        -c|-E|-S)
+            linking=0
+            ARGS+=("$arg")
+            ;;
+        -pthread)
+            ;;
+        -B)
+            skip_next=1
+            ;;
+        -B*)
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+done
+
+MUSA_ROOT_DIR="${MUSA_ROOT:-${MUSA_HOME:-${MUSA_PATH:-/usr/local/musa}}}"
+
+if command -v g++ >/dev/null 2>&1; then
+    GXX_MAJOR="$(g++ -dumpversion | cut -d. -f1)"
+    if [ -d "/usr/include/c++/${GXX_MAJOR}" ]; then
+        ARGS=(
+            "-isystem" "/usr/include/c++/${GXX_MAJOR}"
+            "-isystem" "/usr/include/x86_64-linux-gnu/c++/${GXX_MAJOR}"
+            "-isystem" "/usr/include/c++/${GXX_MAJOR}/backward"
+            "${ARGS[@]}"
+        )
+    fi
+
+    STDCPP_LIB="$(g++ -print-file-name=libstdc++.so)"
+    if [ $linking -eq 1 ] && [ -f "${STDCPP_LIB}" ]; then
+        ARGS=("-L$(dirname "${STDCPP_LIB}")" "${ARGS[@]}")
+    fi
+fi
+
+exec "${MUSA_ROOT_DIR}/bin/mcc" "${ARGS[@]}"

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -124,6 +124,9 @@ class ICCLLauncher:
                     'grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1'
                 )
 
+            elif n_type == "moore":
+                condition = '[ -c "/dev/mtgpu.0" ] || [ -x "$(command -v mthreads-gmi)" ]'
+
             elif n_type == "cambricon":
                 condition = (
                     '[ -n "${NEUWARE_HOME}" ] || command -v cnmon >/dev/null 2>&1'

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -125,7 +125,9 @@ class ICCLLauncher:
                 )
 
             elif n_type == "moore":
-                condition = '[ -c "/dev/mtgpu.0" ] || [ -x "$(command -v mthreads-gmi)" ]'
+                condition = (
+                    '[ -c "/dev/mtgpu.0" ] || [ -x "$(command -v mthreads-gmi)" ]'
+                )
 
             elif n_type == "cambricon":
                 condition = (

--- a/scripts/run_wrapper.sh
+++ b/scripts/run_wrapper.sh
@@ -13,6 +13,8 @@ if [ -c "/dev/nvidia0" ] || [ -x "$(command -v nvidia-smi)" ]; then
     ARCH="nvidia"
 elif grep -l "9999" /sys/bus/pci/devices/*/vendor >/dev/null 2>&1 || [ -d "/opt/maca" ]; then
     ARCH="metax"
+elif [ -c "/dev/mtgpu.0" ] || [ -x "$(command -v mthreads-gmi)" ]; then
+    ARCH="moore"
 elif [ -n "${NEUWARE_HOME}" ] || [ -x "$(command -v cnmon)" ]; then
     ARCH="cambricon"
 else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,29 @@ if(WITH_METAX)
     target_compile_options(infiniccl PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-x maca>)
 endif()
 
+# Mthreads (Moore)
+if(WITH_MOORE)
+    list(APPEND DEVICE_LIST "moore")
+
+    set(MOORE_PATTERNS
+        "cuda/*.cc"
+        "cuda/*.cpp"
+        "moore/*.cc"
+        "moore/*.cpp"
+        "moore/*.mu"
+    )
+    file(GLOB MOORE_SOURCES ${MOORE_PATTERNS})
+
+    set_source_files_properties(${MOORE_SOURCES} PROPERTIES LANGUAGE CXX)
+
+    # target_compile_options(infiniccl PRIVATE "-x" "musa")
+    target_sources(infiniccl PRIVATE ${MOORE_SOURCES})
+
+    target_include_directories(infiniccl PRIVATE "${MUSA_ROOT}/include")
+    target_link_libraries(infiniccl PRIVATE ${MUSA_LIB} ${MUSART_LIB} ${MUBLAS_LIB})
+    target_compile_options(infiniccl PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-x musa>)
+endif()
+
 # Cambricon
 if(WITH_CAMBRICON)
     list(APPEND DEVICE_LIST "cambricon")

--- a/src/device.h
+++ b/src/device.h
@@ -146,6 +146,11 @@ struct DevicePriority<Device::Type::kMetax> {
 };
 
 template <>
+struct DevicePriority<Device::Type::kMoore> {
+  static constexpr int value = 5;
+};
+
+template <>
 struct DevicePriority<Device::Type::kCambricon> {
   static constexpr int value = 5;
 };

--- a/src/moore/data_type_.h
+++ b/src/moore/data_type_.h
@@ -1,0 +1,26 @@
+#ifndef INFINI_CCL_MOORE_DATA_TYPE__H_
+#define INFINI_CCL_MOORE_DATA_TYPE__H_
+
+// clang-format off
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+// clang-format on
+
+#include "data_type_impl.h"
+#include "moore/device_.h"
+
+namespace infini::ccl {
+
+template <>
+struct TypeMap<Device::Type::kMoore, DataType::kFloat16> {
+  using type = half;
+};
+
+template <>
+struct TypeMap<Device::Type::kMoore, DataType::kBFloat16> {
+  using type = __mt_bfloat16;
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_MOORE_DATA_TYPE__H_

--- a/src/moore/device_.h
+++ b/src/moore/device_.h
@@ -10,4 +10,4 @@ struct DeviceEnabled<Device::Type::kMoore> : std::true_type {};
 
 }  // namespace infini::ccl
 
-#endif // INFINI_CCL_MOORE_DEVICE__H_
+#endif  // INFINI_CCL_MOORE_DEVICE__H_

--- a/src/moore/device_.h
+++ b/src/moore/device_.h
@@ -1,0 +1,13 @@
+#ifndef INFINI_CCL_MOORE_DEVICE__H_
+#define INFINI_CCL_MOORE_DEVICE__H_
+
+#include "device.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kMoore> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif // INFINI_CCL_MOORE_DEVICE__H_

--- a/src/moore/runtime_.h
+++ b/src/moore/runtime_.h
@@ -50,7 +50,7 @@ struct Runtime<Device::Type::kMoore>
 
   static constexpr auto DeviceSynchronize = [](auto &&...args) {
     return musaDeviceSynchronize(std::forward<decltype(args)>(args)...);
-  };;
+  };
 
   static constexpr auto StreamSynchronize = musaStreamSynchronize;
 };

--- a/src/moore/runtime_.h
+++ b/src/moore/runtime_.h
@@ -1,0 +1,62 @@
+#ifndef INFINI_CCL_MOORE_RUNTIME_H_
+#define INFINI_CCL_MOORE_RUNTIME_H_
+
+#include <utility>
+
+// clang-format off
+#include <musa_runtime.h>
+// clang-format on
+
+#include "cuda/runtime_.h"
+#include "logging.h"
+#include "moore/device_.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kMoore>
+    : CudaRuntime<Runtime<Device::Type::kMoore>> {
+  using Stream = musaStream_t;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kMoore;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != musaSuccess) {
+          LOG(musaGetErrorString(static_cast<musaError_t>(status)));
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](auto &&...args) {
+    return musaMalloc(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Memcpy = musaMemcpy;
+
+  static constexpr auto Free = [](auto &&...args) {
+    return musaFree(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto MemcpyHostToDevice = musaMemcpyHostToDevice;
+
+  static constexpr auto MemcpyDeviceToHost = musaMemcpyDeviceToHost;
+
+  static constexpr auto Memset = musaMemset;
+
+  static constexpr auto SetDevice = musaSetDevice;
+
+  static constexpr auto DeviceSynchronize = [](auto &&...args) {
+    return musaDeviceSynchronize(std::forward<decltype(args)>(args)...);
+  };;
+
+  static constexpr auto StreamSynchronize = musaStreamSynchronize;
+};
+
+static_assert(Runtime<Device::Type::kMoore>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_MOORE_RUNTIME_H_


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR adds support for Moore Threads (Moore or MThreads) platform, enabling both build-time and runtime integration. Existing examples using the OpenMPI backend can now run on Moore Threads hardware with platform-specific specializations.

Changes include build logic, device priority handling, runtime specialization, and example execution support.


## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **Platform Support**
  - Added Moore build logic to CMake and related scripts;
  - Specialized device handling and priority in `src/device.h` for Moore;
  - Implemented platform-specific data type and device APIs in:
    - `src/moore/data_type_.h`
    - `src/moore/device_.h`
    - `src/moore/runtime_.h`
   
- **Example & Runtime Integration**
  - Updated `scripts/icclrun_logic.py` to include an Moore conditional for generating `run_wrapper.sh` for Moore;
  - Ensures that existing OpenMPI-backend examples can run on Moore.

- **Documentation Update**
  - Updated `.github/pull_request_template.md` to include Moore as a supported platform;
  - Updated `README.md` to include Moore as a supported platform.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] Moore GPU
- [ ] MetaX GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work
 - Further testing needed for heterogeneous clusters with Moore nodes.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] Moore GPU
- [x] MetaX GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**Moore (Single Node):**
[all_gather.log](https://github.com/user-attachments/files/28584993/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28584994/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28584997/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28584998/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28584999/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28585001/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28585004/send_recv.log)


**NIVIDA + MetaX with OpenMPI (Heterogeneous Cluster)**:
[all_gather.log](https://github.com/user-attachments/files/28585255/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/28585258/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/28585260/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/28585261/broadcast.log)
[reduce.log](https://github.com/user-attachments/files/28585262/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/28585263/reduce_scatter.log)
[send_recv.log](https://github.com/user-attachments/files/28585264/send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [x] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.