### PR TITLE
feat: support `MemorySpace` on Iluvatar, Moore Threads, and Cambricon 

### DIFF
--- a/src/cambricon/checks.h
+++ b/src/cambricon/checks.h
@@ -1,0 +1,32 @@
+#ifndef INFINI_CCL_CAMBRICON_CHECKS_H_
+#define INFINI_CCL_CAMBRICON_CHECKS_H_
+
+#include <cnrt.h>
+
+#include <iostream>
+
+#include "return_status_impl.h"
+
+#define INFINI_CHECK_CNRT(result) \
+  ::infini::ccl::detail::CheckCnrtImpl((result), __FILE__, __LINE__)
+
+namespace infini::ccl {
+
+namespace detail {
+
+inline ReturnStatus CheckCnrtImpl(cnrtRet_t cnrt_result, const char *file,
+                                  int line) {
+  if (cnrt_result != cnrtSuccess) {
+    cnrtGetLastError();
+    std::cerr << "CNRT error code: " << cnrt_result << " at line " << line
+              << " in " << file << std::endl;
+    std::abort();
+  }
+  return ReturnStatus::kSuccess;
+}
+
+}  // namespace detail
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_CAMBRICON_CHECKS_H_

--- a/src/cambricon/device_.h
+++ b/src/cambricon/device_.h
@@ -1,12 +1,31 @@
 #ifndef INFINI_CCL_CAMBRICON_DEVICE__H_
 #define INFINI_CCL_CAMBRICON_DEVICE__H_
 
+#include <cnrt.h>
+
+#include "checks.h"
 #include "device.h"
 
 namespace infini::ccl {
 
 template <>
 struct DeviceEnabled<Device::Type::kCambricon> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kCambricon>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  cnrtPointerAttributes_t attr;
+  INFINI_CHECK_CNRT(cnrtPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == cnrtMemTypeDevice) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
 
 }  // namespace infini::ccl
 

--- a/src/cuda/checks.h
+++ b/src/cuda/checks.h
@@ -1,5 +1,5 @@
-#ifndef INFINI_CCL_NVIDIA_CHECKS_H_
-#define INFINI_CCL_NVIDIA_CHECKS_H_
+#ifndef INFINI_CCL_CUDA_CHECKS_H_
+#define INFINI_CCL_CUDA_CHECKS_H_
 
 #include <cuda_runtime.h>
 
@@ -29,4 +29,4 @@ inline ReturnStatus CheckCudaImpl(cudaError_t cuda_result, const char *file,
 
 }  // namespace infini::ccl
 
-#endif  // INFINI_CCL_NVIDIA_CHECKS_H_
+#endif  // INFINI_CCL_CUDA_CHECKS_H_

--- a/src/iluvatar/device_.h
+++ b/src/iluvatar/device_.h
@@ -1,12 +1,31 @@
 #ifndef INFINI_CCL_ILUVATAR_DEVICE__H_
 #define INFINI_CCL_ILUVATAR_DEVICE__H_
 
+#include <cuda_runtime.h>
+
+#include "cuda/checks.h"
 #include "device.h"
 
 namespace infini::ccl {
 
 template <>
 struct DeviceEnabled<Device::Type::kIluvatar> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kIluvatar>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  cudaPointerAttributes attr;
+  INFINI_CHECK_CUDA(cudaPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == cudaMemoryTypeDevice || attr.type == cudaMemoryTypeManaged) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
 
 }  // namespace infini::ccl
 

--- a/src/moore/checks.h
+++ b/src/moore/checks.h
@@ -1,0 +1,32 @@
+#ifndef INFINI_CCL_MOORE_CHECKS_H_
+#define INFINI_CCL_MOORE_CHECKS_H_
+
+#include <musa_runtime.h>
+
+#include <iostream>
+
+#include "return_status_impl.h"
+
+#define INFINI_CHECK_MUSA(result) \
+  ::infini::ccl::detail::CheckMusaImpl((result), __FILE__, __LINE__)
+
+namespace infini::ccl {
+
+namespace detail {
+
+inline ReturnStatus CheckMusaImpl(musaError_t musa_result, const char *file,
+                                  int line) {
+  if (musa_result != musaSuccess) {
+    musaGetLastError();
+    std::cerr << "MUSA error code: " << musa_result << " at line " << line
+              << " in " << file << std::endl;
+    std::abort();
+  }
+  return ReturnStatus::kSuccess;
+}
+
+}  // namespace detail
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_MOORE_CHECKS_H_

--- a/src/moore/device_.h
+++ b/src/moore/device_.h
@@ -1,12 +1,31 @@
 #ifndef INFINI_CCL_MOORE_DEVICE__H_
 #define INFINI_CCL_MOORE_DEVICE__H_
 
+#include <musa_runtime.h>
+
+#include "checks.h"
 #include "device.h"
 
 namespace infini::ccl {
 
 template <>
 struct DeviceEnabled<Device::Type::kMoore> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kMoore>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  musaPointerAttributes attr;
+  INFINI_CHECK_MUSA(musaPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == musaMemoryTypeDevice || attr.type == musaMemoryTypeManaged) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
 
 }  // namespace infini::ccl
 

--- a/src/nvidia/device_.h
+++ b/src/nvidia/device_.h
@@ -3,7 +3,7 @@
 
 #include <cuda_runtime.h>
 
-#include "checks.h"
+#include "cuda/checks.h"
 #include "device.h"
 
 namespace infini::ccl {


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary
This PR extends `MemorySpace` support to the remaining currently supported device platforms (i.e., Cambricon, Moore Threads, and Iluvatar). To facilitate code reuse across these platforms, common CUDA-style runtime checking utilities are refactored into a shared `cuda/checks.h` header.


## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **`MemorySpace` Support**
  - Add `MemorySpace` support for Cambricon, Iluvatar, and Moore Threads devices.

- **Code Refactoring**
  - Move the previous NVIDIA-specific `nvidia/checks.h` to `cuda/checks.h`.
  - Reuse common CUDA-style runtime checking utilities across CUDA-like platforms, currently only used by NVIDIA and Iluvatar.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [ ] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU

### Backend

- N/A- OpenMPI
- N/A- MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work
 - Further opportunities exist to consolidate CUDA-like platform utilities and reduce backend-specific duplication.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**NV+MetaX:**
[all_gather.log](https://github.com/user-attachments/files/29365940/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29365941/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29365942/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29365943/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29365944/gather.log)
[reduce.log](https://github.com/user-attachments/files/29365945/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29365937/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29365938/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29365939/send_recv.log)

**Iluvatar:**
[all_gather.log](https://github.com/user-attachments/files/29365957/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29365958/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29365959/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29365960/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29365961/gather.log)
[reduce.log](https://github.com/user-attachments/files/29365962/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29365965/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29365966/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29365967/send_recv.log)

**Moore Threads:**
[all_gather.log](https://github.com/user-attachments/files/29365979/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29365980/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29365981/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29365983/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29365984/gather.log)
[reduce.log](https://github.com/user-attachments/files/29365985/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29365986/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29365987/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29365988/send_recv.log)

**Cambricon:**
[all_gather.log](https://github.com/user-attachments/files/29365994/all_gather.log)
[all_reduce.log](https://github.com/user-attachments/files/29365996/all_reduce.log)
[all_to_all.log](https://github.com/user-attachments/files/29366000/all_to_all.log)
[broadcast.log](https://github.com/user-attachments/files/29366002/broadcast.log)
[gather.log](https://github.com/user-attachments/files/29366003/gather.log)
[reduce.log](https://github.com/user-attachments/files/29366004/reduce.log)
[reduce_scatter.log](https://github.com/user-attachments/files/29366006/reduce_scatter.log)
[scatter.log](https://github.com/user-attachments/files/29366007/scatter.log)
[send_recv.log](https://github.com/user-attachments/files/29366008/send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
