### PR TITLE
build: refresh InfiniCCL environment exports

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,19 @@ DEFAULT_INSTALL_PATH="$HOME/.infini"
 INSTALL_PREFIX="${INSTALL_PREFIX:-$DEFAULT_INSTALL_PATH}"
 BUILD_DIR="${BUILD_DIR:-build}"
 
+update_bashrc_export() {
+    local name="$1"
+    local value="$2"
+    local escaped_value
+    escaped_value=$(printf '%s' "$value" | sed 's/[\\&|]/\\&/g')
+
+    if grep -q "^export ${name}=" "$HOME/.bashrc"; then
+        sed -i "s|^export ${name}=.*|export ${name}=\"$escaped_value\"|" "$HOME/.bashrc"
+    else
+        echo "export ${name}=\"$value\"" >> "$HOME/.bashrc"
+    fi
+}
+
 echo "========================================================"
 echo " Starting InfiniCCL Build"
 echo " Build Directory:  $BUILD_DIR"
@@ -46,19 +59,14 @@ if ! grep -q "$BIN_PATH" "$HOME/.bashrc"; then
     echo "--> Updating ~/.bashrc with InfiniCCL paths..."
     echo "" >> "$HOME/.bashrc"
     echo "# InfiniCCL Paths" >> "$HOME/.bashrc"
-    echo "export INFINICCL_ROOT=\"$PROJECT_ROOT\"" >> "$HOME/.bashrc"
-    echo "export InfiniCCL_ROOT=\"$PROJECT_ROOT\"" >> "$HOME/.bashrc"
     echo "export PATH=\"$BIN_PATH:\$PATH\"" >> "$HOME/.bashrc"
     echo "export LD_LIBRARY_PATH=\"$LIB_PATH:\$LD_LIBRARY_PATH\"" >> "$HOME/.bashrc"
     echo "Successfully updated ~/.bashrc. Please run 'source ~/.bashrc' or restart your terminal."
 fi
 
-# Update `INFINICCL_ROOT` if it already exists but points to a different project.
-if [[ -n "${INFINICCL_ROOT:-}" && "$INFINICCL_ROOT" != "$PROJECT_ROOT" ]]; then
-    echo "--> Updating INFINICCL_ROOT in ~/.bashrc..."
-    sed -i "s|^export INFINICCL_ROOT=.*|export INFINICCL_ROOT=\"$PROJECT_ROOT\"|" "$HOME/.bashrc"
-    sed -i "s|^export InfiniCCL_ROOT=.*|export InfiniCCL_ROOT=\"$PROJECT_ROOT\"|" "$HOME/.bashrc"
-fi
+echo "--> Updating INFINICCL_ROOT in ~/.bashrc..."
+update_bashrc_export "INFINICCL_ROOT" "$PROJECT_ROOT"
+update_bashrc_export "InfiniCCL_ROOT" "$PROJECT_ROOT"
 
 echo "========================================================"
 echo " Build and Install Finished!"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,23 +34,30 @@ cmake --install "$BUILD_DIR"
 # Handle Environment Variables (`PATH` and `LD_LIBRARY_PATH`)
 BIN_PATH="$INSTALL_PREFIX/bin"
 LIB_PATH="$INSTALL_PREFIX/lib"
-INFINICCL_ROOT="$PROJECT_ROOT"
 
 # Check if `PATH` already contains the `bin` path.
 if [[ ":$PATH:" != *":$BIN_PATH:"* ]]; then
     echo "--> Adding $BIN_PATH to current session PATH..."
     export PATH="$BIN_PATH:$PATH"
-    
-    # Optional: Automatically update `~/.bashrc` for the user.
-    if ! grep -q "$BIN_PATH" "$HOME/.bashrc"; then
-        echo "--> Updating ~/.bashrc with InfiniCCL paths..."
-        echo "" >> "$HOME/.bashrc"
-        echo "# InfiniCCL Paths" >> "$HOME/.bashrc"
-        echo "export INFINICCL_ROOT=\"$INFINICCL_ROOT\"" >> "$HOME/.bashrc"
-        echo "export PATH=\"$BIN_PATH:\$PATH\"" >> "$HOME/.bashrc"
-        echo "export LD_LIBRARY_PATH=\"$LIB_PATH:\$LD_LIBRARY_PATH\"" >> "$HOME/.bashrc"
-        echo "Successfully updated ~/.bashrc. Please run 'source ~/.bashrc' or restart your terminal."
-    fi
+fi
+
+# Automatically update `~/.bashrc` for the user.
+if ! grep -q "$BIN_PATH" "$HOME/.bashrc"; then
+    echo "--> Updating ~/.bashrc with InfiniCCL paths..."
+    echo "" >> "$HOME/.bashrc"
+    echo "# InfiniCCL Paths" >> "$HOME/.bashrc"
+    echo "export INFINICCL_ROOT=\"$PROJECT_ROOT\"" >> "$HOME/.bashrc"
+    echo "export InfiniCCL_ROOT=\"$PROJECT_ROOT\"" >> "$HOME/.bashrc"
+    echo "export PATH=\"$BIN_PATH:\$PATH\"" >> "$HOME/.bashrc"
+    echo "export LD_LIBRARY_PATH=\"$LIB_PATH:\$LD_LIBRARY_PATH\"" >> "$HOME/.bashrc"
+    echo "Successfully updated ~/.bashrc. Please run 'source ~/.bashrc' or restart your terminal."
+fi
+
+# Update `INFINICCL_ROOT` if it already exists but points to a different project.
+if [[ -n "${INFINICCL_ROOT:-}" && "$INFINICCL_ROOT" != "$PROJECT_ROOT" ]]; then
+    echo "--> Updating INFINICCL_ROOT in ~/.bashrc..."
+    sed -i "s|^export INFINICCL_ROOT=.*|export INFINICCL_ROOT=\"$PROJECT_ROOT\"|" "$HOME/.bashrc"
+    sed -i "s|^export InfiniCCL_ROOT=.*|export InfiniCCL_ROOT=\"$PROJECT_ROOT\"|" "$HOME/.bashrc"
 fi
 
 echo "========================================================"
@@ -59,5 +66,5 @@ echo " Binaries:  $BIN_PATH"
 echo " Libraries: $LIB_PATH"
 echo " Headers:   $INSTALL_PREFIX/include"
 echo "========================================================"
-echo " NOTE: If this is your first install, run: source ~/.bashrc"
+echo " NOTE: If this is your first install or there's a path update, run: source ~/.bashrc"
 echo " You can now run 'icclrun' from anywhere."


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR updates `scripts/build.sh` to export both `INFINICCL_ROOT` and `InfiniCCL_ROOT` in `~/.bashrc`. The new `InfiniCCL_ROOT` export matches CMake's package-root variable convention for `find_package(InfiniCCL)`, avoiding reliance on the all-uppercase `INFINICCL_ROOT` variable that can trigger CMP0144 developer warnings in downstream CMake projects.

## Changes

- **CMake Package-Root Compatibility**
  - Add the `InfiniCCL_ROOT` export to `~/.bashrc` so downstream `find_package(InfiniCCL)` usage has a CMake-compatible package-root variable;
  - Avoid depending only on the all-uppercase `INFINICCL_ROOT`, which CMake may ignore for `find_package(InfiniCCL)` under CMP0144 compatibility behavior.

- **Environment Setup**
  - Add a helper to update existing `~/.bashrc` exports or append them when missing;
  - Refresh both root exports from the current checkout path;
  - Move `.bashrc` updates out of the current-session `PATH` check so root variables are maintained even when `PATH` already contains the install bin directory.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- N/A- CPU
- N/A- NVIDIA GPU
- N/A- Iluvatar GPU
- N/A- MetaX GPU
- N/A- Moore Threads GPU
- N/A- Cambricon MLU

### Backend

- N/A- OpenMPI
- N/A- MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A. This PR only changes build/install environment setup in `scripts/build.sh`.

## Known Issues & Future Work

- N/A.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

[mpi_all_gather.log](https://github.com/user-attachments/files/29585724/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/29585725/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/29585726/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/29585727/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/29585728/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/29585729/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/29585731/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/29585732/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/29585734/mpi_send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- N/A- Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- N/A- Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- N/A- `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- N/A- **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- N/A- Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- N/A- Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- N/A- Type hints are added / kept consistent with the surrounding code.

### Testing

- [ ] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
