### PR TITLE
feat: support node-specific launcher directories

### DIFF
--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -39,13 +39,15 @@ backend_env:
 nodes:
   - ip: "localhost"           # IP address or hostname.
     user: "node1_username"    # [OPTIONAL] Overrides `common_user` for this node.
+    dir: "path/to/project"    # [OPTIONAL] Node-specific path to the project, overrides `common_dir`.
     type: "nvidia"            # Architecture type.
     slots: 8                  # Number of GPUs/Processes to run on this node.
     cmake_flags: "-D..."      # [OPTIONAL] Node-specific CMake options (e.g., `-DUSE_CUDA=ON`).
     backend_env:              # [OPTIONAL] Node-specific environment variables.
       NODE1_ENV_VAR1: "value1"
 
+  # Add more nodes as needed, following the same structure.
   - ip: ""
-    type: "metax"
+    type: "..."
     slots: 8
     cmake_flags: "-D..."

--- a/scripts/backends/mpi_base.py
+++ b/scripts/backends/mpi_base.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 
 class BaseMpiBackend:
@@ -39,6 +40,30 @@ class BaseMpiBackend:
 
         if not launcher_script:
             launcher_script = launcher_obj.ensure_launcher_exists()
+
+            # If any node-specific `dir` is given, stage the generated wrapper at one identical '/tmp' path on all nodes.
+            # Node-specific dirs may differ, but 'mpirun' can launch only one script path.
+            if any("dir" in node for node in config["nodes"]):
+                remote_launcher = f"/tmp/infiniccl_{os.path.basename(launcher_script)}"
+                subprocess.run(["cp", launcher_script, remote_launcher], check=True)
+                os.chmod(remote_launcher, 0o755)
+
+                for node in config["nodes"]:
+                    user = node.get("user", config.get("common_user", "root"))
+
+                    if launcher_obj._is_local(node["ip"]):
+                        continue
+
+                    subprocess.run(
+                        [
+                            "scp",
+                            launcher_script,
+                            f"{user}@{node['ip']}:{remote_launcher}",
+                        ],
+                        check=True,
+                    )
+
+                launcher_script = remote_launcher
 
         # Fetch specific base runner flags (OMPI vs MPICH).
         cmd = self.get_base_mpi_args(hostfile_path, total_slots)

--- a/scripts/icclrun_logic.py
+++ b/scripts/icclrun_logic.py
@@ -1,10 +1,23 @@
 import os
+import re
 import socket
 import subprocess
 import sys
 from pathlib import Path
 
 import yaml
+
+PATH_LIKE = {"LD_LIBRARY_PATH", "PATH", "CPATH", "LIBRARY_PATH"}
+
+
+def _is_infiniccl_source_dir(path):
+    cmake_path = Path(path).expanduser() / "CMakeLists.txt"
+    try:
+        cmake_text = cmake_path.read_text(errors="ignore")
+    except OSError:
+        return False
+
+    return re.search(r"project\s*\(\s*InfiniCCL(?:\s|\))", cmake_text) is not None
 
 
 class ICCLLauncher:
@@ -24,13 +37,39 @@ class ICCLLauncher:
                 break
 
         if not self.config:
-            print("Error: cluster.yaml not found.")
+            print("Error: `cluster.yaml` not found.")
             sys.exit(1)
 
-        # Detect InfiniCCL Root
-        self.infiniccl_root = os.environ.get("INFINICCL_ROOT")
-        if not self.infiniccl_root:
-            script_dir = os.path.dirname(os.path.realpath(__file__))
+        # Detect the InfiniCCL source root. Prefer the configured tree
+        # checkout before environment variables, which may point at stale installs.
+        script_dir = os.path.dirname(os.path.realpath(__file__))
+        candidates = []
+        common_dir = self.config.get("common_dir")
+        if common_dir:
+            common_dir = os.path.expanduser(common_dir)
+            candidates.extend([common_dir])
+        candidates.extend(
+            root
+            for root in [
+                os.environ.get("INFINICCL_ROOT"),
+                os.environ.get("InfiniCCL_ROOT"),
+            ]
+            if root
+        )
+        candidates.extend(
+            [
+                os.path.join(script_dir, ".."),
+                os.path.join(script_dir, "../.."),
+                os.path.join(script_dir, "../../.."),
+            ]
+        )
+
+        for candidate in candidates:
+            root = os.path.abspath(os.path.expanduser(candidate))
+            if _is_infiniccl_source_dir(root):
+                self.infiniccl_root = root
+                break
+        else:
             self.infiniccl_root = os.path.abspath(os.path.join(script_dir, "../../.."))
 
     def _is_local(self, ip):
@@ -66,41 +105,55 @@ class ICCLLauncher:
             return False
 
     def orchestrate_build(self):
-        common_dir = self.config["common_dir"]
+        global_common_dir = self.config["common_dir"]
         infiniccl_root = self.infiniccl_root
-        is_internal = os.path.abspath(common_dir) == os.path.abspath(infiniccl_root)
-        base_install = self.config.get("install_dir", common_dir)
 
         for node in self.config["nodes"]:
+            node_common_dir = node.get("dir", global_common_dir)
+            node_is_local = self._is_local(node["ip"])
+            base_install = self.config.get("install_dir", node_common_dir)
+
             arch = node["type"]
             install_path = os.path.join(base_install, "install", arch)
             user_cmake_flags = node.get(
                 "cmake_flags", self.config.get("cmake_flags", "")
             )
 
-            # Build the library using YAML flags.
+            internal_cmd = (
+                f"mkdir -p {node_common_dir}/build/{arch} && cd {node_common_dir}/build/{arch} && "
+                f"cmake -DCMAKE_INSTALL_PREFIX={install_path} {user_cmake_flags} {node_common_dir} && "
+                f"make -j$(nproc) install"
+            )
             lib_cmd = (
                 f"mkdir -p {infiniccl_root}/build/{arch} && cd {infiniccl_root}/build/{arch} && "
                 f"cmake -DCMAKE_INSTALL_PREFIX={install_path} {user_cmake_flags} {infiniccl_root} && "
                 f"make -j$(nproc) install"
             )
+            app_cmd = (
+                f"export INFINICCL_INSTALL={install_path} && "
+                f"mkdir -p {node_common_dir}/build/{arch} && cd {node_common_dir}/build/{arch} && "
+                f"cmake {user_cmake_flags} {node_common_dir} && "
+                f"make -j$(nproc)"
+            )
+            external_cmd = f"{lib_cmd} && {app_cmd}"
 
-            if is_internal:
-                full_cmd = lib_cmd
-            else:
-                app_cmd = (
-                    f"export INFINICCL_INSTALL={install_path} && "
-                    f"mkdir -p {common_dir}/build/{arch} && cd {common_dir}/build/{arch} && "
-                    f"cmake {user_cmake_flags} {common_dir} && "
-                    f"make -j$(nproc)"
+            if node_is_local:
+                full_cmd = (
+                    internal_cmd
+                    if _is_infiniccl_source_dir(node_common_dir)
+                    else external_cmd
                 )
-                full_cmd = f"{lib_cmd} && {app_cmd}"
+            else:
+                full_cmd = (
+                    f'if grep -Eq "project[[:space:]]*\\([[:space:]]*InfiniCCL([[:space:]]|\\))" {node_common_dir}/CMakeLists.txt 2>/dev/null; '
+                    f"then {internal_cmd}; else {external_cmd}; fi"
+                )
 
             # Execute via SSH or locally.
             user = node.get("user", self.config.get("common_user", "root"))
             print(f"[*] Orchestrating {arch} on {node['ip']}...")
 
-            if self._is_local(node["ip"]):
+            if node_is_local:
                 subprocess.run(["bash", "-l", "-c", full_cmd], check=True)
             else:
                 subprocess.run(
@@ -111,22 +164,10 @@ class ICCLLauncher:
         return self.ensure_launcher_exists()
 
     def ensure_launcher_exists(self):
-        common_dir = Path(self.config["common_dir"]).expanduser().resolve()
-        wrapper_path = str(common_dir / "build" / "run_wrapper.sh")
+        global_common_dir = Path(self.config["common_dir"]).expanduser().resolve()
+        wrapper_path = str(global_common_dir / "build" / "run_wrapper.sh")
         os.makedirs(os.path.dirname(wrapper_path), exist_ok=True)
 
-        infiniccl_root_dir = Path(self.infiniccl_root).expanduser().resolve()
-        is_internal = common_dir == infiniccl_root_dir
-
-        base_install = (
-            Path(self.config.get("install_dir", self.config["common_dir"]))
-            .expanduser()
-            .resolve()
-        )
-
-        bin_sub = "examples/$1" if is_internal else "$1"
-
-        PATH_LIKE = {"LD_LIBRARY_PATH", "PATH", "CPATH", "LIBRARY_PATH"}
         global_env = self.config.get("backend_env", {})
 
         blocks = []
@@ -135,7 +176,23 @@ class ICCLLauncher:
         for node in self.config["nodes"]:
             ip_or_host = node["ip"]
             n_type = node["type"]
-            install_lib = base_install / "install" / n_type / "lib"
+
+            node_common_dir_str = node.get("dir", self.config["common_dir"])
+            node_is_local = self._is_local(ip_or_host)
+            node_common_dir = (
+                str(Path(node_common_dir_str).expanduser().resolve())
+                if node_is_local
+                else node_common_dir_str
+            )
+
+            base_install_str = self.config.get("install_dir", node_common_dir_str)
+            base_install = (
+                str(Path(base_install_str).expanduser().resolve())
+                if node_is_local
+                else base_install_str
+            )
+
+            install_lib = os.path.join(base_install, "install", n_type, "lib")
 
             resolved_ips = set()
 
@@ -174,15 +231,14 @@ class ICCLLauncher:
                     )
                     sys.exit(1)
 
-            node_env = node.get("backend_env", {}).copy()
+            node_env = node.get("backend_env", {})
+            merged_env = global_env.copy()
 
-            for concat_var in PATH_LIKE:
-                if concat_var in global_env and concat_var in node_env:
-                    node_env[concat_var] = (
-                        f"{node_env[concat_var]}:{global_env[concat_var]}"
-                    )
-
-            merged_env = {**global_env, **node_env}
+            for env_key, env_value in node_env.items():
+                if env_key in PATH_LIKE and env_key in merged_env:
+                    merged_env[env_key] = f"{env_value}:{merged_env[env_key]}"
+                else:
+                    merged_env[env_key] = env_value
 
             ip_conditions = [
                 f'[[ "$HOST_IPS" == *"{ip}"* ]]' for ip in sorted(resolved_ips)
@@ -191,8 +247,9 @@ class ICCLLauncher:
             condition = " || ".join(ip_conditions)
 
             export_lines = []
+            export_lines.append(f'INSTALL_LIB="$(expand_path "{install_lib}")"')
             export_lines.append(
-                f'export LD_LIBRARY_PATH="{install_lib}:${{LD_LIBRARY_PATH:-}}"'
+                'export LD_LIBRARY_PATH="$INSTALL_LIB:${LD_LIBRARY_PATH:-}"'
             )
 
             for k, v in merged_env.items():
@@ -202,6 +259,14 @@ class ICCLLauncher:
                 export_lines.append(f'export {k}="{v}"')
 
             export_lines.append(f'ARCH="{n_type}"')
+            export_lines.append(f'NODE_COMMON_DIR="$(expand_path "{node_common_dir}")"')
+            export_lines.append(
+                'if grep -Eq "project[[:space:]]*\\([[:space:]]*InfiniCCL([[:space:]]|\\))" "$NODE_COMMON_DIR/CMakeLists.txt" 2>/dev/null; then'
+            )
+            export_lines.append('    BIN_SUB="examples/$1"')
+            export_lines.append("else")
+            export_lines.append('    BIN_SUB="$1"')
+            export_lines.append("fi")
 
             body = "\n".join(f"    {line}" for line in export_lines)
 
@@ -213,6 +278,14 @@ class ICCLLauncher:
         script_lines = [
             "#!/bin/bash",
             "",
+            "expand_path() {",
+            '    case "$1" in',
+            '        "~") printf "%s\\n" "$HOME" ;;',
+            '        "~/"*) printf "%s\\n" "$HOME/${1#~/}" ;;',
+            '        *) printf "%s\\n" "$1" ;;',
+            "    esac",
+            "}",
+            "",
             'HOST_IPS="$(hostname -I)"',
             "",
             "".join(blocks).rstrip(),
@@ -223,7 +296,11 @@ class ICCLLauncher:
             "    exit 1",
             "fi",
             "",
-            f'EXE="{common_dir}/build/$ARCH/{bin_sub}"',
+            'EXE="$NODE_COMMON_DIR/build/$ARCH/$BIN_SUB"',
+            'if [[ ! -x "$EXE" ]]; then',
+            '    echo "[ERROR] Executable not found or not executable: $EXE"',
+            "    exit 1",
+            "fi",
             "",
             "shift",
             "",


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary
This PR adds support for node-specific launcher directories in `icclrun`, updates the cluster configuration template for the new node-level `dir` field, and keeps heterogeneous nodes building and running through one MPI launch command.


## Changes

- **Launcher Root Detection**
  - Detect InfiniCCL source trees by exact `project(InfiniCCL ...)` CMake project name;
  - Prefer the configured source tree before environment variables, which may point at stale installs.

- **Node-Specific Build Directories**
  - Support per-node `dir` overrides when orchestrating internal InfiniCCL builds and external consumer-project builds;
  - Build internal InfiniCCL examples from the node source tree and external projects against the installed per-architecture InfiniCCL package;
  - Preserve remote node paths and expand `~` at wrapper runtime on each host.

- **Cluster Configuration Template**
  - Document node-level `dir` in `examples/cluster.yaml` as an override for `common_dir`;
  - Clarify that additional nodes should follow the same node-field structure;
  - Generalize the placeholder architecture type in the template.

- **Generated Runtime Wrapper**
  - Generate per-host `NODE_COMMON_DIR`, `INSTALL_LIB`, and `BIN_SUB` values;
  - Select `examples/$1` for internal InfiniCCL examples and `$1` for external projects;
  - Validate the resolved executable before launching.

- **MPI Wrapper Staging**
  - Stage the generated wrapper at one identical `/tmp` path across hosts when node-specific dirs are used;
  - Keep `mpirun` launching one script path while allowing that script to resolve node-specific directories at runtime.

## Platform and Backend Affected

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

N/A.

## Known Issues & Future Work

- Shell command construction still relies on interpolated strings. Future work could use stricter shell quoting for paths and CMake flags.
- Remote `CMakeLists.txt` detection is intentionally done at runtime on the remote node.
## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**Logs**:
[mpi_all_gather.log](https://github.com/user-attachments/files/29627040/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/29627041/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/29627042/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/29627043/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/29627045/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/29627047/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/29627048/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/29627049/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/29627050/mpi_send_recv.log)


External programs are also tested in `InfiniCCL-Test`. 

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

N/A — no C++ files changed.

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
