### PR TITLE
feat: introduce memory space detection and apply for MPI `Broadcast`

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -155,6 +155,11 @@ struct DevicePriority<Device::Type::kCambricon> {
   static constexpr int value = 5;
 };
 
+enum class MemorySpace : uint8_t { kHost = 0, kDevice = 1, kUnknown };
+
+template <Device::Type kDev>
+MemorySpace GetMemorySpace(const void *ptr);
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_DEVICE_H_

--- a/src/metax/checks.h
+++ b/src/metax/checks.h
@@ -1,0 +1,34 @@
+#ifndef INFINI_CCL_METAX_CHECKS_H_
+#define INFINI_CCL_METAX_CHECKS_H_
+
+// clang-format off
+#include <mcr/mc_runtime.h>
+// clang-format on
+
+#include <iostream>
+
+#include "return_status_impl.h"
+
+#define INFINI_CHECK_MACA(result) \
+  ::infini::ccl::detail::CheckMacaImpl((result), __FILE__, __LINE__)
+
+namespace infini::ccl {
+
+namespace detail {
+
+inline ReturnStatus CheckMacaImpl(mcError_t maca_result, const char *file,
+                                  int line) {
+  if (maca_result != mcSuccess) {
+    mcGetLastError();
+    std::cerr << "MACA error code: " << maca_result << " at line " << line
+              << " in " << file << std::endl;
+    std::abort();
+  }
+  return ReturnStatus::kSuccess;
+}
+
+}  // namespace detail
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_METAX_CHECKS_H_

--- a/src/metax/device_.h
+++ b/src/metax/device_.h
@@ -1,12 +1,34 @@
 #ifndef INFINI_CCL_METAX_DEVICE__H_
 #define INFINI_CCL_METAX_DEVICE__H_
 
+// clang-format off
+#include <mcr/mc_runtime.h>
+// clang-format on
+
+#include "checks.h"
 #include "device.h"
 
 namespace infini::ccl {
 
 template <>
 struct DeviceEnabled<Device::Type::kMetax> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kMetax>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  mcPointerAttribute_t attr;
+  INFINI_CHECK_MACA(mcPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == mcMemoryTypeDevice || attr.type == mcMemoryTypeManaged ||
+      attr.type == mcMemoryTypeArray) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
 
 }  // namespace infini::ccl
 

--- a/src/nvidia/checks.h
+++ b/src/nvidia/checks.h
@@ -1,0 +1,32 @@
+#ifndef INFINI_CCL_NVIDIA_CHECKS_H_
+#define INFINI_CCL_NVIDIA_CHECKS_H_
+
+#include <cuda_runtime.h>
+
+#include <iostream>
+
+#include "return_status_impl.h"
+
+#define INFINI_CHECK_CUDA(result) \
+  ::infini::ccl::detail::CheckCudaImpl((result), __FILE__, __LINE__)
+
+namespace infini::ccl {
+
+namespace detail {
+
+inline ReturnStatus CheckCudaImpl(cudaError_t cuda_result, const char *file,
+                                  int line) {
+  if (cuda_result != cudaSuccess) {
+    cudaGetLastError();
+    std::cerr << "CUDA error code: " << cuda_result << " at line " << line
+              << " in " << file << std::endl;
+    std::abort();
+  }
+  return ReturnStatus::kSuccess;
+}
+
+}  // namespace detail
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_NVIDIA_CHECKS_H_

--- a/src/nvidia/device_.h
+++ b/src/nvidia/device_.h
@@ -1,12 +1,31 @@
 #ifndef INFINI_CCL_NVIDIA_DEVICE__H_
 #define INFINI_CCL_NVIDIA_DEVICE__H_
 
+#include <cuda_runtime.h>
+
+#include "checks.h"
 #include "device.h"
 
 namespace infini::ccl {
 
 template <>
 struct DeviceEnabled<Device::Type::kNvidia> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kNvidia>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  cudaPointerAttributes attr;
+  INFINI_CHECK_CUDA(cudaPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == cudaMemoryTypeDevice || attr.type == cudaMemoryTypeManaged) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
 
 }  // namespace infini::ccl
 

--- a/src/ompi/impl/broadcast.h
+++ b/src/ompi/impl/broadcast.h
@@ -25,6 +25,68 @@ class BroadcastImpl<BackendType::kOmpi, device_type> {
     using Rt = Runtime<kDev>;
 
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    size_t total_bytes = 0;
+    ReturnStatus status = ValidateArgs(inst, count, data_type, total_bytes);
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    const int rank = comm->rank();
+    const bool is_root = (rank == root);
+    const bool is_out_of_place = (send_buff != recv_buff);
+
+    // Resolve memory topology using the buffer guaranteed to be valid on all
+    // nodes.
+    const MemorySpace space = GetMemorySpace<kDev>(recv_buff);
+    const bool is_device = (space == MemorySpace::kDevice);
+    char *active_buf = nullptr;
+
+    if (is_device) {
+      active_buf = static_cast<char *>(std::malloc(total_bytes));
+      if (!active_buf) {
+        LOG("Failed to allocate host buffer for `Broadcast` staging.");
+        return ReturnStatus::kSystemError;
+      }
+
+      if (is_root) {
+        CHECK_STATUS(Rt, Rt::Memcpy(active_buf, send_buff, total_bytes,
+                                    Rt::MemcpyDeviceToHost));
+        CHECK_STATUS(Rt,
+                     Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
+      }
+    } else {
+      if (is_root && is_out_of_place && recv_buff != nullptr) {
+        std::memcpy(recv_buff, send_buff, total_bytes);
+      }
+      active_buf = static_cast<char *>(recv_buff);
+    }
+
+    size_t offset = 0;
+    constexpr size_t kMaxMpiCount =
+        static_cast<size_t>(std::numeric_limits<int>::max());
+
+    while (offset < total_bytes) {
+      size_t chunk = std::min(total_bytes - offset, kMaxMpiCount);
+      INFINI_CHECK_MPI(MPI_Bcast(active_buf + offset, static_cast<int>(chunk),
+                                 MPI_BYTE, root, inst->handle));
+      offset += chunk;
+    }
+
+    if (is_device) {
+      if (!is_root || is_out_of_place) {
+        CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, active_buf, total_bytes,
+                                    Rt::MemcpyHostToDevice));
+      }
+      std::free(active_buf);
+    }
+
+    return ReturnStatus::kSuccess;
+  }
+
+ private:
+  static ReturnStatus ValidateArgs(const OmpiInstance *inst, size_t count,
+                                   DataType data_type,
+                                   size_t &out_total_bytes) {
     if (!inst || inst->handle == MPI_COMM_NULL) {
       LOG("Invalid OpenMPI communicator instance for Broadcast.");
       return ReturnStatus::kInternalError;
@@ -36,37 +98,8 @@ class BroadcastImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kInvalidArgument;
     }
 
-    size_t total_bytes = count * type_size;
-    void *host_buf = std::malloc(total_bytes);
-    if (!host_buf) {
-      LOG("Failed to allocate host buffer for Broadcast staging.");
-      return ReturnStatus::kSystemError;
-    }
+    out_total_bytes = count * type_size;
 
-    if (comm->rank() == root) {
-      CHECK_STATUS(Rt, Rt::Memcpy(host_buf, send_buff, total_bytes,
-                                  Rt::MemcpyDeviceToHost));
-      CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
-    }
-
-    auto *bytes = static_cast<char *>(host_buf);
-    size_t offset = 0;
-    constexpr size_t kMaxMpiCount =
-        static_cast<size_t>(std::numeric_limits<int>::max());
-    while (offset < total_bytes) {
-      size_t chunk = total_bytes - offset;
-      if (chunk > kMaxMpiCount) {
-        chunk = kMaxMpiCount;
-      }
-      INFINI_CHECK_MPI(MPI_Bcast(bytes + offset, static_cast<int>(chunk),
-                                 MPI_BYTE, root, inst->handle));
-      offset += chunk;
-    }
-
-    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_buf, total_bytes,
-                                Rt::MemcpyHostToDevice));
-
-    std::free(host_buf);
     return ReturnStatus::kSuccess;
   }
 };


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary
This PR introduces a `MemorySpace` abstraction for identifying the memory properties of a given pointer and provides a platform-specific implementation for NVIDIA and MetaX. The new mechanism enables backends to distinguish between host and device memory at runtime and select the appropriate communication path.

As an initial application, the MPI implementation of `Broadcast` is updated to handle host and device buffers separately, allowing correct operation on both memory types.


## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **Memory Space Abstraction**
  - Add `MemorySpace` in `src/device.h` to represent the memory properties of a pointer;
  - Add the template interface `GetMemorySpace()` for platform-specific memory space detection;
  - Implement `GetMemorySpace()` for NVIDIA and MetaX in their corresponding "device_.h".

- **Error Checking Utilities**
  - Add `CheckCudaImpl()` and the convenience macro `INFINI_CHECK_CUDA` for CUDA API error checking in `src/nvidia/checks.h`;
  - Add `CheckMacaImpl()` and the convenience macro `INFINI_CHECK_MACA` for MACA API error checking in `src/metax/checks.h`.

- **MPI Broadcast Enhancement**
  - Update the MPI implementation of `Broadcast` to query the memory space of the communication buffer;
  - Handle host and device memory cases through separate execution paths.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
Performance impact is nuanced. In practice, no significant performance change is expected or observed.

For host-resident buffers, performance can improve substantially. Previously, users had to copy data to device memory before invoking `Broadcast`, after which the MPI implementation would internally transfer the data back to host memory. This introduced redundant data movement and unnecessary overhead. With memory-space awareness, host buffers can now be handled directly.

For device-resident buffers, the new logic introduces a small amount of additional processing to determine the memory space and select the appropriate execution path. However, this overhead is negligible compared to the communication cost and is not expected to have a measurable impact on performance. 


## Known Issues & Future Work
 - Device memory detection is currently implemented only for the NVIDIA and MetaX platforms;
 - Other collective operations should be migrated to use `MemorySpace` in future work;
 - Future enhancements may leverage device-aware MPI capabilities when available.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH


NV + MetaX:
[all_gather.log](https://github.com/user-attachments/files/29206104/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29206107/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29206108/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29206110/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29206112/gather.log)
[reduce.log](https://github.com/user-attachments/files/29206113/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29206115/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29206116/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29206117/send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- N/A- Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
