### PR TITLE
feat: support MCCL on MetaX

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -64,6 +64,7 @@ Please check all the platforms and/or backends this PR affects (i.e., code is to
 - [ ] OpenMPI
 - [ ] MPICH
 - [ ] NCCL
+- [ ] MCCL
 
 ## Performance Impact
 
@@ -112,6 +113,7 @@ See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and
 - [ ] OpenMPI
 - [ ] MPICH
 - [ ] NCCL
+- [ ] MCCL
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
 option(WITH_OMPI "Enable OpenMPI backend" OFF)
 option(WITH_MPICH "Enable MPICH backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
+option(WITH_MCCL "Enable MCCL backend"    OFF)
 
 # =========================================================
 # --- MISC. BUILD OPTIONS ---
@@ -228,10 +229,31 @@ if(AUTO_DETECT_BACKENDS)
     else()
         message(STATUS "No suitable device environment, skipping NCCL detection.")
     endif()
+
+    # Detect MCCL Dependencies
+    if(WITH_METAX)
+        set(_MCCL_HINTS)
+        if(DEFINED ENV{MACA_PATH})
+            list(APPEND _MCCL_HINTS "$ENV{MACA_PATH}")
+        endif()
+        list(APPEND _MCCL_HINTS /opt/maca)
+
+        find_path(AUTO_MCCL_INC NAMES mccl.h HINTS ${_MCCL_HINTS} PATH_SUFFIXES include QUIET)
+        find_library(AUTO_MCCL_LIB NAMES mccl HINTS ${_MCCL_HINTS} PATH_SUFFIXES lib lib64 QUIET)
+
+        if(AUTO_MCCL_INC AND AUTO_MCCL_LIB)
+            set(WITH_MCCL ON)
+            message(STATUS "Auto-detected MCCL backend.")
+        else()
+            message(STATUS "MCCL library/headers not found in MetaX paths.")
+        endif()
+    else()
+        message(STATUS "No suitable device environment, skipping MCCL detection.")
+    endif()
 endif()
 
 # Fallback: If no backends are enabled or auto-detected, fall back to OpenMPI as the default bootstrap profile.
-if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL)
+if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL AND NOT WITH_MCCL)
     set(WITH_OMPI ON)
     message(STATUS "No backend specified or detected. Defaulting to `WITH_OMPI=ON`")
 endif()
@@ -347,6 +369,26 @@ if(WITH_NCCL)
     find_path(NCCL_INC NAMES nccl.h HINTS ${_NCCL_HINTS} PATH_SUFFIXES include REQUIRED)
 
     include_directories(${NCCL_INC})
+endif()
+
+if(WITH_MCCL)
+    if (NOT WITH_METAX)
+        message(FATAL_ERROR "MCCL backend requires MetaX GPU support. Please enable `WITH_METAX`.")
+    endif()
+
+    set(_MCCL_HINTS)
+    if(MACA_PATH)
+        list(APPEND _MCCL_HINTS "${MACA_PATH}")
+    endif()
+    if(DEFINED ENV{MACA_PATH})
+        list(APPEND _MCCL_HINTS "$ENV{MACA_PATH}")
+    endif()
+    list(APPEND _MCCL_HINTS /opt/maca)
+
+    find_library(MCCL_LIB NAMES mccl HINTS ${_MCCL_HINTS} PATH_SUFFIXES lib lib64 REQUIRED)
+    find_path(MCCL_INC NAMES mccl.h HINTS ${_MCCL_HINTS} PATH_SUFFIXES include REQUIRED)
+
+    include_directories(${MCCL_INC})
 endif()
 
 # Python is required for code generation.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | `WITH_OMPI`   | Enable OpenMPI backend | `ON` if no backend specified, otherwise `OFF` |
 | `WITH_MPICH`  | Enable MPICH backend | `OFF` |
 | `WITH_NCCL`   | Enable NCCL backend | `OFF` |
+| `WITH_MCCL`   | Enable MCCL backend | `OFF` |
 | **Miscellaneous** |||
 | `AUTO_DETECT_DEVICES` | Automatically detect available devices and enable corresponding support | `ON` |
 | `AUTO_DETECT_BACKENDS` | Automatically detect available communication backends and enable corresponding support | `OFF` |
@@ -353,6 +354,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 | **OpenMPI** | Full | `WITH_OMPI=ON` | The default backend. Requires the OpenMPI development package.|
 | **MPICH** | Full | `WITH_MPICH=ON` | Requires the MPICH development package.|
 | **NCCL** | Partial | `WITH_NCCL=ON` | Requires NVIDIA or Iluvatar NCCL. Currently available when `WITH_NVIDIA=ON` or `WITH_ILUVATAR=ON`.|
+| **MCCL** | Partial | `WITH_MCCL=ON` | Requires MetaX's MCCL. Currently only available when `WITH_METAX=ON`.|
 
 </details>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -57,6 +57,10 @@ foreach(source_file ${EXAMPLE_SOURCES})
         target_link_libraries(${target_name} PRIVATE "${NCCL_LIB}")
     endif()
 
+    if(WITH_MCCL)
+        target_link_libraries(${target_name} PRIVATE "${MCCL_LIB}")
+    endif()
+
     # Explicitly allow examples to "peek" into the internal `src` and binary dirs.
     # This is necessary because these were marked `PRIVATE` in the library's CMake.
     target_include_directories(${target_name} PRIVATE 

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -31,10 +31,17 @@ BACKEND_IMPL_PATH_MAP = {
     "ompi": ["backends/mpi/ompi/impl"],
     "mpich": ["backends/mpi/ompi/impl"],
     "nccl": ["backends/ccl/nccl/impl"],
+    "mccl": ["backends/ccl/mccl/impl"],
 }
 
 BACKEND_COMMON_HEADERS = {
     "nccl": ["backends/ccl/nccl/type_map.h"],
+    "mccl": ["backends/ccl/mccl/type_map.h"],
+}
+
+CCL_PROVIDER_BACKENDS = {
+    "nccl": "backends/ccl/nccl",
+    "mccl": "backends/ccl/mccl",
 }
 
 # =================================================================
@@ -130,9 +137,10 @@ def generate(project_root, output_dir, devices, backends):
 
         manifest_lines.append(f"\n// --- BACKEND: {bb.upper()} ---")
 
-        if bb == "nccl":
+        provider_root = CCL_PROVIDER_BACKENDS.get(bb)
+        if provider_root:
             for dev in devices:
-                provider_path = f"backends/ccl/nccl/{dev}/api.h"
+                provider_path = f"{provider_root}/{dev}/api.h"
                 if os.path.exists(os.path.join(src_dir, provider_path)):
                     manifest_lines.append(f'#include "{provider_path}"')
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -235,6 +235,16 @@ if(WITH_NCCL)
     target_link_libraries(infiniccl PRIVATE ${NCCL_LIB})
 endif()
 
+# MCCL
+if(WITH_MCCL)
+    list(APPEND BACKEND_LIST "mccl")
+    file(GLOB_RECURSE MCCL_SRCS "backends/ccl/mccl/*.cc" "backends/ccl/mccl/*.cpp" "backends/ccl/mccl/*.maca")
+
+    target_sources(infiniccl PRIVATE ${MCCL_SRCS})
+    target_include_directories(infiniccl PRIVATE ${MCCL_INC})
+    target_link_libraries(infiniccl PRIVATE ${MCCL_LIB})
+endif()
+
 # =========================================================
 # --- File Generation ---
 # =========================================================

--- a/src/backend.h
+++ b/src/backend.h
@@ -58,6 +58,11 @@ struct BackendPriority<BackendType::kNccl> {
   static constexpr int value = 10;
 };
 
+template <>
+struct BackendPriority<BackendType::kMccl> {
+  static constexpr int value = 10;
+};
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_H_

--- a/src/backend_device_map.h
+++ b/src/backend_device_map.h
@@ -21,6 +21,10 @@ template <>
 struct IsSupportedCombination<BackendType::kNccl, Device::Type::kIluvatar>
     : std::true_type {};
 
+template <>
+struct IsSupportedCombination<BackendType::kMccl, Device::Type::kMetax>
+    : std::true_type {};
+
 };  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_DEVICE_MAP_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -1,0 +1,53 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_API_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_API_H_
+
+#include <mccl.h>
+
+#include <cstddef>
+
+#include "backends/ccl/common/api.h"
+#include "logging.h"
+#include "return_status_impl.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct McclApi {
+  static constexpr BackendType kBackendType = BackendType::kMccl;
+  static constexpr Device::Type kDeviceType = device;
+
+  using Comm = mcclComm_t;
+  using UniqueId = mcclUniqueId;
+  using Result = mcclResult_t;
+  using DataType = mcclDataType_t;
+  using RedOp = mcclRedOp_t;
+  using Stream = typename Runtime<device>::Stream;
+
+  static ReturnStatus Check(Result result) {
+    if (result != mcclSuccess) {
+      LOG(mcclGetErrorString(result));
+      return ReturnStatus::kSystemError;
+    }
+    return ReturnStatus::kSuccess;
+  }
+
+  static Result GetUniqueId(UniqueId *id) { return mcclGetUniqueId(id); }
+
+  static Result CommInitRank(Comm *comm, int nranks, UniqueId id, int rank) {
+    return mcclCommInitRank(comm, nranks, id, rank);
+  }
+
+  static Result CommDestroy(Comm comm) { return mcclCommDestroy(comm); }
+
+  static Result AllReduce(const void *send_buff, void *recv_buff, size_t count,
+                          DataType data_type, RedOp op, Comm comm,
+                          Stream stream) {
+    return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
+                         stream);
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_API_H_

--- a/src/backends/ccl/mccl/checks.h
+++ b/src/backends/ccl/mccl/checks.h
@@ -1,0 +1,31 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_CHECKS_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_CHECKS_H_
+
+#include <mccl.h>
+
+#include <iostream>
+
+#include "return_status_impl.h"
+
+#define INFINI_CHECK_MCCL(result) \
+  ::infini::ccl::detail::CheckMcclImpl((result), __FILE__, __LINE__)
+
+namespace infini::ccl {
+
+namespace detail {
+
+inline ReturnStatus CheckMcclImpl(mcclResult_t mccl_result, const char *file,
+                                  int line) {
+  if (mccl_result != mcclSuccess) {
+    std::cerr << "backend(mccl) MCCL error code: " << mccl_result << " at line "
+              << line << " in " << file << std::endl;
+    std::abort();
+  }
+  return ReturnStatus::kSuccess;
+}
+
+}  // namespace detail
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_CHECKS_H_

--- a/src/backends/ccl/mccl/impl/all_reduce.h
+++ b/src/backends/ccl/mccl/impl/all_reduce.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_REDUCE_H_
+
+#include "backends/ccl/common/impl/all_reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllReduceImpl<BackendType::kMccl, device>
+    : public CclAllReduceImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<AllReduce, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_REDUCE_H_

--- a/src/backends/ccl/mccl/impl/comm_destroy.h
+++ b/src/backends/ccl/mccl/impl/comm_destroy.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_DESTROY_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_DESTROY_H_
+
+#include "backends/ccl/common/impl/comm_destroy.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommDestroyImpl<BackendType::kMccl, device>
+    : public CclCommDestroyImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<CommDestroy, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_DESTROY_H_

--- a/src/backends/ccl/mccl/impl/comm_init_rank.h
+++ b/src/backends/ccl/mccl/impl/comm_init_rank.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_INIT_RANK_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_INIT_RANK_H_
+
+#include "backends/ccl/common/impl/comm_init_rank.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommInitRankImpl<BackendType::kMccl, device>
+    : public CclCommInitRankImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<CommInitRank, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_COMM_INIT_RANK_H_

--- a/src/backends/ccl/mccl/impl/get_unique_id.h
+++ b/src/backends/ccl/mccl/impl/get_unique_id.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GET_UNIQUE_ID_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GET_UNIQUE_ID_H_
+
+#include "backends/ccl/common/impl/get_unique_id.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class GetUniqueIdImpl<BackendType::kMccl, device>
+    : public CclGetUniqueIdImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<GetUniqueId, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GET_UNIQUE_ID_H_

--- a/src/backends/ccl/mccl/metax/api.h
+++ b/src/backends/ccl/mccl/metax/api.h
@@ -1,0 +1,15 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_METAX_API_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_METAX_API_H_
+
+#include "backends/ccl/mccl/api.h"
+#include "devices/metax/runtime_.h"
+
+namespace infini::ccl {
+
+template <>
+struct CclApi<BackendType::kMccl, Device::Type::kMetax>
+    : McclApi<Device::Type::kMetax> {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_METAX_API_H_

--- a/src/backends/ccl/mccl/type_map.h
+++ b/src/backends/ccl/mccl/type_map.h
@@ -1,0 +1,77 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_TYPE_MAP_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_TYPE_MAP_H_
+
+#include <mccl.h>
+
+#include <string>
+
+#include "backends/ccl/common/api.h"
+#include "comm_impl.h"
+#include "data_type_impl.h"
+#include "logging.h"
+
+namespace infini::ccl {
+
+static const ConstexprMap<DataType, mcclDataType_t, 12> kMcclTypeMap{{{
+    {DataType::kInt8, mcclInt8},
+    {DataType::kInt16, mcclNumTypes},
+    {DataType::kInt32, mcclInt32},
+    {DataType::kInt64, mcclInt64},
+    {DataType::kUInt8, mcclUint8},
+    {DataType::kUInt16, mcclNumTypes},
+    {DataType::kUInt32, mcclUint32},
+    {DataType::kUInt64, mcclUint64},
+    {DataType::kFloat32, mcclFloat32},
+    {DataType::kFloat64, mcclFloat64},
+    {DataType::kFloat16, mcclFloat16},
+    {DataType::kBFloat16, mcclNumTypes},
+}}};
+
+static const ConstexprMap<ReductionOpType, mcclRedOp_t, 5> kMcclOpMap{{{
+    {ReductionOpType::kSum, mcclSum},
+    {ReductionOpType::kProd, mcclProd},
+    {ReductionOpType::kMax, mcclMax},
+    {ReductionOpType::kMin, mcclMin},
+    {ReductionOpType::kAvg, mcclAvg},
+}}};
+
+inline mcclDataType_t DataTypeToMcclType(DataType dtype) {
+  auto mccl_dtype = kMcclTypeMap.at(dtype);
+
+  if (mccl_dtype == mcclNumTypes) {
+    LOG(("DataType '" + std::string(kDataTypeToDesc.at(dtype)) +
+         "' is not supported by the MCCL backend")
+            .c_str());
+  }
+
+  return mccl_dtype;
+}
+
+inline mcclRedOp_t RedOpToMcclOp(ReductionOpType red_op) {
+  return kMcclOpMap.at(red_op);
+}
+
+template <Device::Type device>
+struct CclTypeMap<BackendType::kMccl, device> {
+  using Api = CclApi<BackendType::kMccl, device>;
+
+  static bool ToBackendDataType(DataType dtype,
+                                typename Api::DataType *backend_dtype) {
+    auto mccl_dtype = DataTypeToMcclType(dtype);
+    if (mccl_dtype == mcclNumTypes) {
+      return false;
+    }
+    *backend_dtype = mccl_dtype;
+    return true;
+  }
+
+  static bool ToBackendRedOp(ReductionOpType red_op,
+                             typename Api::RedOp *backend_op) {
+    *backend_op = RedOpToMcclOp(red_op);
+    return true;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_TYPE_MAP_H_

--- a/src/backends/ccl/mccl/type_map.h
+++ b/src/backends/ccl/mccl/type_map.h
@@ -24,7 +24,7 @@ static const ConstexprMap<DataType, mcclDataType_t, 12> kMcclTypeMap{{{
     {DataType::kFloat32, mcclFloat32},
     {DataType::kFloat64, mcclFloat64},
     {DataType::kFloat16, mcclFloat16},
-    {DataType::kBFloat16, mcclNumTypes},
+    {DataType::kBFloat16, mcclBfloat16},
 }}};
 
 static const ConstexprMap<ReductionOpType, mcclRedOp_t, 5> kMcclOpMap{{{


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

Add MCCL backend support for MetaX by reusing the shared CCL backend abstraction. This PR adds a new `src/backends/ccl/mccl` backend layer, binds `BackendType::kMccl` to `Device::Type::kMetax`, and updates CMake/bridge generation so MetaX builds can discover, link, and generate code for MCCL.

The implementation follows the same provider-oriented structure as NCCL: common CCL operation implementations are reused, while the MCCL-specific API wrapper, type map, operation registration, and MetaX provider alias live under `src/backends/ccl/mccl`.

## Changes

- **MCCL backend support**
  - Add the new `src/backends/ccl/mccl` backend family, including the MCCL API wrapper, type mapping, checks, and operation registrations that reuse the common CCL implementation layer.

- **MetaX integration**
  - Add the MetaX MCCL provider alias under `src/backends/ccl/mccl/metax` and mark `BackendType::kMccl` with `Device::Type::kMetax` as a supported backend/device combination.

- **Build and generation**
  - Update top-level and `src` CMake logic to expose `WITH_MCCL`, discover MetaX MCCL dependencies, and link the library/examples when MCCL is enabled.
  - Update `scripts/gen_bridge.py` so CCL provider headers and backend implementation headers are generated for MCCL in the same pattern as NCCL.

- **Documentation and templates**
  - Update `README.md` with MCCL backend documentation and `.github/pull_request_template.md` with MCCL backend checklist entries.


## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Backend

- [ ] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [x] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work

- MCCL support currently covers the CCL operations already provided by the shared CCL abstraction: `GetUniqueId`, `CommInitRank`, `CommDestroy`, and `AllReduce`.
- `DataType::kInt16` and `DataType::kUInt16` are mapped as unsupported for MCCL until the backend API supports them.
- If MetaX MCCL diverges from the assumed MCCL API surface, follow-up work should override only the divergent pieces under `src/backends/ccl/mccl/metax`.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [x] MCCL

**MetaX with MCCL:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/30047995/ccl_all_reduce.log)

**MetaX with MCCL+OpenMPI:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/30047999/ccl_mpi_hybrid_all_reduce.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [x] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [x] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [x] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [x] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Type hints are added / kept consistent with the surrounding code.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [x] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
