### PR TITLE
docs: clearly document the fields of `cluster.yaml` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,35 @@ To achieve this, a `cluster.yaml` is required to be filled. This is the configur
 
 After having a successful build and a complete `cluster.yaml`, we are ready for compiling and executing a distributed program across the cluster. 
 
+<details>
+<summary><b>📋 Full list of `cluster.yaml` fields (Click to expand)</b></summary>
+
+| Field | Required | Scope | Available Values / Meaning |
+|-------|----------|-------|----------------------------|
+| `common_dir` | Yes | Global | Root directory of the project source tree. For internal examples, set this to the InfiniCCL source root. For external programs, set this to the external project root. |
+| `common_user` | No | Global | Default SSH user for remote nodes. If omitted and no node-level `user` is set, `root` is used. |
+| `install_dir` | No | Global | Base directory for InfiniCCL installation artifacts. If omitted, `common_dir` is used. Libraries are installed under `<install_dir>/install/<type>`. |
+| `cmake_flags` | No | Global | CMake options applied to every node during `--build`, such as `-DAUTO_DETECT_BACKENDS=OFF`. Node-level `cmake_flags` override this value for that node. |
+| `backend_args` | No | Global | Extra arguments passed to the selected backend launcher. Use a YAML mapping from a flag to a scalar or list of values, for example `--mca: ["pml ucx", "btl ^openib"]` for OpenMPI. |
+| `backend_env` | No | Global | Environment variables exported for launcher/runtime setup on every node. Node-level `backend_env` overrides these values; path-like variables (`LD_LIBRARY_PATH`, `PATH`, `CPATH`, `LIBRARY_PATH`) are prepended to the global value. |
+| `launcher_script` | No | Global | Path to a custom wrapper script. If omitted, `icclrun` generates `build/run_wrapper.sh` from `cluster.yaml`. For MPI launchers, the script path must be executable from every participating node. |
+| `nodes` | Yes | Global | List of participating nodes. Each entry describes one host and its build/runtime settings. |
+| `nodes[].ip` | Yes | Node | Node IP address or hostname. Use `localhost` or `127.0.0.1` for the local node. |
+| `nodes[].user` | No | Node | SSH user for this node. Overrides `common_user`. |
+| `nodes[].dir` | No | Node | Node-specific project source directory. Overrides `common_dir` for this node and is useful when the project path differs across hosts. |
+| `nodes[].type` | Yes | Node | Architecture/build label used in build, install, and wrapper paths. Common values include `cpu`, `nvidia`, `iluvatar`, `metax`, `moore`, and `cambricon`. |
+| `nodes[].slots` | No | Node | Number of processes to launch on this node. This usually matches the number of devices assigned to the node. Defaults to `8`. |
+| `nodes[].cmake_flags` | No | Node | Node-specific CMake options used during `--build`, such as `-DUSE_CUDA=ON` or `-DUSE_MACA=ON`. Overrides global `cmake_flags` for this node. |
+| `nodes[].backend_env` | No | Node | Node-specific runtime environment variables, such as `CUDA_VISIBLE_DEVICES`, `UCX_TLS`, or `UCX_NET_DEVICES`. Overrides or prepends to global `backend_env` values for this node. |
+
+> **Notes**:
+> - `backend_args` and launcher-level environment forwarding are used by `--launcher ompi` and `--launcher mpich`.
+> - `--launcher none` still uses the generated or configured wrapper script, but does not invoke `mpirun`.
+> - Unknown YAML keys are ignored by the current launcher implementation.
+
+</details>
+
+
 ### 1. Run Internal Examples
 
 #### 1.1. Run a Single Example


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR documents the supported `cluster.yaml` fields in `README.md` so users can quickly understand the required keys, optional overrides, and launcher-related settings.


## Changes

- **Cluster Configuration Reference**
  - Add a collapsible `cluster.yaml` field table near the library usage instructions;
  - Enumerate both the global fields and node-level fields.

- **Field Semantics**
  - Describe which fields are required and which fields are optional;
  - Clarify global versus node-level override behavior;
  - Note launcher-specific behavior for MPI launchers and `--launcher none`.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

N/A. Pure documentation change.

## Known Issues & Future Work
 - If additional fields are supported in future works, this table should also be updated.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

> Note: Documentation-only change.

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [ ] OpenMPI
- [ ] MPICH

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

N/A — no C++ files changed.

### Python Specific (if Python files changed)

N/A — no Python files changed.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.