### PR TITLE
feat: support NCCL on Iluvatar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,9 +210,14 @@ if(AUTO_DETECT_BACKENDS)
     endif()
 
     # Detect NCCL Dependencies
-    if(WITH_NVIDIA)
-        find_path(AUTO_NCCL_INC NAMES nccl.h QUIET)
-        find_library(AUTO_NCCL_LIB NAMES nccl QUIET)
+    if(WITH_NVIDIA OR WITH_ILUVATAR)
+        if (WITH_ILUVATAR)
+            set(_NCCL_HINTS /usr/local/corex)
+            message(STATUS "Iluvatar detected. Searching for NCCL in ${_NCCL_HINTS}")
+        endif()
+
+        find_path(AUTO_NCCL_INC NAMES nccl.h HINTS ${_NCCL_HINTS} PATH_SUFFIXES include QUIET)
+        find_library(AUTO_NCCL_LIB NAMES nccl HINTS ${_NCCL_HINTS} PATH_SUFFIXES lib lib64 QUIET)
 
         if(AUTO_NCCL_INC AND AUTO_NCCL_LIB)
             set(WITH_NCCL ON)
@@ -334,12 +339,12 @@ if(WITH_OMPI OR WITH_MPICH)
 endif()
 
 if(WITH_NCCL)
-    if (NOT WITH_NVIDIA)
-        message(FATAL_ERROR "NCCL backend requires NVIDIA GPU support. Please enable WITH_NVIDIA.")
+    if (NOT WITH_NVIDIA AND NOT WITH_ILUVATAR)
+        message(FATAL_ERROR "NCCL backend requires NVIDIA or Iluvatar GPU support. Please enable `WITH_NVIDIA` or `WITH_ILUVATAR`.")
     endif()
 
-    find_library(NCCL_LIB NAMES nccl REQUIRED)
-    find_path(NCCL_INC NAMES nccl.h REQUIRED)
+    find_library(NCCL_LIB NAMES nccl HINTS ${_NCCL_HINTS} PATH_SUFFIXES lib lib64 REQUIRED)
+    find_path(NCCL_INC NAMES nccl.h HINTS ${_NCCL_HINTS} PATH_SUFFIXES include REQUIRED)
 
     include_directories(${NCCL_INC})
 endif()

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 |---------|---------------|----------------------|---------------|
 | **OpenMPI** | Full | `WITH_OMPI=ON` | The default backend. Requires the OpenMPI development package.|
 | **MPICH** | Full | `WITH_MPICH=ON` | Requires the MPICH development package.|
-| **NCCL** | Partial | `WITH_NCCL=ON` | Requires NVIDIA NCCL. Currently available only when `WITH_NVIDIA=ON`.|
+| **NCCL** | Partial | `WITH_NCCL=ON` | Requires NVIDIA or Iluvatar NCCL. Currently available when `WITH_NVIDIA=ON` or `WITH_ILUVATAR=ON`.|
 
 </details>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,6 +53,10 @@ foreach(source_file ${EXAMPLE_SOURCES})
         target_link_libraries(${target_name} PRIVATE MPI::MPI_CXX)
     endif()
 
+    if(WITH_NCCL)
+        target_link_libraries(${target_name} PRIVATE "${NCCL_LIB}")
+    endif()
+
     # Explicitly allow examples to "peek" into the internal `src` and binary dirs.
     # This is necessary because these were marked `PRIVATE` in the library's CMake.
     target_include_directories(${target_name} PRIVATE 

--- a/src/backend_device_map.h
+++ b/src/backend_device_map.h
@@ -17,6 +17,10 @@ template <>
 struct IsSupportedCombination<BackendType::kNccl, Device::Type::kNvidia>
     : std::true_type {};
 
+template <>
+struct IsSupportedCombination<BackendType::kNccl, Device::Type::kIluvatar>
+    : std::true_type {};
+
 };  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_DEVICE_MAP_H_

--- a/src/backends/ccl/nccl/iluvatar/api.h
+++ b/src/backends/ccl/nccl/iluvatar/api.h
@@ -1,0 +1,15 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_ILUVATAR_API_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_ILUVATAR_API_H_
+
+#include "devices/iluvatar/runtime_.h"
+#include "backends/ccl/nccl/api.h"
+
+namespace infini::ccl {
+
+template <>
+struct CclApi<BackendType::kNccl, Device::Type::kIluvatar>
+    : NcclApi<Device::Type::kIluvatar> {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_ILUVATAR_API_H_

--- a/src/backends/ccl/nccl/iluvatar/api.h
+++ b/src/backends/ccl/nccl/iluvatar/api.h
@@ -1,8 +1,8 @@
 #ifndef INFINI_CCL_BACKENDS_CCL_NCCL_ILUVATAR_API_H_
 #define INFINI_CCL_BACKENDS_CCL_NCCL_ILUVATAR_API_H_
 
-#include "devices/iluvatar/runtime_.h"
 #include "backends/ccl/nccl/api.h"
+#include "devices/iluvatar/runtime_.h"
 
 namespace infini::ccl {
 


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

Add NCCL backend support for Iluvatar by reusing the shared NCCL CCL abstraction introduced in the current codebase. This PR adds the Iluvatar NCCL provider alias, marks `BackendType::kNccl` with `Device::Type::kIluvatar` as a supported backend/device combination, and updates CMake so NCCL can be discovered and required for either NVIDIA or Iluvatar builds.

This keeps the platform/backend separation intact: Iluvatar does not duplicate NCCL operation implementations, and it can use the existing `src/backends/ccl/nccl` implementation through a small provider-specific `api.h`.

## Changes

- **Iluvatar NCCL Provider**
  - Add `src/backends/ccl/nccl/iluvatar/api.h`.
  - Bind `CclApi<BackendType::kNccl, Device::Type::kIluvatar>` to `NcclApi<Device::Type::kIluvatar>`.

- **Backend/device support**
  - Update `src/backend_device_map.h` so `BackendType::kNccl` is accepted with `Device::Type::kIluvatar`.

- **CMake detection and linking**
  - Allow NCCL auto-detection when either `WITH_NVIDIA` or `WITH_ILUVATAR` is enabled.
  - Add CoreX-style NCCL search hints under `/usr/local/corex` for Iluvatar builds.
  - Update the explicit `WITH_NCCL` requirement so NCCL accepts NVIDIA or Iluvatar GPU support.
  - Link examples against `NCCL_LIB` when `WITH_NCCL` is enabled, so NCCL symbols are available to example targets.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH
- [x] NCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A..

## Known Issues & Future Work

- This PR assumes Iluvatar's NCCL-compatible library exposes the NCCL APIs used by the shared `NcclApi` implementation. If Iluvatar NCCL later diverges from NVIDIA NCCL for specific APIs or semantics, follow-up work can override only the divergent pieces under `src/backends/ccl/nccl/iluvatar`.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL

**Iluvatar with NCCL:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/30001598/ccl_all_reduce.log)

**Iluvatar with NCCL+OpenMPI:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/30001603/ccl_mpi_hybrid_all_reduce.log)

**NVIDIA with NCCL:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/30001666/ccl_all_reduce.log)

**NVIDIA with NCCL+OpenMPI:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/30001671/ccl_mpi_hybrid_all_reduce.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- N/A- Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [x] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
