### PR TITLE
feat: support CCL `Broadcast`

### DIFF
--- a/examples/ccl/broadcast.cc
+++ b/examples/ccl/broadcast.cc
@@ -1,0 +1,201 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Broadcast
+ *
+ * This example spawns one CPU thread per GPU and performs native CCL
+ * broadcasts without an MPI launcher.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "infiniccl.h"
+#include "utils.h"
+
+using namespace infini::ccl;
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  int root;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iter;
+  int profile_iter;
+  std::atomic_bool *all_correct;
+};
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  constexpr float kRootValue = 42.0f;
+  constexpr float kSentinelValue = -1.0f;
+  const size_t total_bytes = args.num_elements * sizeof(float);
+
+  std::vector<float> h_send(args.num_elements, kSentinelValue);
+  std::vector<float> h_recv(args.num_elements, kSentinelValue);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), total_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), total_bytes));
+
+  auto ResetBuffers = [&]() {
+    std::fill(h_send.begin(), h_send.end(),
+              args.rank == args.root ? kRootValue : kSentinelValue);
+    std::fill(h_recv.begin(), h_recv.end(), kSentinelValue);
+    CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  };
+
+  auto RunScenario = [&](const std::string &name, float *verify_buff,
+                         auto &&collective_call) {
+    for (int i = 0; i < args.warmup_iter; ++i) {
+      CHECK_INFINI(collective_call());
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    Timer timer;
+    for (int i = 0; i < args.profile_iter; ++i) {
+      CHECK_INFINI(collective_call());
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    const double elapsed =
+        timer.ElapsedMs() / static_cast<double>(args.profile_iter);
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), verify_buff, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+
+    const bool correct = Validator::ValidateResult(
+        h_recv.data(), args.num_elements, kRootValue, args.rank, true, name);
+    if (!correct) {
+      args.all_correct->store(false, std::memory_order_relaxed);
+    }
+
+    if (args.rank == 0) {
+      Metrics metrics{elapsed, total_bytes, args.size};
+      metrics.Print();
+    }
+  };
+
+  ResetBuffers();
+  RunScenario("Out-of-Place Broadcast", d_recv, [&]() {
+    return infinicclBroadcast(d_send, d_recv, args.num_elements,
+                              infinicclFloat32, args.root, comm, nullptr);
+  });
+
+  ResetBuffers();
+  float *d_in_place = args.rank == args.root ? d_send : d_recv;
+  RunScenario("In-Place Broadcast", d_in_place, [&]() {
+    return infinicclBroadcast(d_in_place, d_in_place, args.num_elements,
+                              infinicclFloat32, args.root, comm, nullptr);
+  });
+
+  ResetBuffers();
+  d_in_place = args.rank == args.root ? d_send : d_recv;
+  RunScenario("Legacy In-Place Bcast", d_in_place, [&]() {
+    return infinicclBcast(d_in_place, args.num_elements, infinicclFloat32,
+                          args.root, comm, nullptr);
+  });
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iters = 1;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 25;
+
+  int opt;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    switch (opt) {
+      case 'g':
+        num_gpus = std::stoi(optarg);
+        break;
+      case 'w':
+        warmup_iters = std::stoi(optarg);
+        break;
+      case 'p':
+        profile_iters = std::stoi(optarg);
+        break;
+      case 'n':
+        num_elements = static_cast<size_t>(std::stoull(optarg));
+        break;
+      case 'h':
+        std::cout << "Usage: " << argv[0] << " [options]\n"
+                  << "Options:\n"
+                  << "  -g <num_gpus>        Number of GPUs (default: 8)\n"
+                  << "  -w <warmup_iters>    Warmup iterations (default: 1)\n"
+                  << "  -p <profile_iters>   Profile iterations (default: 20)\n"
+                  << "  -n <num_elements>    Number of elements (default: "
+                  << (1 << 25) << ")\n";
+        return EXIT_SUCCESS;
+      default:
+        std::cerr << "Invalid argument. Use `-h` for help." << std::endl;
+        return EXIT_FAILURE;
+    }
+  }
+
+  if (num_gpus <= 0 || warmup_iters < 0 || profile_iters <= 0 ||
+      num_elements == 0 ||
+      num_elements > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Invalid execution parameter." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+
+  const int root = num_gpus > 1 ? num_gpus - 1 : 0;
+  std::cout << "[Main Process] Host: " << hostname
+            << " | Target GPUs: " << num_gpus << " | Root: " << root
+            << std::endl;
+
+  infinicclUniqueId shared_id;
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  std::atomic_bool all_correct{true};
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,     root,          shared_id,
+                    num_elements, warmup_iters, profile_iters, &all_correct};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  if (!all_correct.load(std::memory_order_relaxed)) {
+    std::cerr << "Broadcast validation failed." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "[Main Process] All broadcast scenarios passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/examples/ccl/broadcast.cc
+++ b/examples/ccl/broadcast.cc
@@ -8,11 +8,14 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <charconv>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -32,6 +35,28 @@ struct ThreadArgs {
   int profile_iter;
   std::atomic_bool *all_correct;
 };
+
+template <typename T>
+bool ParseIntegerOption(const char *argument, T *value) {
+  if (!argument || !value) {
+    return false;
+  }
+
+  const std::string_view text(argument);
+  if (text.empty()) {
+    return false;
+  }
+
+  T parsed{};
+  const auto [end, error] =
+      std::from_chars(text.data(), text.data() + text.size(), parsed);
+  if (error != std::errc{} || end != text.data() + text.size()) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
 
 void WorkerThread(ThreadArgs args) {
   constexpr Device::Type kDevType =
@@ -131,16 +156,28 @@ int main(int argc, char **argv) {
   while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
     switch (opt) {
       case 'g':
-        num_gpus = std::stoi(optarg);
+        if (!ParseIntegerOption(optarg, &num_gpus)) {
+          std::cerr << "Invalid value for `-g`." << std::endl;
+          return EXIT_FAILURE;
+        }
         break;
       case 'w':
-        warmup_iters = std::stoi(optarg);
+        if (!ParseIntegerOption(optarg, &warmup_iters)) {
+          std::cerr << "Invalid value for `-w`." << std::endl;
+          return EXIT_FAILURE;
+        }
         break;
       case 'p':
-        profile_iters = std::stoi(optarg);
+        if (!ParseIntegerOption(optarg, &profile_iters)) {
+          std::cerr << "Invalid value for `-p`." << std::endl;
+          return EXIT_FAILURE;
+        }
         break;
       case 'n':
-        num_elements = static_cast<size_t>(std::stoull(optarg));
+        if (!ParseIntegerOption(optarg, &num_elements)) {
+          std::cerr << "Invalid value for `-n`." << std::endl;
+          return EXIT_FAILURE;
+        }
         break;
       case 'h':
         std::cout << "Usage: " << argv[0] << " [options]\n"
@@ -164,11 +201,15 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
-  char hostname[256];
-  gethostname(hostname, sizeof(hostname));
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the host name." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
 
   const int root = num_gpus > 1 ? num_gpus - 1 : 0;
-  std::cout << "[Main Process] Host: " << hostname
+  std::cout << "[Main Process] Host: " << hostname.data()
             << " | Target GPUs: " << num_gpus << " | Root: " << root
             << std::endl;
 

--- a/examples/ccl/broadcast.cc
+++ b/examples/ccl/broadcast.cc
@@ -11,7 +11,9 @@
 #include <array>
 #include <atomic>
 #include <charconv>
+#include <cmath>
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -56,6 +58,35 @@ bool ParseIntegerOption(const char *argument, T *value) {
 
   *value = parsed;
   return true;
+}
+
+void PrintBroadcastMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double data_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << std::fixed;
+  std::cout << "Data size:      " << std::setprecision(2)
+            << data_bytes / kBytesPerMiB << " MiB" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        data_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
 }
 
 void WorkerThread(ThreadArgs args) {
@@ -116,8 +147,7 @@ void WorkerThread(ThreadArgs args) {
     }
 
     if (args.rank == 0) {
-      Metrics metrics{elapsed, total_bytes, args.size};
-      metrics.Print();
+      PrintBroadcastMetrics(args.num_elements, elapsed);
     }
   };
 

--- a/examples/ccl_mpi_hybrid/broadcast.cc
+++ b/examples/ccl_mpi_hybrid/broadcast.cc
@@ -1,0 +1,171 @@
+/**
+ * InfiniCCL Example: Broadcast (OpenMPI + CCL Hybrid)
+ *
+ * This example uses OpenMPI to distribute a CCL unique ID across processes,
+ * initializes one native CCL rank per GPU, and then performs CCL broadcasts.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "device.h"
+#include "infiniccl.h"
+#include "runtime.h"
+#include "traits.h"
+#include "utils.h"
+
+using namespace infini::ccl;
+
+bool RunBroadcastExample(int argc, char **argv, int warmup_iter,
+                         int profile_iter, size_t num_elements) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_INFINI(infinicclInit(&argc, &argv));
+
+  int rank = 0;
+  int size = 0;
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    constexpr char kUnknownHostname[] = "unknown";
+    std::copy_n(kUnknownHostname, sizeof(kUnknownHostname), hostname.begin());
+    std::cerr << "[Rank " << rank
+              << "] Failed to query the host name; using `unknown`."
+              << std::endl;
+  }
+  hostname.back() = '\0';
+
+  const char *local_rank_text = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+  int local_rank = 0;
+  if (local_rank_text) {
+    local_rank = std::atoi(local_rank_text);
+  }
+  CHECK_RT(Rt, Rt::SetDevice(local_rank));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
+
+  infinicclUniqueId id{};
+  if (rank == 0) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  CHECK_INFINI(infinicclBroadcast(&id, &id, sizeof(id), infinicclChar, 0, comm,
+                                  nullptr));
+
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
+  const int root = size > 1 ? size - 1 : 0;
+  std::cout << "[Rank " << rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << local_rank << " | Broadcast Root: " << root << std::endl;
+
+  constexpr float kRootValue = 42.0f;
+  constexpr float kSentinelValue = -1.0f;
+  const size_t total_bytes = num_elements * sizeof(float);
+
+  std::vector<float> h_send(num_elements, kSentinelValue);
+  std::vector<float> h_recv(num_elements, kSentinelValue);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), total_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), total_bytes));
+
+  auto ResetBuffers = [&]() {
+    std::fill(h_send.begin(), h_send.end(),
+              rank == root ? kRootValue : kSentinelValue);
+    std::fill(h_recv.begin(), h_recv.end(), kSentinelValue);
+    CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  };
+
+  auto RunScenario = [&](const std::string &name, float *verify_buff,
+                         auto &&collective_call) {
+    for (int i = 0; i < warmup_iter; ++i) {
+      CHECK_INFINI(collective_call());
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    Timer timer;
+    for (int i = 0; i < profile_iter; ++i) {
+      CHECK_INFINI(collective_call());
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    const double elapsed =
+        timer.ElapsedMs() / static_cast<double>(profile_iter);
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), verify_buff, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+
+    const bool correct = Validator::ValidateResult(
+        h_recv.data(), num_elements, kRootValue, rank, true, name);
+    if (rank == 0) {
+      Metrics metrics{elapsed, total_bytes, size};
+      metrics.Print();
+    }
+
+    return correct;
+  };
+
+  bool all_correct = true;
+
+  ResetBuffers();
+  all_correct &=
+      RunScenario("Out-of-Place Hybrid CCL Broadcast", d_recv, [&]() {
+        return infinicclBroadcast(d_send, d_recv, num_elements,
+                                  infinicclFloat32, root, comm, nullptr);
+      });
+
+  ResetBuffers();
+  float *d_in_place = rank == root ? d_send : d_recv;
+  all_correct &=
+      RunScenario("In-Place Hybrid CCL Broadcast", d_in_place, [&]() {
+        return infinicclBroadcast(d_in_place, d_in_place, num_elements,
+                                  infinicclFloat32, root, comm, nullptr);
+      });
+
+  ResetBuffers();
+  d_in_place = rank == root ? d_send : d_recv;
+  all_correct &=
+      RunScenario("Legacy In-Place Hybrid CCL Bcast", d_in_place, [&]() {
+        return infinicclBcast(d_in_place, num_elements, infinicclFloat32, root,
+                              comm, nullptr);
+      });
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
+
+  if (!all_correct) {
+    std::cerr << "[Rank " << rank << "] Hybrid CCL broadcast validation failed."
+              << std::endl;
+  }
+
+  return all_correct;
+}
+
+int main(int argc, char **argv) {
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kNumElements = 1 << 20;
+
+  return RunBroadcastExample(argc, argv, kWarmupIterations, kProfileIterations,
+                             kNumElements)
+             ? EXIT_SUCCESS
+             : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/broadcast.cc
+++ b/examples/ccl_mpi_hybrid/broadcast.cc
@@ -9,7 +9,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -22,6 +24,35 @@
 #include "utils.h"
 
 using namespace infini::ccl;
+
+void PrintBroadcastMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double data_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << std::fixed;
+  std::cout << "Data size:      " << std::setprecision(2)
+            << data_bytes / kBytesPerMiB << " MiB" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        data_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
 
 bool RunBroadcastExample(int argc, char **argv, int warmup_iter,
                          int profile_iter, size_t num_elements) {
@@ -114,8 +145,7 @@ bool RunBroadcastExample(int argc, char **argv, int warmup_iter,
     const bool correct = Validator::ValidateResult(
         h_recv.data(), num_elements, kRootValue, rank, true, name);
     if (rank == 0) {
-      Metrics metrics{elapsed, total_bytes, size};
-      metrics.Print();
+      PrintBroadcastMetrics(num_elements, elapsed);
     }
 
     return correct;

--- a/examples/mpi/broadcast.cc
+++ b/examples/mpi/broadcast.cc
@@ -8,7 +8,9 @@
 
 #include <unistd.h>
 
+#include <cmath>
 #include <functional>
+#include <iomanip>
 #include <iostream>
 #include <vector>
 
@@ -25,6 +27,35 @@
 #include "traits.h"
 
 using namespace infini::ccl;
+
+void PrintBroadcastMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double data_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << std::fixed;
+  std::cout << "Data size:      " << std::setprecision(2)
+            << data_bytes / kBytesPerMiB << " MiB" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        data_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
 
 void RunBroadcastExample(int argc, char **argv, int warmup_iter,
                          int profile_iter, const size_t kNumElements) {
@@ -91,8 +122,6 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
     if (rank == kRoot) {
       std::cout << "\n=== Performing " << scenario_name << " ===" << std::endl;
       if (scenario_name.find("Scenario 1") != std::string::npos) {
-        std::cout << "Data size: " << kNumElements << " floats ("
-                  << total_bytes / 1024 / 1024 << " MB)" << std::endl;
         std::cout << "Root Node: " << kRoot << std::endl;
       }
     }
@@ -121,8 +150,7 @@ void RunBroadcastExample(int argc, char **argv, int warmup_iter,
 
     // Performance Reporting
     if (rank == kRoot) {
-      Metrics metrics{elapsed, total_bytes, size};
-      metrics.Print();
+      PrintBroadcastMetrics(kNumElements, elapsed);
     }
   };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,19 @@ set(AUTOGEN_WARNING [[/*
 
 file(GLOB CORE_SRCS "*.cc")
 file(GLOB_RECURSE BASE_IMPL_SRCS "base/*.cc")
+file(GLOB_RECURSE BRIDGE_DEP_HEADERS CONFIGURE_DEPENDS
+    "base/*.h"
+    "backends/*.h"
+    "devices/*.h"
+    "devices/*.cuh"
+)
+string(REPLACE ";" "\n" BRIDGE_DEPENDENCY_CONTENT "${BRIDGE_DEP_HEADERS}")
+set(BRIDGE_DEPENDENCY_MANIFEST
+    "${CMAKE_CURRENT_BINARY_DIR}/bridge_dependencies.txt"
+)
+file(GENERATE OUTPUT "${BRIDGE_DEPENDENCY_MANIFEST}"
+    CONTENT "${BRIDGE_DEPENDENCY_CONTENT}\n"
+)
 
 target_sources(infiniccl PRIVATE
     ${CORE_SRCS}
@@ -298,7 +311,9 @@ add_custom_command(
             "${BACK_STR}"
     DEPENDS "${PROJECT_SOURCE_DIR}/scripts/gen_bridge.py"
             "${PROJECT_SOURCE_DIR}/include/comm.h"
+            "${BRIDGE_DEPENDENCY_MANIFEST}"
             ${BASE_IMPL_SRCS}
+            ${BRIDGE_DEP_HEADERS}
     VERBATIM
     COMMENT "Generating InfiniCCL bridge and manifest files for Devices: [${DEV_STR}] Backends: [${BACK_STR}]..."
 )

--- a/src/backends/ccl/common/impl/broadcast.h
+++ b/src/backends/ccl/common/impl/broadcast.h
@@ -1,0 +1,50 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_BROADCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_BROADCAST_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/broadcast.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclBroadcastImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type, int root,
+                            Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    auto *comm_internal = static_cast<Communicator *>(comm);
+    if (!comm_internal) {
+      return ReturnStatus::kInternalError;
+    }
+
+    if (!comm_internal->intra_comm() ||
+        comm_internal->intra_comm_backend() != backend ||
+        comm_internal->device_type() != device) {
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *intra = static_cast<CommInstance *>(comm_internal->intra_comm());
+    if (!intra->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType ccl_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &ccl_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(Api::Broadcast(
+        send_buff, recv_buff, count, ccl_type, root, intra->handle,
+        reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_BROADCAST_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,13 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result Broadcast(const void *send_buff, void *recv_buff, size_t count,
+                          DataType data_type, int root, Comm comm,
+                          Stream stream) {
+    return mcclBroadcast(send_buff, recv_buff, count, data_type, root, comm,
+                         stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/bcast.h
+++ b/src/backends/ccl/mccl/impl/bcast.h
@@ -1,0 +1,13 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BCAST_H_
+
+#include "base/bcast.h"
+
+namespace infini::ccl {
+
+template <>
+struct BackendEnabled<Bcast, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BCAST_H_

--- a/src/backends/ccl/mccl/impl/broadcast.h
+++ b/src/backends/ccl/mccl/impl/broadcast.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_
+
+#include "backends/ccl/common/impl/broadcast.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class BroadcastImpl<BackendType::kMccl, device>
+    : public CclBroadcastImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Broadcast, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,13 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result Broadcast(const void *send_buff, void *recv_buff, size_t count,
+                          DataType data_type, int root, Comm comm,
+                          Stream stream) {
+    return ncclBroadcast(send_buff, recv_buff, count, data_type, root, comm,
+                         stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/bcast.h
+++ b/src/backends/ccl/nccl/impl/bcast.h
@@ -1,0 +1,13 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BCAST_H_
+
+#include "base/bcast.h"
+
+namespace infini::ccl {
+
+template <>
+struct BackendEnabled<Bcast, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BCAST_H_

--- a/src/backends/ccl/nccl/impl/broadcast.h
+++ b/src/backends/ccl/nccl/impl/broadcast.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BROADCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BROADCAST_H_
+
+#include "backends/ccl/common/impl/broadcast.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class BroadcastImpl<BackendType::kNccl, device>
+    : public CclBroadcastImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Broadcast, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_BROADCAST_H_

--- a/src/base/broadcast.h
+++ b/src/base/broadcast.h
@@ -31,11 +31,38 @@ class Broadcast : public Operation<Broadcast> {
       return ReturnStatus::kSuccess;
     }
 
+    if (!comm->HasBackend(backend_type) || comm->device_type() != device_type) {
+      BackendType comm_backend = backend_type;
+      if (!comm->HasBackend(comm_backend)) {
+        comm_backend = comm->intra_comm_backend();
+        if (comm_backend == BackendType::kCount) {
+          comm_backend = comm->inter_comm_backend();
+        }
+      }
+      if (comm_backend == BackendType::kCount) {
+        LOG("No initialized backend is available for `Broadcast`.");
+        return ReturnStatus::kInternalError;
+      }
+
+      // Keep the key dependent so provider `BackendEnabled`
+      // specializations are visible when redispatch is instantiated.
+      using DispatchKey =
+          typename BackendDependentType<backend_type, Broadcast>::type;
+      return Operation<DispatchKey>::Call(comm_backend, comm->device_type(),
+                                          send_buff, recv_buff, count, datatype,
+                                          root, comm_handle, stream);
+    }
+
     return BroadcastImpl<backend_type, device_type>::Apply(
         send_buff, recv_buff, count, datatype, root, comm, stream);
   }
 
  private:
+  template <BackendType, typename T>
+  struct BackendDependentType {
+    using type = T;
+  };
+
   static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
                              size_t count, DataType datatype, int root,
                              Communicator *comm) {


### PR DESCRIPTION
## Summary

This PR adds `Broadcast` support to the shared CCL backend abstraction, including native bindings through the existing NCCL and MCCL provider layers for the public `infinicclBroadcast()` API and its legacy in-place `infinicclBcast()` alias. It also teaches `Broadcast` dispatch to follow the backend/device combination stored in the communicator for mixed-backend bootstrap flows, adds generated-bridge dependency tracking for header-only operation implementations, and includes CCL-only plus OpenMPI-assisted `Broadcast` example programs covering out-of-place, in-place, and legacy broadcast flows with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclBroadcast()` and `infinicclBcast()` APIs for configured CCL backends through generated bridge dispatch.
  - Redispatch `Broadcast` according to the initialized backend and device stored in the supplied communicator.
  - Keep bootstrap broadcasts on the communicator's initialized MPI backend in mixed MPI and CCL configurations.

- **Common CCL Implementation**
  - Add a shared CCL `Broadcast` implementation following the existing provider-oriented `AllReduce` structure.
  - Validate the CCL communicator instance and map InfiniCCL data types through the configured provider before dispatch.
  - Return `NotSupported` when the selected provider cannot represent the requested data type.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with thin bindings to `ncclBroadcast()` and `mcclBroadcast()`.
  - Register `Broadcast` and the legacy in-place `Bcast` alias with the existing NCCL and MCCL provider layers.

- **Bridge Generation**
  - Track base, backend, and device headers as generated bridge dependencies.
  - Regenerate the bridge when a header-only operation implementation is added, removed, or changed.

- **Examples and Validation**
  - Add a thread-per-GPU single-node CCL `Broadcast` example.
  - Add an OpenMPI-assisted CCL `Broadcast` example that uses OpenMPI for rank discovery and unique-ID broadcast, then initializes a native CCL communicator for GPU data broadcast.
  - Validate out-of-place `Broadcast`, in-place `Broadcast`, and legacy in-place `Bcast` with the last GPU rank as root.
  - Propagate validation failures through the process exit status and reset buffers independently for every scenario.
  - Parse numeric options without exceptions and validate host-name discovery in the CCL-only example.
  - Report payload size, average time, algorithm bandwidth as `count * type_size / time`, and bus bandwidth with the Broadcast correction factor of 1 for every scenario.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds a GPU-native CCL path for `Broadcast`, avoiding the existing MPI host-staging path when a supported CCL backend is selected. Existing MPI collectives are intended to remain unchanged.

## Known Issues & Future Work

- CCL collective support now covers `AllReduce`, `Broadcast`, and the legacy `Bcast` alias; other CCL collective operations remain future work.
- `Broadcast` inherits the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The server examples validate `Float32` payloads with the last rank as root on the default stream. Additional data types, roots, non-default streams, and runtime coverage on Iluvatar and Moore Threads remain future work.

## Test Results

The tested head is `7c6d61b2670a709597b0ba1a72de9e829bdc1659`. Its four focused commits are rebased linearly on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The current-commit evidence contains exactly 15 canonical logs: all 15 targets passed on the full matrix. All 23 expected validation outcomes are positive with no negative result; in the pure-NCCL log, one asynchronous NCCL INFO line split the first `Correct:` label from its immediately following `YES` token, while the target and runner both exited successfully.

Every Broadcast scenario used 1,048,576 `Float32` elements (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations. The three values in each cell are out-of-place / in-place / legacy `Bcast`:

| Path | Test topology | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 1.921 / 2.161 / 0.853 ms | 2.18 / 1.94 / 4.92 GB/s | 2.18 / 1.94 / 4.92 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 0.054 / 0.380 / 0.963 ms | 77.26 / 11.04 / 4.35 GB/s | 77.26 / 11.04 / 4.35 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 3.596 / 3.153 / 3.152 ms | 1.17 / 1.33 / 1.33 GB/s | 1.17 / 1.33 / 1.33 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 0.378 / 0.444 / 0.459 ms | 11.10 / 9.45 / 9.14 GB/s | 11.10 / 9.45 / 9.14 GB/s |

Algorithm bandwidth uses `count * sizeof(float) / time`; Broadcast bus bandwidth uses a correction factor of 1, so it equals algorithm bandwidth. Values were independently checked against the three-decimal displayed time and are execution evidence, not a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2, on all 8 A100 GPUs.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks, mapping ranks 0-7 to NVIDIA devices 0-7 and ranks 8-15 to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, mapping ranks 0-7 to devices 0-7.
- All five formal runner invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA**:
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346307/ccl_all_reduce.log)
[ccl_broadcast.log](https://github.com/user-attachments/files/31346308/ccl_broadcast.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31346310/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_broadcast.log](https://github.com/user-attachments/files/31346311/ccl_mpi_hybrid_broadcast.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31346313/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31346314/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31346315/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31346316/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31346317/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31346318/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31346319/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31346320/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31346321/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346323/ccl_all_reduce.log)
[ccl_broadcast.log](https://github.com/user-attachments/files/31346324/ccl_broadcast.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The feature, example-hardening, hybrid-example, and metrics-fix commits are focused and independently reviewable. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The four commits are linear above `ef4045a`. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- The example's output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; existing `infinicclBroadcast()` and `infinicclBcast()` gain CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Library error paths follow the repository's `LOG(...)` plus `ReturnStatus` convention; numeric example options use non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor or member declaration was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The current-commit evidence contains 15/15 passing canonical logs and all 23 expected positive validation outcomes on the full 8-A100 + 8-C550 matrix. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed, so ruff is not applicable. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- The host-name buffer is zero-initialized, `gethostname()` is checked, and termination is explicitly guaranteed. -->
