### PR TITLE
feat: provide CMake config package for `find_package(InfiniCCL)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(InfiniCCL LANGUAGES C CXX)
+project(InfiniCCL VERSION 0.1.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -379,11 +379,52 @@ file(CHMOD "${CMAKE_BINARY_DIR}/icclrun"
 # For Production/System Install
 include(GNUInstallDirs)
 
-install(TARGETS infiniccl DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# Install the library and record it in an export set so that downstream
+# projects can pull in `InfiniCCL::infiniccl` via `find_package(InfiniCCL)`.
+# All hardware/backend dependencies (CUDA, MPI, NCCL, ...) are linked PRIVATE
+# into this shared library, so they are NOT propagated as usage requirements.
+install(TARGETS infiniccl
+    EXPORT InfiniCCLTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/infiniccl)
 
 install(PROGRAMS scripts/icclrun.py DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME icclrun)
+
+# =========================================================
+# --- CMake Package Config (`find_package(InfiniCCL)`) ---
+# =========================================================
+set(INFINICCL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/InfiniCCL)
+
+# Export the imported target definition (`InfiniCCL::infiniccl`).
+install(EXPORT InfiniCCLTargets
+    FILE InfiniCCLTargets.cmake
+    NAMESPACE InfiniCCL::
+    DESTINATION ${INFINICCL_CMAKE_DIR}
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/InfiniCCLConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/InfiniCCLConfig.cmake"
+    INSTALL_DESTINATION ${INFINICCL_CMAKE_DIR}
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/InfiniCCLConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/InfiniCCLConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/InfiniCCLConfigVersion.cmake"
+    DESTINATION ${INFINICCL_CMAKE_DIR}
+)
 
 # Install the supporting logic to a private folder.
 set(ICCL_PRIVATE_LIB ${CMAKE_INSTALL_LIBDIR}/infiniccl)

--- a/README.md
+++ b/README.md
@@ -212,19 +212,45 @@ For all the options of the script, see:
 
 ### 2. Run a Custom User Program
 
-InfiniCCL does not yet provide a CMake config package (e.g., `find_package(InfiniCCL)`). Until then, the recommended way to link your own programs is to:
-
-1. **Set an environment variable** `INFINICCL_INSTALL` pointing to the InfiniCCL installation directory (e.g., `~/.infini` or a shared NFS path), and/or set the installed library path to `LD_LIBRARY_PATH`.  
-
-2. **Link directly** to the library, headers, and required dependencies (MPI, GPU runtime).
-
 Within the program, just include:
 
 ```cpp
 #include <infiniccl/infiniccl.h>
 ```
 
-### Minimal `CMakeLists.txt` Example
+#### Recommended: `find_package(InfiniCCL)`
+
+The simplest way to consume InfiniCCL is through `find_package`. This pulls in the
+imported target `InfiniCCL::infiniccl`, and there is no need to hand-wire include
+paths, the `.so`, or the RPATH yourself.
+
+```cmake
+cmake_minimum_required(VERSION 3.18)
+project(UserApp LANGUAGES CXX)
+
+find_package(InfiniCCL REQUIRED)
+
+add_executable(app main.cc)
+target_link_libraries(app PRIVATE InfiniCCL::infiniccl)
+```
+
+Point CMake at the InfiniCCL install prefix with any of the usual mechanisms:
+
+```bash
+cmake -B build -DCMAKE_PREFIX_PATH=/path/to/install   # e.g. ~/.infini
+# or:  -DInfiniCCL_ROOT=/path/to/install
+```
+
+There is no need to resolve hardware/backend dependencies (e.g., CUDA, MPI, NCCL, …)
+just to use InfiniCCL. However, if your own program calls those APIs directly
+(e.g. allocating GPU buffers or calling MPI), you must link them in addition to
+`InfiniCCL::infiniccl`.
+
+#### Alternative: manual linking
+
+If you prefer not to use the config package, set the environment variable
+`INFINICCL_INSTALL` to the InfiniCCL installation directory (e.g. `~/.infini` or
+a shared NFS path) and link directly to the library and headers:
 
 ```cmake
 cmake_minimum_required(VERSION 3.18)

--- a/cmake/InfiniCCLConfig.cmake.in
+++ b/cmake/InfiniCCLConfig.cmake.in
@@ -1,0 +1,18 @@
+@PACKAGE_INIT@
+
+# InfiniCCL CMake package configuration file.
+#
+# Provides the imported target:
+#     InfiniCCL::infiniccl
+#
+# which carries the public include directory and the location of
+# `libinfiniccl`. All hardware/backend dependencies (CUDA, MPI, NCCL, ...)
+# are linked PRIVATE into the shared library, so consumers do not need to
+# resolve them just to use InfiniCCL. The `find_dependency` hooks below are
+# intentionally left as a guarded extension point for future builds that may
+# expose such dependencies through the public interface.
+include(CMakeFindDependencyMacro)
+
+include("${CMAKE_CURRENT_LIST_DIR}/InfiniCCLTargets.cmake")
+
+check_required_components(InfiniCCL)


### PR DESCRIPTION
<!-- PR TITLE (paste into the GitHub title field): feat: provide CMake config package for `find_package(InfiniCCL)` -->
## Summary

InfiniCCL previously shipped no CMake config package, so downstream projects had to wire the integration by hand: set an `INFINICCL_INSTALL` environment variable, add `${INFINICCL_INSTALL}/include` manually, link the absolute path to `libinfiniccl.so`, and hand-set `INSTALL_RPATH`.

This PR makes InfiniCCL installable as a first-class CMake package. After `cmake --install`, downstream projects consume it with `find_package(InfiniCCL REQUIRED)` and link the imported target `InfiniCCL::infiniccl`, which already carries the public include directory, the library location, and the runtime search path. All hardware/backend dependencies (CUDA, MPI, NCCL, ...) are linked `PRIVATE` into the shared library, so they are intentionally not propagated as usage requirements — consumers do not need to resolve them just to use InfiniCCL. The change is purely additive and non-breaking: the installed `libinfiniccl.so` and headers are unchanged; only export/packaging metadata is added, and the manual-linking path is retained in `README.md` as an alternative.

## Changes

- **Packaging / export (`CMakeLists.txt`)**
  - Add a project version (`project(InfiniCCL VERSION 0.1.0 ...)`) so a package version file can be generated.
  - Record the `infiniccl` target in an export set: `install(TARGETS infiniccl EXPORT InfiniCCLTargets ...)` with explicit `LIBRARY` / `ARCHIVE` / `RUNTIME` destinations.
  - Generate and install `InfiniCCLConfig.cmake` and `InfiniCCLConfigVersion.cmake` via `CMakePackageConfigHelpers` (`configure_package_config_file` + `write_basic_package_version_file`, `COMPATIBILITY SameMajorVersion`).
  - Install the export set as `InfiniCCLTargets.cmake` under `${CMAKE_INSTALL_LIBDIR}/cmake/InfiniCCL` with namespace `InfiniCCL::`.
- **Config template (`cmake/InfiniCCLConfig.cmake.in`)**
  - New minimal package config: `@PACKAGE_INIT@`, include the generated targets file, then `check_required_components(InfiniCCL)`.
  - No `find_dependency(...)` calls — the backend libraries are `PRIVATE` to the shared library; the `CMakeFindDependencyMacro` include is kept as a guarded extension point for any future build that exposes such a dependency through the public interface.
- **Documentation (`README.md`)**
  - Rewrite the "Run a Custom User Program" section to present `find_package(InfiniCCL)` as the recommended approach (with `-DCMAKE_PREFIX_PATH` / `-DInfiniCCL_ROOT` hints), keeping the existing manual-linking method as a documented alternative.

## Platform and Backend Affected

This is a build-system / packaging change. It touches no device-specific code (`src/<device>/`) and no backend implementation (`src/ompi/`, ...), and it does not change the compiled `libinfiniccl.so` — only how it is exported and installed. No platform- or backend-specific behavior is affected, so no box below is checked.

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

The change only adds install/export metadata; no compiled code or runtime path is altered, and the floating-point reduction paths are byte-for-byte unchanged. For reference, the heterogeneous run (8 ranks, 4 MB per rank, `Float32 + Sum`) measured `AllReduce` at 9.979 ms (0.69 GB/s bus BW) and in-place `Broadcast` at 2.131 ms, matching the pre-change baseline.

## Known Issues & Future Work

- The package version is pinned to `0.1.0` as a starting point; there was no prior versioning scheme. It should be bumped as the public surface evolves.
- The config is intentionally minimal and assumes the shared-library build: it emits no `find_dependency(...)` because CUDA / MPI / NCCL are linked `PRIVATE`. A future static-library build (or a public interface that exposes those dependencies) would need to add the corresponding `find_dependency(...)` calls in `cmake/InfiniCCLConfig.cmake.in`.
- For an installed consumer binary, CMake does not automatically add the InfiniCCL library directory to its install RPATH. Build-tree consumers (the usual `icclrun` flow) get it automatically; an installed consumer should set `CMAKE_INSTALL_RPATH_USE_LINK_PATH` or its own RPATH.

## Test Results

Validated on a NVIDIA–MetaX heterogeneous cluster over the OpenMPI backend via `scripts/run_examples.py` (run `run_20260626_060706`):

- `server`: NVIDIA, 4 GPUs, ranks 0–3 (built with Devices `[cpu, nvidia]`, Backends `[ompi]`).
- `test`: MetaX, 4 GPUs, ranks 4–7 (built with Devices `[cpu, metax]`, Backends `[ompi]`).
- 8 ranks total; message size 1,048,576 `float32` (4 MB) per rank; 2 warm-up + 20 profiled iterations.
- All bundled example programs report `Correct: YES` (`broadcast` covers all 3 scenarios: out-of-place, in-place, legacy `Bcast`).

Because this is a build-system change that does not alter the compiled library or any collective's behavior, the full example regression above is the relevant signal: it confirms the rebuilt library and every collective still pass on real heterogeneous hardware. The new package itself was additionally verified by a downstream consumer: a clean-prefix `cmake --install` emits the four `lib/cmake/InfiniCCL/*.cmake` files, and a minimal program using only `find_package(InfiniCCL REQUIRED)` + `target_link_libraries(app PRIVATE InfiniCCL::infiniccl)` configures, builds (header resolved transitively, RPATH auto-set), and runs `Correct: YES`.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

[all_gather.log](https://github.com/user-attachments/files/29369856/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29369859/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29369864/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29369868/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29369871/gather.log)
[reduce.log](https://github.com/user-attachments/files/29369872/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29369875/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29369877/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29369881/send_recv.log)



---

## Checklist

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- N/A- Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly. <!-- No C/C++ files changed; only `CMakeLists.txt`, `cmake/InfiniCCLConfig.cmake.in`, `README.md`. -->
- N/A- `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- N/A- **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- N/A- Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** between members (functions _and_ variables) within a class (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
