### PR TITLE
feat: add HYGON platform support across runtime, device, build, and launcher stack

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -58,6 +58,7 @@ Please check all the platforms and/or backends this PR affects (i.e., code is to
 - [ ] MetaX GPU
 - [ ] Moore Threads GPU
 - [ ] Cambricon MLU
+- [ ] HYGON DCU
 
 ### Backend
 
@@ -107,6 +108,7 @@ See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and
 - [ ] MetaX GPU
 - [ ] Moore Threads GPU
 - [ ] Cambricon MLU
+- [ ] HYGON DCU
 
 ### Test Involved Backend
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(WITH_ILUVATAR    "Enable ILUVATAR GPU support"   OFF)
 option(WITH_METAX       "Enable MetaX GPU support"      OFF)
 option(WITH_MOORE       "Enable Moore GPU support"      OFF)
 option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
+option(WITH_HYGON       "Enable Hygon DCU support"      OFF)
 
 set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
 
@@ -175,6 +176,44 @@ if(AUTO_DETECT_DEVICES)
     else()
         set(WITH_CAMBRICON OFF)
         message(STATUS "Cambricon environment not detected.")
+    endif()
+
+    # Hygon DCU
+    if(NOT WITH_HYGON)
+        set(HYGON_FOUND FALSE)
+
+        if((DEFINED ENV{DTKROOT} OR DEFINED ENV{DTK_ROOT} OR DEFINED ENV{ROCM_PATH})
+           AND EXISTS "/dev/kfd")
+            set(HYGON_FOUND TRUE)
+        elseif(EXISTS "/opt/dtk" AND EXISTS "/dev/kfd")
+            set(HYGON_FOUND TRUE)
+        else()
+            find_program(HYGON_SMI_PATH
+                NAMES hy-smi rocm-smi
+                HINTS /opt/hyhal/bin /opt/dtk/bin
+            )
+            if(HYGON_SMI_PATH)
+                execute_process(
+                    COMMAND ${HYGON_SMI_PATH}
+                    RESULT_VARIABLE SMI_RESULT
+                    OUTPUT_QUIET
+                    ERROR_QUIET
+                )
+                if(SMI_RESULT EQUAL 0)
+                    set(HYGON_FOUND TRUE)
+                endif()
+            endif()
+        endif()
+
+        if(HYGON_FOUND)
+            set(WITH_HYGON ON)
+        endif()
+    endif()
+
+    if(WITH_HYGON)
+        message(STATUS "Hygon environment detected.")
+    else()
+        message(STATUS "Hygon environment not detected.")
     endif()
 endif()
 
@@ -372,6 +411,51 @@ if(WITH_CAMBRICON)
     find_library(CAMBRICON_CNNL_LIB       NAMES cnnl       HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
     find_library(CAMBRICON_CNNL_EXTRA_LIB NAMES cnnl_extra HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
     find_library(CAMBRICON_PAPI_LIB       NAMES cnpapi     HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
+endif()
+
+if(WITH_HYGON)
+    set(HYGON_DTK_ROOT "")
+    foreach(_hygon_env DTKROOT DTK_ROOT ROCM_PATH)
+        if(NOT HYGON_DTK_ROOT AND DEFINED ENV{${_hygon_env}} AND NOT "$ENV{${_hygon_env}}" STREQUAL "")
+            set(HYGON_DTK_ROOT "$ENV{${_hygon_env}}")
+        endif()
+    endforeach()
+
+    if(NOT HYGON_DTK_ROOT AND DEFINED ENV{HIP_PATH} AND NOT "$ENV{HIP_PATH}" STREQUAL "")
+        get_filename_component(HYGON_DTK_ROOT "$ENV{HIP_PATH}/.." ABSOLUTE)
+    endif()
+
+    if(NOT HYGON_DTK_ROOT AND EXISTS "/opt/dtk")
+        set(HYGON_DTK_ROOT "/opt/dtk")
+    endif()
+
+    if(NOT HYGON_DTK_ROOT)
+        message(FATAL_ERROR "`WITH_HYGON` is `ON` but DTK was not found. Set `DTKROOT`, `DTK_ROOT`, `ROCM_PATH`, or `HIP_PATH`.")
+    endif()
+
+    set(HYGON_HIP_HINTS "${HYGON_DTK_ROOT}" "${HYGON_DTK_ROOT}/hip")
+    find_path(HYGON_HIP_INCLUDE_DIR
+        NAMES hip/hip_runtime.h
+        HINTS ${HYGON_HIP_HINTS}
+        PATH_SUFFIXES include hip/include
+        REQUIRED
+    )
+    find_library(HYGON_HIP_RUNTIME_LIB
+        NAMES amdhip64
+        HINTS ${HYGON_HIP_HINTS}
+        PATH_SUFFIXES lib lib64 hip/lib
+        REQUIRED
+    )
+    find_program(HYGON_HIPCC_COMPILER
+        NAMES hipcc
+        HINTS ${HYGON_HIP_HINTS}
+        PATH_SUFFIXES bin hip/bin
+        REQUIRED
+    )
+
+    set(CMAKE_CXX_COMPILER "${HYGON_HIPCC_COMPILER}" CACHE FILEPATH "Hygon DTK hipcc compiler" FORCE)
+    set(HYGON_HIP_DEFINITIONS __HIP_PLATFORM_AMD__)
+    include_directories(${HYGON_HIP_INCLUDE_DIR})
 endif()
 
 if(WITH_OMPI OR WITH_MPICH)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ cmake .. -DWITH_NVIDIA=ON -DWITH_OMPI=ON
 | `WITH_METAX`      | Enable MetaX GPU support  | `OFF` |
 | `WITH_MOORE`      | Enable Moore Threads GPU support  | `OFF` |
 | `WITH_CAMBRICON`  | Enable Cambricon MLU support  | `OFF` |
+| `WITH_HYGON`      | Enable HYGON DCU support  | `OFF` |
 | `WITH_CPU`        | CPU support (always enabled) | `ON` (internal, not user‑settable) |
 | **Backend (Communication) Options** |||
 | `WITH_OMPI`   | Enable OpenMPI backend | `ON` if no backend specified, otherwise `OFF` |
@@ -187,7 +188,7 @@ After having a successful build and a complete `cluster.yaml`, we are ready for 
 | `nodes[].ip` | Yes | Node | Node IP address or hostname. Use `localhost` or `127.0.0.1` for the local node. |
 | `nodes[].user` | No | Node | SSH user for this node. Overrides `common_user`. |
 | `nodes[].dir` | No | Node | Node-specific project source directory. Overrides `common_dir` for this node and is useful when the project path differs across hosts. |
-| `nodes[].type` | Yes | Node | Architecture/build label used in build, install, and wrapper paths. Common values include `cpu`, `nvidia`, `iluvatar`, `metax`, `moore`, and `cambricon`. |
+| `nodes[].type` | Yes | Node | Architecture/build label used in build, install, and wrapper paths. Common values include `cpu`, `nvidia`, `iluvatar`, `metax`, `moore`, `cambricon`, and `hygon`. |
 | `nodes[].slots` | No | Node | Number of processes to launch on this node. This usually matches the number of devices assigned to the node. Defaults to `8`. |
 | `nodes[].cmake_flags` | No | Node | Node-specific CMake options used during `--build`, such as `-DUSE_CUDA=ON` or `-DUSE_MACA=ON`. Overrides global `cmake_flags` for this node. |
 | `nodes[].backend_env` | No | Node | Node-specific runtime environment variables, such as `CUDA_VISIBLE_DEVICES`, `UCX_TLS`, or `UCX_NET_DEVICES`. Overrides or prepends to global `backend_env` values for this node. |
@@ -343,6 +344,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 | **MetaX**      | Full | Requires MACA SDK and `MACA_PATH` (default `/opt/maca`) to be set. |
 | **Moore Threads** | Full | Requires MUSA SDK and at least one of `MACA_ROOT` (default `/usr/local/musa`), `MACA_PATH`, and `MUSA_HOME` to be set. |
 | **Cambricon**  | Full | Requires CNToolKit and `NEUWARE_HOME` to be set. |
+| **HYGON**      | Full | Requires HYGON DTK and HYHAL. |
 
 </details>
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,12 @@ foreach(source_file ${EXAMPLE_SOURCES})
         target_link_libraries(${target_name} PRIVATE ${CAMBRICON_RUNTIME_LIB})
     endif()
     
+    if(WITH_HYGON)
+        target_include_directories(${target_name} PRIVATE ${HYGON_HIP_INCLUDE_DIR})
+        target_compile_definitions(${target_name} PRIVATE ${HYGON_HIP_DEFINITIONS})
+        target_link_libraries(${target_name} PRIVATE ${HYGON_HIP_RUNTIME_LIB})
+    endif()
+
     if(WITH_OMPI OR WITH_MPICH)
         target_link_libraries(${target_name} PRIVATE MPI::MPI_CXX)
     endif()

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -55,6 +55,7 @@ struct Metrics {
               << bus_bw << " GB/s (Bus BW)" << std::endl;
     std::cout << "Alg Bandwidth:  " << std::fixed << std::setprecision(2)
               << alg_bw << " GB/s" << std::endl;
+    return;
   }
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -199,6 +199,24 @@ if(WITH_CAMBRICON)
     )
 endif()
 
+# Hygon
+if(WITH_HYGON)
+    list(APPEND DEVICE_LIST "hygon")
+
+    set(HYGON_PATTERNS
+        "devices/hygon/*.cc"
+        "devices/hygon/*.cpp"
+    )
+    file(GLOB_RECURSE HYGON_SRCS ${HYGON_PATTERNS})
+
+    set_source_files_properties(${HYGON_SRCS} PROPERTIES LANGUAGE CXX)
+
+    target_sources(infiniccl PRIVATE ${HYGON_SRCS})
+    target_include_directories(infiniccl PRIVATE ${HYGON_HIP_INCLUDE_DIR})
+    target_compile_definitions(infiniccl PRIVATE ${HYGON_HIP_DEFINITIONS})
+    target_link_libraries(infiniccl PRIVATE ${HYGON_HIP_RUNTIME_LIB})
+endif()
+
 # =========================================================
 # --- BACKEND SECTIONS (Communication Protocols) ---
 # =========================================================

--- a/src/backends/mpi/ompi/comm_instance.h
+++ b/src/backends/mpi/ompi/comm_instance.h
@@ -19,6 +19,7 @@ struct OmpiInstance : public BackendCommInstance {
       INFINI_CHECK_MPI(MPI_Comm_free(&handle));
       handle = MPI_COMM_NULL;
     }
+    return;
   }
 };
 

--- a/src/communicator.h
+++ b/src/communicator.h
@@ -24,6 +24,7 @@ class Communicator {
   void set_world_info(int rank, int size) {
     global_rank_ = rank;
     global_size_ = size;
+    return;
   }
 
   auto intra_comm() const { return intra_comm_.get(); }
@@ -32,10 +33,12 @@ class Communicator {
 
   void set_intra_comm(std::unique_ptr<BackendCommInstance> inst) {
     intra_comm_ = std::move(inst);
+    return;
   }
 
   void set_inter_comm(std::unique_ptr<BackendCommInstance> inst) {
     inter_comm_ = std::move(inst);
+    return;
   }
 
   BackendType intra_comm_backend() const {
@@ -52,7 +55,10 @@ class Communicator {
 
   int device_id() const { return device_id_; }
 
-  void set_device_id(int id) { device_id_ = id; }
+  void set_device_id(int id) {
+    device_id_ = id;
+    return;
+  }
 
   Device::Type device_type() const { return device_type_; }
 

--- a/src/device.h
+++ b/src/device.h
@@ -156,6 +156,11 @@ struct DevicePriority<Device::Type::kCambricon> {
   static constexpr int value = 5;
 };
 
+template <>
+struct DevicePriority<Device::Type::kHygon> {
+  static constexpr int value = 5;
+};
+
 enum class MemorySpace : std::uint8_t { kHost = 0, kDevice = 1, kUnknown };
 
 template <Device::Type kDev>

--- a/src/devices/hygon/caster_.h
+++ b/src/devices/hygon/caster_.h
@@ -1,0 +1,80 @@
+#ifndef INFINI_CCL_DEVICES_HYGON_CASTER_H_
+#define INFINI_CCL_DEVICES_HYGON_CASTER_H_
+
+#include "caster.h"
+#include "data_type_.h"
+#include "traits.h"
+
+namespace infini::ccl {
+
+// DTK exposes half/bfloat16 compound operators to `hipcc`, but they are not
+// usable on host staging buffers in the MPI backend. Force these types through
+// the bridge.
+template <typename S, typename Op>
+struct SupportsOp<half, S, Op, void> : std::false_type {};
+
+template <typename S, typename Op>
+struct SupportsOp<hip_bfloat16, S, Op, void> : std::false_type {};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, float, hip_bfloat16> {
+  __host__ __device__ static float Apply(hip_bfloat16 x) {
+    return static_cast<float>(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, hip_bfloat16, float> {
+  __host__ __device__ static hip_bfloat16 Apply(float x) {
+    return hip_bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, hip_bfloat16, int> {
+  __host__ __device__ static hip_bfloat16 Apply(int x) {
+    return hip_bfloat16(static_cast<float>(x));
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, half, int> {
+  __host__ __device__ static half Apply(int x) {
+    return __float2half(static_cast<float>(x));
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, hip_bfloat16, double> {
+  __host__ __device__ static hip_bfloat16 Apply(double x) {
+    return hip_bfloat16(static_cast<float>(x));
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, half, double> {
+  __host__ __device__ static half Apply(double x) {
+    return __float2half(static_cast<float>(x));
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kHygon, half, hip_bfloat16> {
+  __host__ __device__ static half Apply(hip_bfloat16 x) {
+    return __float2half(static_cast<float>(x));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_HYGON_CASTER_H_

--- a/src/devices/hygon/data_type_.h
+++ b/src/devices/hygon/data_type_.h
@@ -1,0 +1,26 @@
+#ifndef INFINI_CCL_DEVICES_HYGON_DATA_TYPE_H_
+#define INFINI_CCL_DEVICES_HYGON_DATA_TYPE_H_
+
+// clang-format off
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_fp16.h>
+// clang-format on
+
+#include "data_type_impl.h"
+#include "devices/hygon/device_.h"
+
+namespace infini::ccl {
+
+template <>
+struct TypeMap<Device::Type::kHygon, DataType::kFloat16> {
+  using type = half;
+};
+
+template <>
+struct TypeMap<Device::Type::kHygon, DataType::kBFloat16> {
+  using type = hip_bfloat16;
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_HYGON_DATA_TYPE_H_

--- a/src/devices/hygon/device_.h
+++ b/src/devices/hygon/device_.h
@@ -1,0 +1,36 @@
+#ifndef INFINI_CCL_DEVICES_HYGON_DEVICE_H_
+#define INFINI_CCL_DEVICES_HYGON_DEVICE_H_
+
+// clang-format off
+#include <hip/hip_runtime.h>
+// clang-format on
+
+#include "device.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kHygon> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kHygon>(const void *ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  hipPointerAttribute_t attr;
+  hipError_t status = hipPointerGetAttributes(&attr, ptr);
+  if (status != hipSuccess) {
+    (void)hipGetLastError();
+    return MemorySpace::kHost;
+  }
+
+  return attr.type == hipMemoryTypeDevice || attr.type == hipMemoryTypeArray ||
+                 attr.type == hipMemoryTypeManaged
+             ? MemorySpace::kDevice
+             : MemorySpace::kHost;
+}
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_HYGON_DEVICE_H_

--- a/src/devices/hygon/runtime_.h
+++ b/src/devices/hygon/runtime_.h
@@ -1,0 +1,60 @@
+#ifndef INFINI_CCL_DEVICES_HYGON_RUNTIME_H_
+#define INFINI_CCL_DEVICES_HYGON_RUNTIME_H_
+
+#include <utility>
+
+// clang-format off
+#include <hip/hip_runtime.h>
+// clang-format on
+
+#include "devices/cuda/runtime_.h"
+#include "devices/hygon/device_.h"
+#include "logging.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kHygon>
+    : CudaRuntime<Runtime<Device::Type::kHygon>> {
+  using Stream = hipStream_t;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kHygon;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != hipSuccess) {
+          LOG(hipGetErrorString(static_cast<hipError_t>(status)));
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](auto &&...args) {
+    return hipMalloc(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Memcpy = hipMemcpy;
+
+  static constexpr auto Free = hipFree;
+
+  static constexpr auto MemcpyHostToDevice = hipMemcpyHostToDevice;
+
+  static constexpr auto MemcpyDeviceToHost = hipMemcpyDeviceToHost;
+
+  static constexpr auto Memset = hipMemset;
+
+  static constexpr auto GetDevice = hipGetDevice;
+
+  static constexpr auto SetDevice = hipSetDevice;
+
+  static constexpr auto DeviceSynchronize = hipDeviceSynchronize;
+
+  static constexpr auto StreamSynchronize = hipStreamSynchronize;
+};
+
+static_assert(Runtime<Device::Type::kHygon>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_HYGON_RUNTIME_H_


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

This PR adds support for the HYGON platform, enabling both build-time and runtime integration. Existing examples using the MPI backends (e.g., OpenMPI) can now run on HYGON hardware with platform-specific specializations.

Changes include build logic, device priority handling, runtime specialization, and example execution support.

## Changes

- **Hygon Build Integration**
  - Detects DTK through `DTKROOT`, `DTK_ROOT`, `ROCM_PATH`, `HIP_PATH`, or the default `/opt/dtk` path;
  - Finds DTK HIP headers, `libamdhip64`, and `hipcc`, then uses DTK `hipcc` as the C++ compiler for Hygon builds.

- **Hygon Runtime Device Support**
  - Adds `Device::Type::kHygon`, string mappings, and device priority handling in `src/device.h`;
  - Adds HIP-backed runtime wrappers in `src/devices/hygon/runtime_.h`;
  - Adds Hygon memory-space detection in `src/devices/hygon/device_.h`.

- **Hygon Data Type and Casting Support**
  - Maps InfiniCCL float16/bfloat16 types to DTK HIP `half` and `hip_bfloat16` in `src/devices/hygon/data_type_.h`;
  - Adds Hygon hardware cast specializations in `src/devices/hygon/caster_.h`;
  - Forces Hygon half/bfloat16 MPI reductions through the existing float bridge path because DTK host staging buffers cannot rely on direct compound operators for these types.

- **MPI Example Build Cleanup**
  - Adds explicit return statements in small `void` helpers that DTK `hipcc` warned about. Touches: 
    -  `src/communicator.h`
    - `src/backends/mpi/ompi/comm_instance.h`, and 
    - `examples/utils.h`.

- **Documentation and Template Updates**
  - Updated `.github/pull_request_template.md` to include HYGON as a supported platform;
  - Updated `README.md` to include HYGON as a supported platform.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [x] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [ ] NCCL
- [ ] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
N/A.

## Known Issues & Future Work

- Hygon support is currently validated for MPI examples through OpenMPI only. RCCL/CCL integration is not implemented in this PR.
- When CUDA-compatible APIs and environment variables are enabled, setting `AUTO_DETECT_DEVICES=ON` will also detect and enable `nvidia`, which may cause errors at this point. In this case, it is recommended to disable `AUTO_DETECT_DEVICES` and manually enable only HYGON.

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [x] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL

**HYGON (single node, OpenMPI):**
[mpi_all_gather.log](https://github.com/user-attachments/files/30780366/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/30780371/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/30780374/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/30780376/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/30780379/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/30780381/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/30780384/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/30780385/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/30780386/mpi_send_recv.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A - No Python files changed.

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [x] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
