### PR TITLE
fix: make device header self-contained

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -1,6 +1,7 @@
 #ifndef INFINI_CCL_DEVICE_H_
 #define INFINI_CCL_DEVICE_H_
 
+#include <cstdint>
 #include <string>
 
 #include "constexpr_map.h"
@@ -155,7 +156,7 @@ struct DevicePriority<Device::Type::kCambricon> {
   static constexpr int value = 5;
 };
 
-enum class MemorySpace : uint8_t { kHost = 0, kDevice = 1, kUnknown };
+enum class MemorySpace : std::uint8_t { kHost = 0, kDevice = 1, kUnknown };
 
 template <Device::Type kDev>
 MemorySpace GetMemorySpace(const void *ptr);


### PR DESCRIPTION
## Summary

Make `src/device.h` self-contained by including `<cstdint>` directly and using `std::uint8_t` as the underlying type of `MemorySpace`.

This removes reliance on a transitive declaration of `uint8_t`. It does not add collective functionality or change runtime behavior, enum values, or supported platforms and backends.

## Changes

- **Header dependency**
  - Include `<cstdint>` directly in `src/device.h`.

- **Fixed-width type**
  - Qualify the underlying type of `MemorySpace` as `std::uint8_t`.

## Platform and Backend Affected

`src/device.h` is shared by every device implementation and the common communication paths, so all supported configurations are affected at compile time. Runtime behavior is unchanged.

### Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

N/A. This change only makes a header dependency explicit and preserves the existing fixed-width enum representation.

## Known Issues & Future Work

- No known issues are introduced by this change.
- Runtime validation for this PR is limited to NVIDIA GPU with NCCL. Other affected platform/backend combinations were not exercised.
- This PR does not add or expand collective, platform, or backend functionality.

## Test Results

Environment:

- Container: `accelerator-dev/nvidia:latest` (NVIDIA PyTorch 25.12)
- Hardware: 2 x NVIDIA A100-SXM4-80GB
- Configuration: NVIDIA device with NCCL backend, two local ranks

Results:

- `clang-format-16 --dry-run --Werror src/device.h`: passed.
- `ruff check .`: passed.
- `ruff format --check .`: passed.
- Standalone C++17 compilation including only `src/device.h`: passed.
- `scripts/run_examples.py` for `ccl/all_reduce`: passed with two NVIDIA GPUs.
- Downstream InfiniLM Qwen3-0.6B inference: passed with tensor parallelism 1 and 2.

The applicable example was run as:

```bash
python scripts/run_examples.py \
    --config /workspace/ccl-cluster.yaml \
    --examples ccl/all_reduce \
    --log-path /workspace/ccl-example-logs \
    --timeout 600 \
    -- -g 2 -w 1 -p 1 -n 1048576
```

Generated `ccl_all_reduce.log` result:

```text
[Main Process] Host: master | Target GPUs: 2

=== AllReduce Results ===
Correct: YES
Expect:  3.00
Actual:  3.00

=== Single-Node Threaded AllReduce Results ===
Data size: 1048576 floats (4 MB)
Time:           0.119 ms
Throughput:     32.71 GB/s (Bus BW)
Alg Bandwidth:  32.71 GB/s

[Main Process] All worker threads joined. InfiniCCL finalized safely.
```

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU

### Test Involved Backend

- [ ] OpenMPI
- [ ] MPICH
- [x] NCCL
- [ ] MCCL

---

## Checklist

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`, with the type matching the PR title.
- [x] Each **commit** message follows Conventional Commits.
- [x] This small PR is a single squashable commit.
- [x] The branch is rebased cleanly on top of the current `master` with no stray merge commits.
- [x] No `fixup!`, `squash!`, or `wip` commits remain.

### Scope and Design

- [x] Changes are minimal and contain no unrelated modifications.
- [x] No dead code, commented-out blocks, debug prints, or unowned `TODO` items were introduced.
- [x] No unrelated formatting churn obscures the diff.
- N/A - Public API behavior, ABI, and enum values are unchanged.

### General Code Hygiene

- [x] The change is self-explanatory and needs no additional comment.
- [x] The modified file ends with a single trailing newline.
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- N/A - No comments or error messages were added or modified.
- N/A - No comments or error messages were added or modified.
- N/A - No comments or error messages were added or modified.

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
- [x] `clang-format` version 16 has been run against the modified file; the diff is clean.
- N/A - No exception or error path was added or modified.
- N/A - No error or warning message was added or modified.
- N/A - No constructor or initializer list was added or modified.
- N/A - No class or function spacing was changed.
- N/A - No class member spacing was changed.
- N/A - No namespace layout was changed.

### Python Specific (if Python files changed)

- N/A - No Python files changed.
- N/A - No Python files changed.
- N/A - No Python comments changed.
- N/A - No Python framework-specific messages changed.
- N/A - No Python function signatures changed.
- N/A - No Python control flow changed.
- N/A - No Python return statements changed.
- N/A - No Python docstrings changed.
- N/A - No Python type hints changed.

### Testing

- [x] The applicable example program was built and tested successfully with two NVIDIA GPUs and NCCL.

### Build, CI, and Tooling

- N/A - No backend, device, or auto-detection logic changed.
- [x] The `clang-format.yml` and `ruff.yml` checks pass locally.

### Documentation

- N/A - No behavior, build flag, or developer workflow changed.
- N/A - This PR has no user-visible breaking change.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers were committed.
- N/A - No third-party code was added or modified.
- [x] No unsafe pointer arithmetic, uninitialized read, or missing bounds check was introduced.
