### PR TITLE
fix(build): regenerate communication bridge for header changes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,21 @@ set(AUTOGEN_WARNING [[/*
 
 file(GLOB CORE_SRCS "*.cc")
 file(GLOB_RECURSE BASE_IMPL_SRCS "base/*.cc")
+file(GLOB_RECURSE BRIDGE_DEP_HEADERS CONFIGURE_DEPENDS
+    "base/*.h"
+    "backends/*.h"
+    "devices/*.h"
+    "devices/*.cuh"
+)
+
+string(REPLACE ";" "\n" BRIDGE_DEPENDENCY_CONTENT "${BRIDGE_DEP_HEADERS}")
+set(BRIDGE_DEPENDENCY_MANIFEST
+    "${CMAKE_CURRENT_BINARY_DIR}/bridge_dependencies.txt"
+)
+file(GENERATE
+    OUTPUT "${BRIDGE_DEPENDENCY_MANIFEST}"
+    CONTENT "${BRIDGE_DEPENDENCY_CONTENT}\n"
+)
 
 target_sources(infiniccl PRIVATE
     ${CORE_SRCS}
@@ -298,7 +313,9 @@ add_custom_command(
             "${BACK_STR}"
     DEPENDS "${PROJECT_SOURCE_DIR}/scripts/gen_bridge.py"
             "${PROJECT_SOURCE_DIR}/include/comm.h"
+            "${BRIDGE_DEPENDENCY_MANIFEST}"
             ${BASE_IMPL_SRCS}
+            ${BRIDGE_DEP_HEADERS}
     VERBATIM
     COMMENT "Generating InfiniCCL bridge and manifest files for Devices: [${DEV_STR}] Backends: [${BACK_STR}]..."
 )


### PR DESCRIPTION
## Summary

Regenerate the generated communication bridge whenever a source header used by the bridge generator changes. Existing build directories could otherwise retain a stale backend manifest after provider headers were added, removed, or modified.

## Changes

- **Dependency tracking**
  - Track the base, backend, and device headers read by the bridge generator.
  - Generate a stable dependency list so header additions and removals trigger CMake reconfiguration.
  - Add the tracked headers to the bridge custom command dependencies.
- **Regression coverage**
  - Add a source contract test for the generator dependency graph.
  - Register the contract with CTest.

## Platform and Backend Affected

### Platform

- [x] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [x] Cambricon MLU
- [x] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

N/A. This changes build invalidation only.

## Known Issues & Future Work

- None.

## Test Results

Test environment: `ssh nvidia`, `accelerator-dev/nvidia:latest`.

- Clean OpenMPI configure and build passed.
- Touching an existing provider header regenerated the manifest and bridge.
- Adding a provider header triggered CMake glob reconfiguration, regenerated the bridge, and added the provider to the manifest.
- CTest passed.
- `ruff check`, `ruff format --check`, and `git diff --check` passed.

### Test Involved Platform

- [x] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL

---

## Checklist

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Each **commit** message follows Conventional Commits.
- [x] This small PR is a single squashable commit.
- [x] No stray merge commits from `master`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are minimal and contain no unrelated modifications.
- [x] No dead code, debug output, or unowned TODOs were added.
- [x] No unrelated formatting churn was introduced.
- N/A: No public runtime API changes are included.

### General Code Hygiene

- [x] Comments are limited to non-obvious intent.
- [x] Every modified or added file ends with a single trailing newline.
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting remains.
- [x] Code identifiers in comments and errors use Markdown backticks where applicable.
- [x] Comments and error messages are in English.
- [x] Comments and error messages follow the repository language conventions.

### C++ Specific

N/A: No C++ source file changes are included.

### Python Specific

- [x] The regression test is PEP 8 compliant and `ruff check` passes.
- [x] `ruff format --check` passes.
- [x] Comments follow the repository conventions.
- [x] Framework-specific conventions are preserved.
- [x] Function body spacing follows the repository conventions.
- [x] Control-flow spacing follows the repository conventions.
- [x] Return statement spacing follows the repository conventions.
- [x] Docstrings follow PEP 257 where applicable.
- [x] Type hints are consistent with surrounding tests.

### Testing

- N/A: This build-dependency PR has no runtime example behavior; clean and incremental bridge builds are covered above.

### Build, CI, and Tooling

- N/A: No backend or device auto-detection entry is added.
- [x] The applicable Ruff checks pass locally; clang-format is not applicable.

### Documentation

- N/A: This fixes internal build invalidation and does not change the user workflow or public behavior.
- N/A: No user-visible breaking change is introduced.

### Security and Safety

- [x] No secrets, internal URLs, customer data, or personal hardware identifiers are included.
- [x] No third-party code is introduced.
- [x] No unsafe pointer arithmetic, uninitialized read, or bounds-check change is introduced.