### PR TITLE
feat: support CCL `Send` and `Recv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ export LD_LIBRARY_PATH=${INFINI_INSTALL}/lib:$LD_LIBRARY_PATH
 |---------|---------------|----------------------|---------------|
 | **OpenMPI** | Full | `WITH_OMPI=ON` | The default backend. Requires the OpenMPI development package.|
 | **MPICH** | Full | `WITH_MPICH=ON` | Requires the MPICH development package.|
-| **NCCL** | Partial | `WITH_NCCL=ON` | Requires NVIDIA or Iluvatar NCCL. Currently available when `WITH_NVIDIA=ON` or `WITH_ILUVATAR=ON`.|
+| **NCCL** | Partial | `WITH_NCCL=ON` | Requires NVIDIA or Iluvatar NCCL 2.10 or newer. Currently available when `WITH_NVIDIA=ON` or `WITH_ILUVATAR=ON`.|
 | **MCCL** | Partial | `WITH_MCCL=ON` | Requires MetaX or Moore MCCL. Currently available when `WITH_METAX=ON` or `WITH_MOORE=ON`.|
 
 </details>

--- a/examples/ccl/send_recv.cc
+++ b/examples/ccl/send_recv.cc
@@ -1,0 +1,282 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Send/Recv
+ *
+ * This example initializes one native CCL communicator rank per GPU thread
+ * and transfers data from rank 0 to rank 1 with `infinicclSend()` and
+ * `infinicclRecv()`. Other ranks participate in communicator initialization
+ * and teardown only.
+ *
+ * Run this example with `--launcher none`; it does not use MPI.
+ */
+
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "infiniccl.h"
+#include "utils.h"
+
+namespace ccl = infini::ccl;
+
+namespace {
+
+constexpr int kSenderRank = 0;
+constexpr int kReceiverRank = 1;
+constexpr float kPayloadValue = 7.0f;
+
+struct RunState {
+  std::atomic<int> initialized{0};
+  std::atomic<int> completed{0};
+  bool correct = false;
+  float actual = 0.0f;
+  double elapsed_ms = 0.0;
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId unique_id;
+  size_t num_elements;
+  int warmup_iters;
+  int profile_iters;
+  RunState *state;
+};
+
+template <typename T>
+bool ParseInteger(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  const char *end = text + std::strlen(text);
+  auto result = std::from_chars(text, end, *value);
+  return result.ec == std::errc{} && result.ptr == end;
+}
+
+void WaitForAll(std::atomic<int> *counter, int size) {
+  counter->fetch_add(1, std::memory_order_acq_rel);
+  while (counter->load(std::memory_order_acquire) != size) {
+    std::this_thread::yield();
+  }
+}
+
+void PrintSendRecvMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double payload_bytes =
+      static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size:      " << num_elements << " floats (" << std::fixed
+            << std::setprecision(2) << payload_bytes / kBytesPerMiB << " MiB)"
+            << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        payload_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    // A one-way point-to-point transfer moves one payload over the bus.
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void RunWorker(ThreadArgs args) {
+  constexpr ccl::Device::Type kDeviceType =
+      ccl::ListGetBest<ccl::DevicePriority>(ccl::EnabledDevices{});
+  using Rt = ccl::Runtime<kDeviceType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(
+      infinicclCommInitRank(&comm, args.size, args.unique_id, args.rank));
+
+  const bool is_sender = args.rank == kSenderRank;
+  const bool is_receiver = args.rank == kReceiverRank;
+  const bool transfers_data = is_sender || is_receiver;
+  const size_t total_bytes = args.num_elements * sizeof(float);
+
+  std::vector<float> host_buffer(transfers_data ? args.num_elements : 0,
+                                 is_sender ? kPayloadValue : 0.0f);
+  float *device_buffer = nullptr;
+
+  if (transfers_data) {
+    CHECK_RT(
+        Rt, Rt::Malloc(reinterpret_cast<void **>(&device_buffer), total_bytes));
+    CHECK_RT(Rt, Rt::Memcpy(device_buffer, host_buffer.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  }
+
+  WaitForAll(&args.state->initialized, args.size);
+
+  auto transfer = [&]() {
+    if (is_sender) {
+      return infinicclSend(device_buffer, args.num_elements, infinicclFloat32,
+                           kReceiverRank, comm, nullptr);
+    }
+    if (is_receiver) {
+      return infinicclRecv(device_buffer, args.num_elements, infinicclFloat32,
+                           kSenderRank, comm, nullptr);
+    }
+    return infinicclSuccess;
+  };
+
+  for (int i = 0; i < args.warmup_iters; ++i) {
+    CHECK_INFINI(transfer());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iters; ++i) {
+    CHECK_INFINI(transfer());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  if (is_sender) {
+    args.state->elapsed_ms =
+        timer.ElapsedMs() / static_cast<double>(args.profile_iters);
+  }
+
+  if (is_receiver) {
+    CHECK_RT(Rt, Rt::Memcpy(host_buffer.data(), device_buffer, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+    args.state->correct = Validator::ValidateResult(
+        host_buffer.data(), args.num_elements, kPayloadValue, args.rank, false,
+        "CCL Send/Recv");
+    args.state->actual = host_buffer.front();
+  }
+
+  WaitForAll(&args.state->completed, args.size);
+
+  if (transfers_data) {
+    CHECK_RT(Rt, Rt::Free(device_buffer));
+  }
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>        Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>    Warm-up iterations (default: 2)\n"
+            << "  -p <profile_iters>   Profile iterations (default: 20)\n"
+            << "  -n <num_elements>    Number of elements (default: 1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  int option = 0;
+  while ((option = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool valid = true;
+    switch (option) {
+      case 'g':
+        valid = ParseInteger(optarg, &num_gpus);
+        break;
+      case 'w':
+        valid = ParseInteger(optarg, &warmup_iters);
+        break;
+      case 'p':
+        valid = ParseInteger(optarg, &profile_iters);
+        break;
+      case 'n':
+        valid = ParseInteger(optarg, &num_elements);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        valid = false;
+        break;
+    }
+
+    if (!valid) {
+      std::cerr << "Invalid numeric argument." << std::endl;
+      PrintUsage(argv[0]);
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument." << std::endl;
+    PrintUsage(argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  if (num_gpus < 2 || warmup_iters < 0 || profile_iters <= 0 ||
+      num_elements == 0 ||
+      num_elements > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Send/Recv requires at least two GPUs, a non-negative warm-up "
+                 "count, a positive profile count, and a positive element "
+                 "count."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size() - 1) != 0) {
+    std::cerr << "Failed to query the local hostname." << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << " | Sender: " << kSenderRank
+            << " | Receiver: " << kReceiverRank << std::endl;
+
+  infinicclUniqueId unique_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&unique_id));
+
+  RunState state;
+  std::vector<std::thread> workers;
+  workers.reserve(num_gpus);
+
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    workers.emplace_back(RunWorker,
+                         ThreadArgs{rank, num_gpus, unique_id, num_elements,
+                                    warmup_iters, profile_iters, &state});
+  }
+
+  for (auto &worker : workers) {
+    worker.join();
+  }
+
+  const char *color = state.correct ? "\033[32m" : "\033[31m";
+  std::cout << "\n=== CCL Send/Recv Results ===" << std::endl;
+  std::cout << "Correct: " << color << (state.correct ? "YES" : "NO")
+            << "\033[0m" << std::endl;
+  std::cout << "Expect:  " << kPayloadValue << std::endl;
+  std::cout << "Actual:  " << state.actual << std::endl;
+  PrintSendRecvMetrics(num_elements, state.elapsed_ms);
+
+  std::cout << "[Main Process] All worker threads joined." << std::endl;
+  return state.correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/send_recv.cc
+++ b/examples/ccl_mpi_hybrid/send_recv.cc
@@ -1,0 +1,218 @@
+/**
+ * InfiniCCL Example: Send/Recv (OpenMPI + CCL Hybrid)
+ *
+ * OpenMPI launches the ranks and distributes the native CCL unique ID. After
+ * rank-based CCL communicator initialization, rank 0 sends GPU data to rank 1
+ * through the public `infinicclSend()` and `infinicclRecv()` APIs.
+ */
+
+#include <unistd.h>
+
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "device.h"
+#include "infiniccl.h"
+#include "runtime.h"
+#include "traits.h"
+#include "utils.h"
+
+namespace ccl = infini::ccl;
+
+namespace {
+
+constexpr int kSenderRank = 0;
+constexpr int kReceiverRank = 1;
+constexpr int kRequiredRanks = 2;
+constexpr float kPayloadValue = 7.0f;
+
+bool ParseLocalRank(const char *text, int *local_rank) {
+  if (!text || !local_rank) {
+    return false;
+  }
+
+  const char *end = text + std::strlen(text);
+  auto result = std::from_chars(text, end, *local_rank);
+  return result.ec == std::errc{} && result.ptr == end && *local_rank >= 0;
+}
+
+void PrintSendRecvMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double payload_bytes =
+      static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size:      " << num_elements << " floats (" << std::fixed
+            << std::setprecision(2) << payload_bytes / kBytesPerMiB << " MiB)"
+            << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        payload_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    // A one-way point-to-point transfer moves one payload over the bus.
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  constexpr int kWarmupIters = 2;
+  constexpr int kProfileIters = 20;
+  constexpr size_t kNumElements = 1 << 20;
+
+  constexpr ccl::Device::Type kDeviceType =
+      ccl::ListGetBest<ccl::DevicePriority>(ccl::EnabledDevices{});
+  using Rt = ccl::Runtime<kDeviceType>;
+
+  CHECK_INFINI(infinicclInit(&argc, &argv));
+
+  int rank = 0;
+  int size = 0;
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
+
+  if (size < kRequiredRanks) {
+    if (rank == kSenderRank) {
+      std::cerr << "Hybrid Send/Recv requires at least two ranks." << std::endl;
+    }
+    CHECK_INFINI(infinicclFinalize());
+    return EXIT_FAILURE;
+  }
+
+  int local_rank = -1;
+  if (!ParseLocalRank(std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"), &local_rank)) {
+    std::cerr << "Rank " << rank
+              << " received an invalid `OMPI_COMM_WORLD_LOCAL_RANK` value."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  CHECK_RT(Rt, Rt::SetDevice(local_rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size() - 1) != 0) {
+    std::cerr << "Rank " << rank << " failed to query the local hostname."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  std::cout << "[Rank " << rank << "] Host: " << hostname.data()
+            << " | GPU: " << ccl::Device::StringFromType(kDeviceType)
+            << " | Device " << local_rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
+
+  infinicclUniqueId unique_id{};
+  if (rank == kSenderRank) {
+    CHECK_INFINI(infinicclGetUniqueId(&unique_id));
+  }
+  CHECK_INFINI(infinicclBroadcast(&unique_id, &unique_id, sizeof(unique_id),
+                                  infinicclChar, kSenderRank, comm, nullptr));
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, unique_id, rank));
+
+  const bool is_sender = rank == kSenderRank;
+  const bool is_receiver = rank == kReceiverRank;
+  const bool transfers_data = is_sender || is_receiver;
+  const size_t total_bytes = kNumElements * sizeof(float);
+
+  std::vector<float> host_buffer(transfers_data ? kNumElements : 0,
+                                 is_sender ? kPayloadValue : 0.0f);
+  float *device_buffer = nullptr;
+
+  if (transfers_data) {
+    CHECK_RT(
+        Rt, Rt::Malloc(reinterpret_cast<void **>(&device_buffer), total_bytes));
+    CHECK_RT(Rt, Rt::Memcpy(device_buffer, host_buffer.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  }
+
+  auto transfer = [&]() {
+    if (is_sender) {
+      return infinicclSend(device_buffer, kNumElements, infinicclFloat32,
+                           kReceiverRank, comm, nullptr);
+    }
+    if (is_receiver) {
+      return infinicclRecv(device_buffer, kNumElements, infinicclFloat32,
+                           kSenderRank, comm, nullptr);
+    }
+    return infinicclSuccess;
+  };
+
+  for (int i = 0; i < kWarmupIters; ++i) {
+    CHECK_INFINI(transfer());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < kProfileIters; ++i) {
+    CHECK_INFINI(transfer());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  double elapsed_ms = timer.ElapsedMs() / static_cast<double>(kProfileIters);
+
+  bool correct = true;
+  if (is_receiver) {
+    CHECK_RT(Rt, Rt::Memcpy(host_buffer.data(), device_buffer, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+    correct = Validator::ValidateResult(host_buffer.data(), kNumElements,
+                                        kPayloadValue, rank, false,
+                                        "Hybrid CCL Send/Recv");
+    const char *color = correct ? "\033[32m" : "\033[31m";
+    std::cout << "\n=== Hybrid CCL Send/Recv Results ===" << std::endl;
+    std::cout << "Correct: " << color << (correct ? "YES" : "NO") << "\033[0m"
+              << std::endl;
+    std::cout << "Expect:  " << kPayloadValue << std::endl;
+    std::cout << "Actual:  " << host_buffer.front() << std::endl;
+    PrintSendRecvMetrics(kNumElements, elapsed_ms);
+  }
+
+  // The receiver publishes validation status from device memory. This works
+  // with the current OpenMPI staging path and with native CCL `Broadcast`.
+  std::int32_t completion_token = is_receiver && correct ? 1 : 0;
+  std::int32_t *device_completion = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&device_completion),
+                          sizeof(completion_token)));
+  CHECK_RT(Rt, Rt::Memcpy(device_completion, &completion_token,
+                          sizeof(completion_token), Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_INFINI(infinicclBroadcast(device_completion, device_completion, 1,
+                                  infinicclInt32, kReceiverRank, comm,
+                                  nullptr));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(&completion_token, device_completion,
+                          sizeof(completion_token), Rt::MemcpyDeviceToHost));
+  correct = completion_token == 1;
+
+  if (transfers_data) {
+    CHECK_RT(Rt, Rt::Free(device_buffer));
+  }
+  CHECK_RT(Rt, Rt::Free(device_completion));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
+
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/mpi/send_recv.cc
+++ b/examples/mpi/send_recv.cc
@@ -7,7 +7,9 @@
 
 #include <unistd.h>
 
+#include <cmath>
 #include <cstdlib>
+#include <iomanip>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -20,6 +22,41 @@
 #include "utils.h"
 
 namespace ccl = infini::ccl;
+
+namespace {
+
+void PrintSendRecvMetrics(size_t num_elements, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double payload_bytes =
+      static_cast<double>(num_elements) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size:      " << num_elements << " floats (" << std::fixed
+            << std::setprecision(2) << payload_bytes / kBytesPerMiB << " MiB)"
+            << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        payload_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    // A one-way point-to-point transfer moves one payload over the bus.
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+}  // namespace
 
 void RunSendRecvExample(int argc, char **argv, int warmup_iter,
                         int profile_iter, size_t num_elements) {
@@ -82,8 +119,6 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
     std::cout << "\n=== Performing Send/Recv on GPU Memory ===" << std::endl;
     std::cout << "Sender rank: " << kSender << std::endl;
     std::cout << "Receiver rank: " << kReceiver << std::endl;
-    std::cout << "Data size: " << num_elements << " floats ("
-              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
     std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
     std::cout << "Profile iterations: " << profile_iter << std::endl;
   }
@@ -144,6 +179,7 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
               << std::endl;
     std::cout << "Expect:  " << kSendValue << std::endl;
     std::cout << "Actual:  " << h_recv[0] << std::endl;
+    PrintSendRecvMetrics(num_elements, elapsed);
 
     if (!correct) {
       CHECK_RT(Rt, Rt::Free(d_send));
@@ -152,11 +188,6 @@ void RunSendRecvExample(int argc, char **argv, int warmup_iter,
       CHECK_INFINI(infinicclFinalize());
       std::exit(EXIT_FAILURE);
     }
-  }
-
-  if (rank == kSender) {
-    Metrics metrics{elapsed, total_bytes, kRequiredRanks};
-    metrics.Print();
   }
 
   CHECK_RT(Rt, Rt::Free(d_send));

--- a/src/backends/ccl/common/impl/point_to_point.h
+++ b/src/backends/ccl/common/impl/point_to_point.h
@@ -1,0 +1,48 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_POINT_TO_POINT_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_POINT_TO_POINT_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclPointToPoint {
+ public:
+  static bool HasNativeCommunicator(const Communicator *comm) {
+    return comm && comm->intra_comm() &&
+           comm->intra_comm_backend() == backend &&
+           comm->device_type() == device;
+  }
+
+  template <typename Callback>
+  static ReturnStatus Call(DataType data_type, Communicator *comm,
+                           Callback callback) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    if (!HasNativeCommunicator(comm)) {
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(callback(native_type, instance->handle));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_POINT_TO_POINT_H_

--- a/src/backends/ccl/common/impl/recv.h
+++ b/src/backends/ccl/common/impl/recv.h
@@ -1,0 +1,41 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_
+
+#include "backends/ccl/common/impl/point_to_point.h"
+#include "base/recv.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclRecvImpl {
+ public:
+  static ReturnStatus Apply(void *recv_buff, size_t count, DataType data_type,
+                            int peer, Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using PointToPoint = CclPointToPoint<backend, device>;
+
+    if (!PointToPoint::HasNativeCommunicator(comm)) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      if constexpr (BackendEnabled<Recv, BackendType::kOmpi>::value) {
+        return RecvImpl<BackendType::kOmpi, device>::Apply(
+            recv_buff, count, data_type, peer, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    return PointToPoint::Call(
+        data_type, comm, [&](auto native_type, auto native_comm) {
+          return Api::Recv(recv_buff, count, native_type, peer, native_comm,
+                           reinterpret_cast<typename Api::Stream>(stream));
+        });
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_

--- a/src/backends/ccl/common/impl/send.h
+++ b/src/backends/ccl/common/impl/send.h
@@ -1,0 +1,42 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_
+
+#include "backends/ccl/common/impl/point_to_point.h"
+#include "base/send.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclSendImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, size_t count,
+                            DataType data_type, int peer, Communicator *comm,
+                            void *stream) {
+    using Api = CclApi<backend, device>;
+    using PointToPoint = CclPointToPoint<backend, device>;
+
+    if (!PointToPoint::HasNativeCommunicator(comm)) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      if constexpr (BackendEnabled<Send, BackendType::kOmpi>::value) {
+        return SendImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, count, data_type, peer, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    return PointToPoint::Call(
+        data_type, comm, [&](auto native_type, auto native_comm) {
+          return Api::Send(send_buff, count, native_type, peer, native_comm,
+                           reinterpret_cast<typename Api::Stream>(stream));
+        });
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,16 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/recv.h
+++ b/src/backends/ccl/mccl/impl/recv.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_RECV_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_RECV_H_
+
+#include "backends/ccl/common/impl/recv.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class RecvImpl<BackendType::kMccl, device>
+    : public CclRecvImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Recv, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_RECV_H_

--- a/src/backends/ccl/mccl/impl/send.h
+++ b/src/backends/ccl/mccl/impl/send.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SEND_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SEND_H_
+
+#include "backends/ccl/common/impl/send.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class SendImpl<BackendType::kMccl, device>
+    : public CclSendImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Send, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SEND_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -10,6 +10,12 @@
 #include "return_status_impl.h"
 #include "runtime.h"
 
+#if !defined(NCCL_VERSION_CODE) || !defined(NCCL_VERSION)
+#error "InfiniCCL NCCL support requires NCCL 2.10.0 or newer."
+#elif NCCL_VERSION_CODE < NCCL_VERSION(2, 10, 0)
+#error "InfiniCCL NCCL support requires NCCL 2.10.0 or newer."
+#endif
+
 namespace infini::ccl {
 
 template <Device::Type device>
@@ -45,6 +51,16 @@ struct NcclApi {
                           Stream stream) {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
+  }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclRecv(recv_buff, count, data_type, peer, comm, stream);
   }
 };
 

--- a/src/backends/ccl/nccl/impl/recv.h
+++ b/src/backends/ccl/nccl/impl/recv.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_
+
+#include "backends/ccl/common/impl/recv.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class RecvImpl<BackendType::kNccl, device>
+    : public CclRecvImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Recv, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_

--- a/src/backends/ccl/nccl/impl/send.h
+++ b/src/backends/ccl/nccl/impl/send.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_
+
+#include "backends/ccl/common/impl/send.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class SendImpl<BackendType::kNccl, device>
+    : public CclSendImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Send, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_


### PR DESCRIPTION
## Summary

This PR adds `Send` and `Recv` support to the shared CCL backend abstraction, including native bindings through the existing NCCL and MCCL provider layers for the public `infinicclSend()` and `infinicclRecv()` APIs. It also adds shared communicator and data-type handling for CCL point-to-point operations, keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend flows, includes CCL-only plus OpenMPI-assisted `Send`/`Recv` example programs with correctness and one-way communication-bandwidth reporting, and enforces and documents NCCL 2.10 as the minimum supported version.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclSend()` and `infinicclRecv()` APIs for configured CCL backends through generated bridge dispatch.
  - Keep an inter-only communicator on its initialized OpenMPI provider when a mixed OpenMPI/CCL build selects the CCL implementation before native rank initialization.
  - Use the native CCL communicator once `infinicclCommInitRank()` has initialized the matching intra-node provider.
  - Reuse the existing public signatures without introducing a new communication API.

- **Common CCL Implementation**
  - Add shared CCL `Send` and `Recv` implementations following the existing provider-oriented `AllReduce` structure.
  - Validate the CCL communicator instance and map InfiniCCL data types through the configured provider before dispatch.
  - Return `NotSupported` when the selected provider cannot represent the requested data type.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with thin bindings to `ncclSend()`, `ncclRecv()`, `mcclSend()`, and `mcclRecv()`.
  - Register `Send` and `Recv` with the existing NCCL and MCCL provider layers.

- **Examples and Validation**
  - Add a thread-per-GPU single-node CCL `Send`/`Recv` example using one shared unique ID.
  - Add an OpenMPI-assisted CCL `Send`/`Recv` example that uses OpenMPI for rank discovery and unique-ID broadcast, then initializes a native CCL communicator for GPU point-to-point communication.
  - Validate a matched one-way transfer from rank 0 to rank 1 and propagate validation failures through the process exit status.
  - Report payload size, average profiled time, algorithm bandwidth as `payload_bytes / time`, and bus bandwidth with the point-to-point correction factor of 1 in all three examples.

- **Documentation**
  - Enforce NCCL 2.10 at compile time and document it as the minimum supported version because the existing NCCL type map uses `ncclAvg`.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native CCL paths for `Send` and `Recv`, avoiding the existing MPI host-staging paths when a supported CCL backend is selected. Existing MPI point-to-point operations are intended to remain unchanged.

## Known Issues & Future Work

- CCL operation support now covers `AllReduce`, `Send`, and `Recv`; other CCL operations remain future work.
- `Send` and `Recv` inherit the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The CCL examples validate one matched, one-way `float32` transfer from rank 0 to rank 1 on the default stream. Multi-peer, bidirectional, grouped, additional-data-type, and non-default-stream coverage remain future work. The heterogeneous MPI `Send`/`Recv` regression also transfers between ranks 0 and 1 on the NVIDIA node, so it is not a cross-vendor point-to-point test.

## Test Results

The implementation commit is `a0874c9ba781c110ab1325f7b0ded2d7f8d31c9e`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached evidence contains exactly 15 hash-verified canonical logs from the current commit: all 15 targets passed, with `Correct: YES` 17 times and `Correct: NO` 0 times. The extra two positive results are the additional expected validation cases in the broadcast log.

All four `Send`/`Recv` paths passed with a 1,048,576-element `Float32` payload (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations:

| Path | Test topology | Payload | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 4.00 MiB | 0.096 ms | 43.69 GB/s | 43.69 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 4.00 MiB | 0.062 ms | 67.24 GB/s | 67.24 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 4.00 MiB | 2.189 ms | 1.92 GB/s | 1.92 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 4.00 MiB | 0.128 ms | 32.69 GB/s | 32.69 GB/s |

The reported time is the elapsed time averaged over the 20 profiled one-way transfers after the 2 warm-up transfers. Algorithm bandwidth uses `payload_bytes / time`; bus bandwidth is identical because the point-to-point correction factor is 1. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, with ranks 0-7 mapped to devices 0-7.
- All five formal invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346830/ccl_all_reduce.log)
[ccl_broadcast.log](https://github.com/user-attachments/files/31346832/ccl_broadcast.log)



**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31346834/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_broadcast.log](https://github.com/user-attachments/files/31346835/ccl_mpi_hybrid_broadcast.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31346836/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31346837/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31346838/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31346839/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31346840/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31346841/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31346842/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31346843/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31346844/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346846/ccl_all_reduce.log)
[ccl_broadcast.log](https://github.com/user-attachments/files/31346847/ccl_broadcast.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains a single self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch has a clean linear history from `master` and contains no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- The example's output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature changes; the existing `infinicclSend()` and `infinicclRecv()` APIs gain native NCCL and MCCL provider support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; local-rank parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files are changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files are changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python). <!-- No Python files are changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files are changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- Five `run_examples.py` invocations passed: 15/15 targets with `Correct: YES` 17 times and `Correct: NO` 0 times on the full 8-A100 + 8-C550 matrix. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 and the full-repository Ruff checks pass. -->

### Documentation

- [x] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- The README now documents the effective NCCL 2.10 minimum version. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Local-rank parsing rejects missing, malformed, negative, or overflowing input before device selection. -->
