### PR TITLE
style: rename `Timer.elapsed_ms()` method to `Timer.ElapsedMs()` in `examples/utils.h`

### DIFF
--- a/examples/mpi/all_gather.cc
+++ b/examples/mpi/all_gather.cc
@@ -109,7 +109,7 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
                           Rt::MemcpyDeviceToHost));
 
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation
   bool correct = true;

--- a/examples/mpi/all_reduce.cc
+++ b/examples/mpi/all_reduce.cc
@@ -108,7 +108,7 @@ void RunAllReduceExample(int argc, char **argv, int warmup_iter,
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation
   float expected = 0.0f;

--- a/examples/mpi/all_to_all.cc
+++ b/examples/mpi/all_to_all.cc
@@ -120,7 +120,7 @@ void RunAllToAllExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
                           Rt::MemcpyDeviceToHost));
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation
   // recv `block[src]` on rank r should come from `src`'s send `block[dst=r]`.

--- a/examples/mpi/broadcast.cc
+++ b/examples/mpi/broadcast.cc
@@ -113,7 +113,7 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
       CHECK_INFINI(collective_call());
     }
     CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-    double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+    double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
     // Validation
     Validator::ValidateResult(h_recv.data(), kNumElements, kRootMagicValue,

--- a/examples/mpi/gather.cc
+++ b/examples/mpi/gather.cc
@@ -109,7 +109,7 @@ void RunGatherExample(int argc, char **argv, int warmup_iter, int profile_iter,
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation (only meaningful on `root`).
   if (rank == kRoot) {

--- a/examples/mpi/reduce.cc
+++ b/examples/mpi/reduce.cc
@@ -113,7 +113,7 @@ void RunReduceExample(int argc, char **argv, int warmup_iter, int profile_iter,
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation (only meaningful on `root`).
   if (rank == kRoot) {

--- a/examples/mpi/reduce_scatter.cc
+++ b/examples/mpi/reduce_scatter.cc
@@ -119,7 +119,7 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
                           Rt::MemcpyDeviceToHost));
 
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation:
   float expected = 0.0f;

--- a/examples/mpi/scatter.cc
+++ b/examples/mpi/scatter.cc
@@ -114,7 +114,7 @@ void RunScatterExample(int argc, char **argv, int warmup_iter, int profile_iter,
   }
 
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation: every rank should receive its own `(rank + 1)` block.
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,

--- a/examples/mpi/send_recv.cc
+++ b/examples/mpi/send_recv.cc
@@ -127,7 +127,7 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
                             Rt::MemcpyDeviceToHost));
   }
 
-  double elapsed = timer.elapsed_ms() / static_cast<double>(profile_iter);
+  double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   if (rank == kReceiver) {
     bool correct = Validator::ValidateResult(

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -28,7 +28,7 @@ class Timer {
 
  public:
   Timer() : start(std::chrono::high_resolution_clock::now()) {}
-  double elapsed_ms() const {
+  double ElapsedMs() const {
     auto end = std::chrono::high_resolution_clock::now();
     return std::chrono::duration<double, std::milli>(end - start).count();
   }


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR renames the example `Timer` elapsed-time accessor from `elapsed_ms()` to `ElapsedMs()` and updates all existing example call sites to match the repository's C++ method naming convention.


## Changes

- **Timer Naming**
  - Rename `Timer::elapsed_ms()` to `Timer::ElapsedMs()` in `examples/utils.h`;
  - Keep the timer behavior unchanged.

- **MPI Example Call Sites**
  - Update all MPI examples to call `timer.ElapsedMs()`;
  - Keep the profiling elapsed-time calculation unchanged.


## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work

<!--
Describe any known limitations, caveats, or unresolved issues introduced by this PR in bullet points.

If applicable, also outline potential follow-up improvements, extensions, or future work related to these changes.
-->
N/A.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH

**Logs:**
[mpi_all_gather.log](https://github.com/user-attachments/files/29692719/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/29692720/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/29692721/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/29692722/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/29692723/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/29692724/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/29692725/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/29692726/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/29692727/mpi_send_recv.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

N/A — no Python files changed.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
