### PR TITLE
feat: support unified cast and type-safe host math fallbacks for reduce-type MPI operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(AUTO_DETECT_DEVICES)
     # NVIDIA
     set(NVIDIA_FOUND FALSE)
 
-    file(GLOB NVIDIA_DEV_FILES "/dev/nvidia*")
+    file(GLOB NVIDIA_DEV_FILES "/dev/nvidia0")
 
     if(NVIDIA_DEV_FILES)
         set(NVIDIA_FOUND TRUE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,6 +14,7 @@ foreach(source_file ${EXAMPLE_SOURCES})
 
     if(WITH_METAX)
         target_link_libraries(${example_name} PRIVATE ${MACA_RUNTIME_LIB})
+        target_compile_options(${example_name} PRIVATE "-x" "maca")
     endif()
 
     if(WITH_MOORE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,8 +8,17 @@ foreach(source_file ${EXAMPLE_SOURCES})
     target_link_libraries(${example_name} PRIVATE infiniccl)
 
     # Add runtime and backend dependencies for direct runtime/backend usage.
-    if(WITH_NVIDIA OR WITH_ILUVATAR)
+    if(WITH_NVIDIA)
         target_link_libraries(${example_name} PRIVATE CUDA::cudart)
+    endif()
+
+    if(WITH_ILUVATAR)
+        set_source_files_properties(${source_file} PROPERTIES LANGUAGE CXX)
+        set_target_properties(${example_name} PROPERTIES
+            RULE_LAUNCH_COMPILE "${ILUVATAR_CUDA_COMPILER} "
+        )
+        target_compile_options(${example_name} PRIVATE ${ILUVATAR_CUDA_FLAGS} "-Wno-unused-command-line-argument")
+        target_link_libraries(${example_name} PRIVATE CUDA::cudart CUDA::cuda_driver)
     endif()
 
     if(WITH_METAX)

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -19,7 +19,12 @@ AUTOGEN_HEADER = """/*
 """
 
 # Hardware traits to look for in device directories.
-DEVICE_TRAIT_HEADERS = ["device_.h", "runtime_.h", "data_type_.h"]
+DEVICE_TRAIT_FILES = {
+    "caster_": ["h", "cuh"],
+    "device_": ["h"],
+    "runtime_": ["h", "cuh"],
+    "data_type_": ["h", "cuh"],
+}
 
 # Map logical backend names (from CMake) to their internal source paths.
 BACKEND_PATH_MAP = {"ompi": "ompi/impl", "mpich": "ompi/impl", "nccl": "nvidia/nccl"}
@@ -97,11 +102,14 @@ def generate(project_root, output_dir, devices, backends):
         device_included = False
         manifest_lines.append(f"\n// --- DEVICE: {dev.upper()} ---")
 
-        for trait in DEVICE_TRAIT_HEADERS:
-            rel_path = f"{dev}/{trait}"
-            if os.path.exists(os.path.join(src_dir, rel_path)):
-                manifest_lines.append(f'#include "{rel_path}"')
-                device_included = True
+        for trait, extensions in DEVICE_TRAIT_FILES.items():
+            for ext in extensions:
+                rel_path = f"{dev}/{trait}.{ext}"
+
+                if os.path.exists(os.path.join(src_dir, rel_path)):
+                    manifest_lines.append(f'#include "{rel_path}"')
+                    device_included = True
+                    break
 
         if device_included:
             found_devices.append(f"Device::Type::k{dev.capitalize()}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,8 @@ if(WITH_ILUVATAR)
     set_source_files_properties(${ILUVATAR_SOURCES} PROPERTIES 
         COMPILE_OPTIONS "${ILUVATAR_CUDA_FLAGS}"
     )
+    set(CMAKE_CXX_COMPILER "${ILUVATAR_CUDA_COMPILER}" CACHE FILEPATH "Iluvatar Compiler" FORCE)
+    target_compile_options(infiniccl PRIVATE ${ILUVATAR_CUDA_FLAGS})
 
     target_link_libraries(infiniccl PRIVATE CUDA::cudart CUDA::cuda_driver)
 endif()

--- a/src/cambricon/caster.mlu
+++ b/src/cambricon/caster.mlu
@@ -2,42 +2,48 @@
 
 namespace infini::ccl {
 
-float HardwareCastImpl<Device::Type::kCambricon, float, CambriconFP16>::Apply(CambriconFP16 x) {
-    const __half& native_x = *reinterpret_cast<const __half*>(&x.bits);
-    return __half2float(native_x);
+float HardwareCastImpl<Device::Type::kCambricon, float, CambriconFP16>::Apply(
+    CambriconFP16 x) {
+  const __half& native_x = *reinterpret_cast<const __half*>(&x.bits);
+  return __half2float(native_x);
 }
 
-CambriconFP16 HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, float>::Apply(float x) {
-    __half native_res = __float2half__(x);
-    CambriconFP16 out;
-    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
-    return out;
+CambriconFP16 HardwareCastImpl<Device::Type::kCambricon, CambriconFP16,
+                               float>::Apply(float x) {
+  __half native_res = __float2half__(x);
+  CambriconFP16 out;
+  out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+  return out;
 }
 
-CambriconFP16 HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, int>::Apply(int x) {
-    __half native_res = __int2half_rn__(x);
-    CambriconFP16 out;
-    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
-    return out;
+CambriconFP16
+HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, int>::Apply(int x) {
+  __half native_res = __int2half_rn__(x);
+  CambriconFP16 out;
+  out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+  return out;
 }
 
-float HardwareCastImpl<Device::Type::kCambricon, float, CambriconBF16>::Apply(CambriconBF16 x) {
-    const bfloat16_t& native_x = *reinterpret_cast<const bfloat16_t*>(&x.bits);
-    return __bfloat162float__(native_x);
+float HardwareCastImpl<Device::Type::kCambricon, float, CambriconBF16>::Apply(
+    CambriconBF16 x) {
+  const bfloat16_t& native_x = *reinterpret_cast<const bfloat16_t*>(&x.bits);
+  return __bfloat162float__(native_x);
 }
 
-CambriconBF16 HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, float>::Apply(float x) {
-    bfloat16_t native_res = __float2bfloat16__(x);
-    CambriconBF16 out;
-    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
-    return out;
+CambriconBF16 HardwareCastImpl<Device::Type::kCambricon, CambriconBF16,
+                               float>::Apply(float x) {
+  bfloat16_t native_res = __float2bfloat16__(x);
+  CambriconBF16 out;
+  out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+  return out;
 }
 
-CambriconBF16 HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, int>::Apply(int x) {
-    bfloat16_t native_res = __int2bfloat16_rn__(x);
-    CambriconBF16 out;
-    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
-    return out;
+CambriconBF16
+HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, int>::Apply(int x) {
+  bfloat16_t native_res = __int2bfloat16_rn__(x);
+  CambriconBF16 out;
+  out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+  return out;
 }
 
 }  // namespace infini::ccl

--- a/src/cambricon/caster.mlu
+++ b/src/cambricon/caster.mlu
@@ -1,0 +1,43 @@
+#include "caster_.h"
+
+namespace infini::ccl {
+
+float HardwareCastImpl<Device::Type::kCambricon, float, CambriconFP16>::Apply(CambriconFP16 x) {
+    const __half& native_x = *reinterpret_cast<const __half*>(&x.bits);
+    return __half2float(native_x);
+}
+
+CambriconFP16 HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, float>::Apply(float x) {
+    __half native_res = __float2half__(x);
+    CambriconFP16 out;
+    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+    return out;
+}
+
+CambriconFP16 HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, int>::Apply(int x) {
+    __half native_res = __int2half_rn__(x);
+    CambriconFP16 out;
+    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+    return out;
+}
+
+float HardwareCastImpl<Device::Type::kCambricon, float, CambriconBF16>::Apply(CambriconBF16 x) {
+    const bfloat16_t& native_x = *reinterpret_cast<const bfloat16_t*>(&x.bits);
+    return __bfloat162float__(native_x);
+}
+
+CambriconBF16 HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, float>::Apply(float x) {
+    bfloat16_t native_res = __float2bfloat16__(x);
+    CambriconBF16 out;
+    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+    return out;
+}
+
+CambriconBF16 HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, int>::Apply(int x) {
+    bfloat16_t native_res = __int2bfloat16_rn__(x);
+    CambriconBF16 out;
+    out.bits = *reinterpret_cast<uint16_t*>(&native_res);
+    return out;
+}
+
+}  // namespace infini::ccl

--- a/src/cambricon/caster_.h
+++ b/src/cambricon/caster_.h
@@ -1,0 +1,41 @@
+#ifndef INFINI_CCL_CAMBRICON_CASTER__H_
+#define INFINI_CCL_CAMBRICON_CASTER__H_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, float, CambriconFP16> {
+  static float Apply(CambriconFP16 x);
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, float> {
+  static CambriconFP16 Apply(float x);
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, CambriconFP16, int> {
+  static CambriconFP16 Apply(int x);
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, float, CambriconBF16> {
+  static float Apply(CambriconBF16 x);
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, float> {
+  static CambriconBF16 Apply(float x);
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCambricon, CambriconBF16, int> {
+  static CambriconBF16 Apply(int x);
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CAMBRICON_CASTER__H_

--- a/src/cambricon/data_type_.h
+++ b/src/cambricon/data_type_.h
@@ -1,33 +1,28 @@
 #ifndef INFINI_CCL_CAMBRICON_DATA_TYPE__H_
 #define INFINI_CCL_CAMBRICON_DATA_TYPE__H_
 
-#if defined(__mlu__) || defined(__BANG__)
-#include "bang_bf16.h"
-#else
-// If compiling on the host side using standard GCC, mock the storage types
-// to prevent header poisoning and avoid `bang_fp16.h` dependency altogether.
-#ifndef HAS_CAMBRICON_HOST_HALF_MOCKS
-#define HAS_CAMBRICON_HOST_HALF_MOCKS
+#include <cstdint>
 
-typedef uint16_t half;
-typedef uint16_t bfloat16_t;
-
-#endif
-#endif
-
-#include "cambricon/device_.h"
 #include "data_type_impl.h"
 
 namespace infini::ccl {
 
+// Unique tag types to force completely distinct template signatures.
+struct CambriconFP16 {
+  uint16_t bits;
+};
+struct CambriconBF16 {
+  uint16_t bits;
+};
+
 template <>
 struct TypeMap<Device::Type::kCambricon, DataType::kFloat16> {
-  using type = half;
+  using type = CambriconFP16;
 };
 
 template <>
 struct TypeMap<Device::Type::kCambricon, DataType::kBFloat16> {
-  using type = bfloat16_t;
+  using type = CambriconBF16;
 };
 
 }  // namespace infini::ccl

--- a/src/caster.h
+++ b/src/caster.h
@@ -1,0 +1,70 @@
+#ifndef INFINI_CCL_CASTER_H_
+#define INFINI_CCL_CASTER_H_
+
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+
+#include "device.h"
+
+namespace infini::ccl {
+
+// Check if a type is complete (i.e. fully defined) at compile-time.
+template <typename T, typename = void>
+struct IsComplete : std::false_type {};
+
+template <typename T>
+struct IsComplete<T, std::void_t<decltype(sizeof(T))>> : std::true_type {};
+
+template <Device::Type kDev, typename Dst, typename Src>
+struct HardwareCastImpl;
+
+template <Device::Type kDev, typename Dst, typename Src>
+inline constexpr bool HasHardwareCastV =
+    IsComplete<HardwareCastImpl<kDev, Dst, Src>>::value;
+
+// Intermediate type used for fallback conversions, usually `float`.
+template <Device::Type kDev>
+struct CastBridge {
+  using Type = float;
+};
+
+template <Device::Type kDev>
+struct Caster {
+  template <typename Dst, typename Src>
+  static constexpr Dst Cast(Src&& x) {
+    using PureSrc = std::remove_cv_t<std::remove_reference_t<Src>>;
+    using PureDst = std::remove_cv_t<std::remove_reference_t<Dst>>;
+    using Bridge = typename CastBridge<kDev>::Type;
+
+    if constexpr (std::is_same_v<PureSrc, PureDst>) {
+      return std::forward<Src>(x);
+    } else if constexpr (HasHardwareCastV<kDev, PureDst, PureSrc>) {
+      return HardwareCastImpl<kDev, PureDst, PureSrc>::Apply(
+          std::forward<Src>(x));
+    } else if constexpr (!std::is_same_v<PureSrc, Bridge> &&
+                         !std::is_same_v<PureDst, Bridge> &&
+                         HasHardwareCastV<kDev, Bridge, PureSrc> &&
+                         (HasHardwareCastV<kDev, PureDst, Bridge> ||
+                          std::is_arithmetic_v<PureDst>)) {
+      Bridge tmp = Cast<Bridge>(std::forward<Src>(x));
+      return Cast<PureDst>(tmp);
+    } else if constexpr (!std::is_same_v<PureDst, Bridge> &&
+                         std::is_arithmetic_v<PureSrc> &&
+                         HasHardwareCastV<kDev, PureDst, Bridge>) {
+      Bridge tmp = static_cast<Bridge>(std::forward<Src>(x));
+      return Cast<PureDst>(tmp);
+    } else if constexpr (std::is_arithmetic_v<PureSrc> &&
+                         std::is_arithmetic_v<PureDst>) {
+      return static_cast<PureDst>(std::forward<Src>(x));
+    } else {
+      static_assert(HasHardwareCastV<kDev, PureDst, PureSrc>,
+                    "no cast path available. "
+                    "Need to provide `HardwareCastImpl` specialization.");
+    }
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CASTER_H_

--- a/src/caster.h
+++ b/src/caster.h
@@ -65,6 +65,19 @@ struct Caster {
   }
 };
 
+// Convenience wrapper for casting between two types.
+// Otherwise, need to write `Caster<kDev>::template Cast<Target>(val)` every
+// time.
+template <Device::Type kDev, typename Target, typename Source>
+inline Target CastTo(Source&& val) {
+  return Caster<kDev>::template Cast<Target>(std::forward<Source>(val));
+}
+
+template <Device::Type kDev, typename Source>
+inline float ToFloat(Source&& val) {
+  return Caster<kDev>::template Cast<float>(std::forward<Source>(val));
+}
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_CASTER_H_

--- a/src/cpu/caster_.h
+++ b/src/cpu/caster_.h
@@ -1,0 +1,31 @@
+#ifndef INFINI_CCL_CPU_CASTER__H_
+#define INFINI_CCL_CPU_CASTER__H_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kCpu, float, Float16> {
+  static float Apply(Float16 x) { return x.ToFloat(); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCpu, Float16, float> {
+  static Float16 Apply(float x) { return Float16::FromFloat(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCpu, float, BFloat16> {
+  static float Apply(BFloat16 x) { return x.ToFloat(); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kCpu, BFloat16, float> {
+  static BFloat16 Apply(float x) { return BFloat16::FromFloat(x); }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CPU_CASTER__H_

--- a/src/iluvatar/caster_.cuh
+++ b/src/iluvatar/caster_.cuh
@@ -3,8 +3,17 @@
 
 #include "caster.h"
 #include "data_type_.h"
+#include "traits.h"
 
 namespace infini::ccl {
+
+// Explicitly tell the trait system that host-side math on these types is
+// unworkable on Iluvatar.
+template <typename S, typename Op>
+struct SupportsOp<half, S, Op, void> : std::false_type {};
+
+template <typename S, typename Op>
+struct SupportsOp<__nv_bfloat16, S, Op, void> : std::false_type {};
 
 template <>
 struct HardwareCastImpl<Device::Type::kIluvatar, float, half> {

--- a/src/iluvatar/caster_.cuh
+++ b/src/iluvatar/caster_.cuh
@@ -1,0 +1,42 @@
+#ifndef INFINI_CCL_ILUVATAR_CASTER__CUH_
+#define INFINI_CCL_ILUVATAR_CASTER__CUH_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kIluvatar, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kIluvatar, float, __nv_bfloat16> {
+  __host__ __device__ static float Apply(__nv_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kIluvatar, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kIluvatar, __nv_bfloat16, float> {
+  __host__ __device__ static __nv_bfloat16 Apply(float x) {
+    return __float2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kIluvatar, __nv_bfloat16, double> {
+  __host__ __device__ static __nv_bfloat16 Apply(double x) {
+    return __double2bfloat16(x);
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_ILUVATAR_CASTER__CUH_

--- a/src/metax/caster_.cuh
+++ b/src/metax/caster_.cuh
@@ -1,0 +1,66 @@
+#ifndef INFINI_CCL_METAX_CASTER__CUH_
+#define INFINI_CCL_METAX_CASTER__CUH_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, float, __maca_bfloat16> {
+  __host__ __device__ static float Apply(__maca_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __maca_bfloat16, float> {
+  __host__ __device__ static __maca_bfloat16 Apply(float x) {
+    return __float2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __maca_bfloat16, int> {
+  __host__ __device__ static __maca_bfloat16 Apply(int x) {
+    return __int2bfloat16_rn(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __half, int> {
+  __host__ __device__ static __half Apply(int x) { return __int2half_rn(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __maca_bfloat16, double> {
+  __host__ __device__ static __maca_bfloat16 Apply(double x) {
+    return __double2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __half, double> {
+  __host__ __device__ static __half Apply(double x) { return __double2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMetax, __half, __maca_bfloat16> {
+  __host__ __device__ static __half Apply(__maca_bfloat16 x) {
+    return __float2half_rn(__bfloat162float(x));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_METAX_CASTER__CUH_

--- a/src/moore/caster_.cuh
+++ b/src/moore/caster_.cuh
@@ -1,0 +1,52 @@
+#ifndef INFINI_CCL_MOORE_CASTER__CUH_
+#define INFINI_CCL_MOORE_CASTER__CUH_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, float, __mt_bfloat16> {
+  __host__ __device__ static float Apply(__mt_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half_rn(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, __mt_bfloat16, float> {
+  __host__ __device__ static __mt_bfloat16 Apply(float x) {
+    return __float2bfloat16_rn(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, half, int> {
+  __host__ __device__ static half Apply(int x) { return __int2half_rn(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, __mt_bfloat16, double> {
+  __host__ __device__ static __mt_bfloat16 Apply(double x) {
+    return __double2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kMoore, half, double> {
+  __host__ __device__ static half Apply(double x) { return __double2half(x); }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_MOORE_CASTER__CUH_

--- a/src/moore/caster_.cuh
+++ b/src/moore/caster_.cuh
@@ -6,6 +6,14 @@
 
 namespace infini::ccl {
 
+// Explicitly tell the trait system that host-side math on these types is
+// unworkable on Moore.
+template <typename S, typename Op>
+struct SupportsOp<half, S, Op, void> : std::false_type {};
+
+template <typename S, typename Op>
+struct SupportsOp<__mt_bfloat16, S, Op, void> : std::false_type {};
+
 template <>
 struct HardwareCastImpl<Device::Type::kMoore, float, half> {
   __host__ __device__ static float Apply(half x) { return __half2float(x); }

--- a/src/nvidia/caster_.cuh
+++ b/src/nvidia/caster_.cuh
@@ -1,0 +1,64 @@
+#ifndef INFINI_CCL_NVIDIA_CASTER__CUH_
+#define INFINI_CCL_NVIDIA_CASTER__CUH_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, float, __nv_bfloat16> {
+  __host__ __device__ static float Apply(__nv_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, __nv_bfloat16, float> {
+  __host__ __device__ static __nv_bfloat16 Apply(float x) {
+    return __float2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, __nv_bfloat16, int> {
+  __host__ __device__ static __nv_bfloat16 Apply(int x) {
+    return __int2bfloat16_rn(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, half, int> {
+  __host__ __device__ static half Apply(int x) { return __int2half_rn(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, __nv_bfloat16, double> {
+  __host__ __device__ static __nv_bfloat16 Apply(double x) {
+    return __double2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, half, double> {
+  __host__ __device__ static half Apply(double x) { return __double2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kNvidia, half, __nv_bfloat16> {
+  __host__ __device__ static half Apply(__nv_bfloat16 x) { return __half(x); }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_NVIDIA_CASTER__CUH_

--- a/src/ompi/impl/all_reduce.h
+++ b/src/ompi/impl/all_reduce.h
@@ -4,6 +4,7 @@
 #include <type_traits>
 
 #include "base/all_reduce.h"
+#include "caster.h"
 #include "communicator.h"
 #include "dispatcher.h"
 #include "logging.h"
@@ -66,15 +67,13 @@ class AllReduceImpl<BackendType::kOmpi, device_type> {
 
         // Simply do the averaging on the CPU before the H2D copy.
         for (size_t i = 0; i < count; ++i) {
-          // TODO(lzm): should later use the unified `Cast` function instead of
-          // static_cast to support CPU custom types.
           if constexpr (std::is_integral_v<T>) {
             // Scale in floating point first; casting `scale` to an integer
             // type would truncate it to `0` and zero out the result.
-            typed_buf[i] =
-                static_cast<T>(static_cast<double>(typed_buf[i]) * scale);
+            typed_buf[i] = Caster<kDev>::template Cast<T>(
+                Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
           } else {
-            typed_buf[i] *= static_cast<T>(scale);
+            typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
           }
         }
       });

--- a/src/ompi/impl/all_reduce.h
+++ b/src/ompi/impl/all_reduce.h
@@ -70,10 +70,14 @@ class AllReduceImpl<BackendType::kOmpi, device_type> {
           if constexpr (std::is_integral_v<T>) {
             // Scale in floating point first; casting `scale` to an integer
             // type would truncate it to `0` and zero out the result.
-            typed_buf[i] = Caster<kDev>::template Cast<T>(
-                Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
+            typed_buf[i] =
+                CastTo<kDev, T>(CastTo<kDev, double>(typed_buf[i]) * scale);
+          } else if constexpr (SupportsOpValue<T, decltype(scale),
+                                               MulAssignOp>) {
+            typed_buf[i] *= scale;
           } else {
-            typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
+            float f_val = ToFloat<kDev>(typed_buf[i]) * scale;
+            typed_buf[i] = CastTo<kDev, T>(f_val);
           }
         }
       });

--- a/src/ompi/impl/reduce.h
+++ b/src/ompi/impl/reduce.h
@@ -79,10 +79,14 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
             if constexpr (std::is_integral_v<T>) {
               // Scale in floating point first; casting `scale` to an integer
               // type would truncate it to `0` and zero out the result.
-              typed_buf[i] = Caster<kDev>::template Cast<T>(
-                  Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
+              typed_buf[i] =
+                  CastTo<kDev, T>(CastTo<kDev, double>(typed_buf[i]) * scale);
+            } else if constexpr (SupportsOpValue<T, decltype(scale),
+                                                 MulAssignOp>) {
+              typed_buf[i] *= scale;
             } else {
-              typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
+              float f_val = ToFloat<kDev>(typed_buf[i]) * scale;
+              typed_buf[i] = CastTo<kDev, T>(f_val);
             }
           }
         });

--- a/src/ompi/impl/reduce.h
+++ b/src/ompi/impl/reduce.h
@@ -76,15 +76,13 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
 
           // Simply do the averaging on the CPU before the H2D copy.
           for (size_t i = 0; i < count; ++i) {
-            // TODO(lzm): should later use the unified `Cast` function instead
-            // of `static_cast` to support CPU custom types.
             if constexpr (std::is_integral_v<T>) {
               // Scale in floating point first; casting `scale` to an integer
               // type would truncate it to `0` and zero out the result.
-              typed_buf[i] =
-                  static_cast<T>(static_cast<double>(typed_buf[i]) * scale);
+              typed_buf[i] = Caster<kDev>::template Cast<T>(
+                  Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
             } else {
-              typed_buf[i] *= static_cast<T>(scale);
+              typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
             }
           }
         });

--- a/src/ompi/impl/reduce_scatter.h
+++ b/src/ompi/impl/reduce_scatter.h
@@ -81,10 +81,14 @@ class ReduceScatterImpl<BackendType::kOmpi, device_type> {
           if constexpr (std::is_integral_v<T>) {
             // Scale in floating point first; casting `scale` to an integer
             // type would truncate it to `0` and zero out the result.
-            typed_buf[i] = Caster<kDev>::template Cast<T>(
-                Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
+            typed_buf[i] =
+                CastTo<kDev, T>(CastTo<kDev, double>(typed_buf[i]) * scale);
+          } else if constexpr (SupportsOpValue<T, decltype(scale),
+                                               MulAssignOp>) {
+            typed_buf[i] *= scale;
           } else {
-            typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
+            float f_val = ToFloat<kDev>(typed_buf[i]) * scale;
+            typed_buf[i] = CastTo<kDev, T>(f_val);
           }
         }
       });

--- a/src/ompi/impl/reduce_scatter.h
+++ b/src/ompi/impl/reduce_scatter.h
@@ -78,15 +78,13 @@ class ReduceScatterImpl<BackendType::kOmpi, device_type> {
 
         // Simply do the averaging on the CPU before the H2D copy.
         for (size_t i = 0; i < recv_count; ++i) {
-          // TODO(lzm): should later use the unified `Cast` function instead of
-          // static_cast to support CPU custom types.
           if constexpr (std::is_integral_v<T>) {
             // Scale in floating point first; casting `scale` to an integer
             // type would truncate it to `0` and zero out the result.
-            typed_buf[i] =
-                static_cast<T>(static_cast<double>(typed_buf[i]) * scale);
+            typed_buf[i] = Caster<kDev>::template Cast<T>(
+                Caster<kDev>::template Cast<double>(typed_buf[i]) * scale);
           } else {
-            typed_buf[i] *= static_cast<T>(scale);
+            typed_buf[i] *= Caster<kDev>::template Cast<T>(scale);
           }
         }
       });

--- a/src/traits.h
+++ b/src/traits.h
@@ -205,6 +205,54 @@ struct FilterList<Functor, std::tuple<Args...>, List<items...>> {
       typename Filter<Functor, std::tuple<Args...>, List<>, items...>::type;
 };
 
+// -----------------------------------------------------------------------------
+// Operator Expression Detection (SFINAE)
+// -----------------------------------------------------------------------------
+
+namespace detail {
+
+struct AddAssign {
+  template <typename T, typename S>
+  using apply_with_scale = decltype(std::declval<T&>() += std::declval<S>());
+};
+
+struct SubAssign {
+  template <typename T, typename S>
+  using apply_with_scale = decltype(std::declval<T&>() -= std::declval<S>());
+};
+
+struct MulAssign {
+  template <typename T, typename S>
+  using apply_with_scale = decltype(std::declval<T&>() *= std::declval<S>());
+};
+
+struct DivAssign {
+  template <typename T, typename S>
+  using apply_with_scale = decltype(std::declval<T&>() /= std::declval<S>());
+};
+
+}  // namespace detail
+
+using MulAssignOp = detail::MulAssign;
+using AddAssignOp = detail::AddAssign;
+using SubAssignOp = detail::SubAssign;
+using DivAssignOp = detail::DivAssign;
+
+// Check if a type natively supports a given mathematical, logical, or
+// relational expression. This allows dynamically querying type
+// capabilities and select the optimal path: either a fast, native hardware
+// instruction lane or a fallback conversion via bridge.
+template <typename T, typename S, typename Op, typename = void>
+struct SupportsOp : std::false_type {};
+
+template <typename T, typename S, typename Op>
+struct SupportsOp<T, S, Op,
+                  std::void_t<typename Op::template apply_with_scale<T, S>>>
+    : std::true_type {};
+
+template <typename T, typename S, typename Op>
+inline constexpr bool SupportsOpValue = SupportsOp<T, S, Op>::value;
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_TRAITS_H_


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR introduces a unified compile-time type-casting and capability evaluation framework across all currently supported devices.

Previously, performing reductions and scaling modifications within core MPI collectives (such as `AllReduce`, `Reduce`, and `ReduceScatter`) lacked a standardized approach for dealing with non-native host types (e.g., `half` and `bfloat16`).

This change introduces a generic `Caster` alongside a highly extensible SFINAE-driven expression detector (`SupportsOp`). Together, they allow collective reduction execution loops to automatically inspect type compatibility at compile time. They can now execute native, high-performance intrinsic paths where possible, while gracefully routing through transparent float-bridge emulation structures for platforms whose host toolchains do not support math on their device float types.


## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **Core Infrastructure & Type Utilities**
  - Added a generic `Caster` abstraction layer in `src/caster.h` to achieve a unified interface for data type conversions across all the platforms;
  - Implemented the SFINAE-driven expression reflection trait `SupportsOp` in `src/traits.h` to check operator support (e.g., `*=`, `+=`) dynamically at compile time across distinct type and scalar combinations;
  - Provided `ToFloat<kDev>()` and `CastTo<kDev, T>()` convenience shorthand wrappers to eliminate verbose template boilerplate;
  - Refactored the bridge file generation logic to dynamically discover, validate, and aggregate flexible backend-specific caster combinations.

- **Platform-Specific Hardware Cast Implementations**
  - Implemented specialized `HardwareCastImpl` variants for CPU, NVIDIA, Iluvatar, MetaX, Moore Threads (MThreads), and Cambricon backends;
  - Updated `data_type_.h` inside `src/cambricon/` to explicitly decouple fp16 and bf16 layouts structurally, eliminating underlying primitive collisions.

- **Collective Code Update**
  - Applied the integrated `SupportsOp` and unified casting paths to the reduce-related OpenMPI implementations including `all_reduce.h`, `reduce.h`, and `reduce_scatter.h`.

- **Platform Adjustments & Host Toolchain Fixes**
  - Added specialized template constraints for Iluvatar and Moore Threads (MThreads) headers to explicitly evaluate `SupportsOp` to false for `half` and `bfloat16` structures on the host CPU pass, bypassing device-only compilation restrictions;
  - Updated `AUTO_DETECT_DEVICES` matching logic within the NVIDIA driver mapping layer to specifically and safely bind to GPU card 0;
  - Added explicit configuration targets for compiling device code sequences cleanly on Iluvatar architectures.


## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH

## Performance Impact

- [x] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
**Performance Notes**
This PR is architectural. However, performance is optimization-preserved compared to naive casting workarounds because some platforms like NVIDIA maintain native 16-bit register execution layouts rather than being artificially forced through intermediate float translation bridges.

## Known Issues & Future Work
 - Extend the specialized operators within `detail` namespaces inside `traits.h` to support more operations, including relational comparison expressions (`LessThanOp`, `EqualityOp`) to cleanly back a type-safe unified path for `MIN` and `MAX` collective operations;
 - Native host-side reductions on CPU for `kFloat16` and `kBFloat16` data types are currently restricted. Full enablement requires future work to finalize base memory initialization routines, layout mapping allocations, and explicit host-side software arithmetic emulations.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**Note**: 
1. Since averge-reduction is primarily involved in this change, `all_reduce`, `reduce`, and `reduce_scatter` are set to `infinicclAvg` for the reduction operation type;
2. Due to the situation mentioned in **Known Issues & Future Work**, fp16 and bf16 calculations are not yet supported, but other native data types are supported and casting works as expected.

**CPU**:
[all_gather.log](https://github.com/user-attachments/files/29050742/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29050745/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29050746/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29050747/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29050748/gather.log)
[reduce.log](https://github.com/user-attachments/files/29050749/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29050751/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29050753/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29050756/send_recv.log)

**NVIDIA + MetaX**:
[send_recv.log](https://github.com/user-attachments/files/29050436/send_recv.log)
[all_gather.log](https://github.com/user-attachments/files/29050437/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29050438/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29050440/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29050441/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29050443/gather.log)
[reduce.log](https://github.com/user-attachments/files/29050444/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29050445/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29050446/scatter.log)

**Iluvatar**: 
[all_gather.log](https://github.com/user-attachments/files/29050490/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29050491/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29050495/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29050496/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29050497/gather.log)
[reduce.log](https://github.com/user-attachments/files/29050498/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29050499/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29050500/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29050503/send_recv.log)

**Moore Threads**: 
[all_gather.log](https://github.com/user-attachments/files/29050525/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29050527/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29050528/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29050531/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29050532/gather.log)
[reduce.log](https://github.com/user-attachments/files/29050533/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29050534/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29050536/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29050537/send_recv.log)

**Cambricon**: 
[all_gather.log](https://github.com/user-attachments/files/29050543/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29050544/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29050546/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29050548/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29050549/gather.log)
[reduce.log](https://github.com/user-attachments/files/29050550/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29050551/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29050553/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29050554/send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
