### PR TITLE
feat: support CCL `AllGather`

### DIFF
--- a/examples/ccl/all_gather.cc
+++ b/examples/ccl/all_gather.cc
@@ -1,0 +1,347 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node AllGather
+ *
+ * This example creates one native CCL rank per GPU, then validates
+ * out-of-place and in-place AllGather without an MPI launcher.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+struct ScenarioState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iter;
+  int profile_iter;
+  ScenarioState *out_of_place;
+  ScenarioState *in_place;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+void PrintAllGatherMetrics(size_t num_elements, int world_size,
+                           double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double rank_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const double total_bytes = rank_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per rank: " << num_elements << " floats ("
+            << std::fixed << std::setprecision(2) << rank_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data per rank: "
+            << num_elements * static_cast<size_t>(world_size) << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void PrintResult(const char *scenario, bool correct,
+                 const std::vector<float> &result, size_t num_elements,
+                 int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== " << scenario
+            << " CCL AllGather Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Sample blocks: ";
+  for (int src_rank = 0; src_rank < world_size && src_rank < 4; ++src_rank) {
+    const size_t offset = static_cast<size_t>(src_rank) * num_elements;
+    std::cout << "[r" << src_rank << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+  PrintAllGatherMetrics(num_elements, world_size, elapsed_ms);
+}
+
+void WaitForScenario(ScenarioState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_release);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+bool ValidateAllGather(const std::vector<float> &result, size_t num_elements,
+                       int world_size, int rank) {
+  bool correct = true;
+  for (int src_rank = 0; src_rank < world_size; ++src_rank) {
+    const size_t offset = static_cast<size_t>(src_rank) * num_elements;
+    const bool block_correct =
+        Validator::ValidateResult(result.data() + offset, num_elements,
+                                  static_cast<float>(src_rank + 1), rank);
+    correct = block_correct && correct;
+  }
+  return correct;
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the AllGather worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const size_t send_bytes = args.num_elements * sizeof(float);
+  const size_t recv_elements =
+      args.num_elements * static_cast<size_t>(args.size);
+  const size_t recv_bytes = recv_elements * sizeof(float);
+
+  std::vector<float> h_send(args.num_elements,
+                            static_cast<float>(args.rank + 1));
+  std::vector<float> h_recv(recv_elements, 0.0f);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  auto run_scenario = [&](bool in_place) {
+    std::fill(h_recv.begin(), h_recv.end(), 0.0f);
+    const size_t local_offset =
+        static_cast<size_t>(args.rank) * args.num_elements;
+    if (in_place) {
+      std::fill_n(h_recv.begin() + local_offset, args.num_elements,
+                  static_cast<float>(args.rank + 1));
+    }
+
+    CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), recv_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    const void *active_send =
+        in_place ? static_cast<const void *>(d_recv + local_offset)
+                 : static_cast<const void *>(d_send);
+
+    for (int i = 0; i < args.warmup_iter; ++i) {
+      CHECK_INFINI(infinicclAllGather(active_send, d_recv, args.num_elements,
+                                      infinicclFloat32, comm, nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    Timer timer;
+    for (int i = 0; i < args.profile_iter; ++i) {
+      CHECK_INFINI(infinicclAllGather(active_send, d_recv, args.num_elements,
+                                      infinicclFloat32, comm, nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    const double elapsed_ms =
+        timer.ElapsedMs() / static_cast<double>(args.profile_iter);
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    const bool correct =
+        ValidateAllGather(h_recv, args.num_elements, args.size, args.rank);
+    ScenarioState *state = in_place ? args.in_place : args.out_of_place;
+    if (!correct) {
+      state->correct.store(false, std::memory_order_relaxed);
+    }
+    WaitForScenario(state, args.size);
+
+    if (args.rank == 0) {
+      PrintResult(in_place ? "In-Place" : "Out-of-Place",
+                  state->correct.load(std::memory_order_acquire), h_recv,
+                  args.num_elements, args.size, elapsed_ms);
+    }
+  };
+
+  run_scenario(false);
+  run_scenario(true);
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>        Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>    Warmup iterations (default: 2)\n"
+            << "  -p <profile_iters>   Profile iterations (default: 20)\n"
+            << "  -n <num_elements>    Elements per rank (default: 1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iters);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iters);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &num_elements);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for AllGather."
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for AllGather." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (num_elements > std::numeric_limits<size_t>::max() / sizeof(float) ||
+      static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / num_elements ||
+      num_elements * static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "AllGather buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for AllGather." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  ScenarioState out_of_place;
+  ScenarioState in_place;
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,      shared_id,     num_elements,
+                    warmup_iters, profile_iters, &out_of_place, &in_place};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = out_of_place.correct.load(std::memory_order_acquire) &&
+                       in_place.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] All AllGather scenarios passed." << std::endl;
+  } else {
+    std::cerr << "[Main Process] AllGather validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/all_gather.cc
+++ b/examples/ccl_mpi_hybrid/all_gather.cc
@@ -1,0 +1,331 @@
+/**
+ * InfiniCCL Example: AllGather (OpenMPI + CCL Hybrid)
+ *
+ * This example first uses AllGather through an OpenMPI inter communicator to
+ * distribute a native CCL unique ID. It then initializes a native CCL
+ * communicator and validates out-of-place and in-place GPU AllGather.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+bool ParseLocalRank(const char *text, int *local_rank) {
+  if (!text || !local_rank) {
+    return false;
+  }
+
+  int parsed = -1;
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed < 0) {
+    return false;
+  }
+
+  *local_rank = parsed;
+  return true;
+}
+
+bool ValidateAllGather(const std::vector<float> &result, size_t num_elements,
+                       int world_size, int rank) {
+  bool correct = true;
+  for (int src_rank = 0; src_rank < world_size; ++src_rank) {
+    const size_t offset = static_cast<size_t>(src_rank) * num_elements;
+    const bool block_correct =
+        Validator::ValidateResult(result.data() + offset, num_elements,
+                                  static_cast<float>(src_rank + 1), rank);
+    correct = block_correct && correct;
+  }
+  return correct;
+}
+
+void PrintAllGatherMetrics(size_t num_elements, int world_size,
+                           double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double rank_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const double total_bytes = rank_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per rank: " << num_elements << " floats ("
+            << std::fixed << std::setprecision(2) << rank_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data per rank: "
+            << num_elements * static_cast<size_t>(world_size) << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void PrintResult(const char *scenario, bool correct,
+                 const std::vector<float> &result, size_t num_elements,
+                 int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== " << scenario
+            << " Hybrid CCL AllGather Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Sample blocks: ";
+  for (int src_rank = 0; src_rank < world_size && src_rank < 4; ++src_rank) {
+    const size_t offset = static_cast<size_t>(src_rank) * num_elements;
+    std::cout << "[r" << src_rank << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+  PrintAllGatherMetrics(num_elements, world_size, elapsed_ms);
+}
+
+bool RunAllGatherExample(int argc, char **argv) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kNumElements = 1 << 20;
+
+  CHECK_INFINI(infinicclInit(&argc, &argv));
+
+  int rank = -1;
+  int size = 0;
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
+  if (size <= 0) {
+    std::cerr << "Invalid world size for hybrid AllGather." << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  int local_rank = -1;
+  if (!ParseLocalRank(std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"), &local_rank)) {
+    std::cerr << "Missing or invalid `OMPI_COMM_WORLD_LOCAL_RANK`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  CHECK_RT(Rt, Rt::SetDevice(local_rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for hybrid AllGather."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << local_rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
+
+  // Bootstrap the native communicator with AllGather itself. At this point
+  // only the OpenMPI inter communicator exists, so the CCL provider delegates
+  // this call to the existing OpenMPI staging implementation.
+  infinicclUniqueId id{};
+  if (rank == 0) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  const size_t id_bytes = sizeof(id);
+  if (static_cast<size_t>(size) >
+      std::numeric_limits<size_t>::max() / id_bytes) {
+    std::cerr << "AllGather bootstrap buffer size overflows `size_t`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  const size_t gathered_id_bytes = id_bytes * static_cast<size_t>(size);
+
+  unsigned char *d_id_send = nullptr;
+  unsigned char *d_id_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_id_send), id_bytes));
+  CHECK_RT(
+      Rt, Rt::Malloc(reinterpret_cast<void **>(&d_id_recv), gathered_id_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_id_send, &id, id_bytes, Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclAllGather(d_id_send, d_id_recv, id_bytes, infinicclChar,
+                                  comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(&id, d_id_recv, id_bytes, Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_RT(Rt, Rt::Free(d_id_send));
+  CHECK_RT(Rt, Rt::Free(d_id_recv));
+
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
+  if (kNumElements > std::numeric_limits<size_t>::max() / sizeof(float) ||
+      static_cast<size_t>(size) >
+          std::numeric_limits<size_t>::max() / kNumElements ||
+      kNumElements * static_cast<size_t>(size) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Hybrid AllGather buffer size overflows `size_t`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  const size_t send_bytes = kNumElements * sizeof(float);
+  const size_t recv_elements = kNumElements * static_cast<size_t>(size);
+  const size_t recv_bytes = recv_elements * sizeof(float);
+  std::vector<float> h_send(kNumElements, static_cast<float>(rank + 1));
+  std::vector<float> h_recv(recv_elements, 0.0f);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  std::array<bool, 2> local_correct{true, true};
+  std::array<double, 2> elapsed_ms{};
+  for (int scenario = 0; scenario < 2; ++scenario) {
+    const bool in_place = scenario == 1;
+    std::fill(h_recv.begin(), h_recv.end(), 0.0f);
+    const size_t local_offset = static_cast<size_t>(rank) * kNumElements;
+    if (in_place) {
+      std::fill_n(h_recv.begin() + local_offset, kNumElements,
+                  static_cast<float>(rank + 1));
+    }
+
+    CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), recv_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    const void *active_send =
+        in_place ? static_cast<const void *>(d_recv + local_offset)
+                 : static_cast<const void *>(d_send);
+
+    for (int i = 0; i < kWarmupIterations; ++i) {
+      CHECK_INFINI(infinicclAllGather(active_send, d_recv, kNumElements,
+                                      infinicclFloat32, comm, nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    Timer timer;
+    for (int i = 0; i < kProfileIterations; ++i) {
+      CHECK_INFINI(infinicclAllGather(active_send, d_recv, kNumElements,
+                                      infinicclFloat32, comm, nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    elapsed_ms[scenario] =
+        timer.ElapsedMs() / static_cast<double>(kProfileIterations);
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    local_correct[scenario] =
+        ValidateAllGather(h_recv, kNumElements, size, rank);
+  }
+
+  // Gather both local validation flags so rank 0 reports cluster-wide results
+  // and every rank reaches communicator destruction only after validation.
+  std::array<int32_t, 2> h_status_send{local_correct[0] ? 1 : 0,
+                                       local_correct[1] ? 1 : 0};
+  std::vector<int32_t> h_status_recv(static_cast<size_t>(size) * 2, 0);
+  int32_t *d_status_send = nullptr;
+  int32_t *d_status_recv = nullptr;
+  const size_t status_send_bytes =
+      h_status_send.size() * sizeof(h_status_send[0]);
+  const size_t status_recv_bytes =
+      h_status_recv.size() * sizeof(h_status_recv[0]);
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_status_send),
+                          status_send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_status_recv),
+                          status_recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_status_send, h_status_send.data(),
+                          status_send_bytes, Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclAllGather(d_status_send, d_status_recv,
+                                  h_status_send.size(), infinicclInt32, comm,
+                                  nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(h_status_recv.data(), d_status_recv,
+                          status_recv_bytes, Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  std::array<bool, 2> global_correct{true, true};
+  for (int src_rank = 0; src_rank < size; ++src_rank) {
+    for (int scenario = 0; scenario < 2; ++scenario) {
+      const size_t index = static_cast<size_t>(src_rank) * 2 + scenario;
+      global_correct[scenario] =
+          global_correct[scenario] && h_status_recv[index] == 1;
+    }
+  }
+
+  if (rank == 0) {
+    // Rank 0's gathered payload is representative after cluster-wide status
+    // aggregation because every rank validates the complete result.
+    PrintResult("Out-of-Place", global_correct[0], h_recv, kNumElements, size,
+                elapsed_ms[0]);
+    PrintResult("In-Place", global_correct[1], h_recv, kNumElements, size,
+                elapsed_ms[1]);
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_status_send));
+  CHECK_RT(Rt, Rt::Free(d_status_recv));
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
+
+  if (rank == 0) {
+    if (global_correct[0] && global_correct[1]) {
+      std::cout << "[Main Process] All hybrid AllGather scenarios passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid AllGather validation failed."
+                << std::endl;
+    }
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+  return global_correct[0] && global_correct[1];
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  return RunAllGatherExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/mpi/all_gather.cc
+++ b/examples/mpi/all_gather.cc
@@ -6,6 +6,9 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
 #include <iostream>
 #include <vector>
 
@@ -24,7 +27,47 @@
 
 using namespace infini::ccl;
 
-void RunAllGatherExample(int argc, char **argv, int warmup_iter,
+namespace {
+
+void PrintAllGatherMetrics(size_t num_elements, int world_size,
+                           double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double rank_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const double total_bytes = rank_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per rank: " << num_elements << " floats ("
+            << std::fixed << std::setprecision(2) << rank_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data per rank: "
+            << num_elements * static_cast<size_t>(world_size) << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+}  // namespace
+
+bool RunAllGatherExample(int argc, char **argv, int warmup_iter,
                          int profile_iter, const size_t kNumElements) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
@@ -113,14 +156,14 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
 
   // Result Validation
   bool correct = true;
-  int error_count = 0;
 
   for (int src_rank = 0; src_rank < size; ++src_rank) {
     float expected = static_cast<float>(src_rank + 1);
     size_t offset = static_cast<size_t>(src_rank) * kNumElements;
 
-    Validator::ValidateResult(h_recv.data() + offset, kNumElements, expected,
-                              rank);
+    const bool block_correct = Validator::ValidateResult(
+        h_recv.data() + offset, kNumElements, expected, rank);
+    correct = block_correct && correct;
   }
 
   if (rank == 0) {
@@ -132,7 +175,6 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
     std::cout << "Correct: "
               << (correct ? (GREEN + std::string("YES") + RESET)
                           : (RED + std::string("NO") + RESET));
-    if (!correct) std::cout << " (" << error_count << " errors)";
     std::cout << std::endl;
 
     std::cout << "Sample blocks: ";
@@ -143,10 +185,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
     std::cout << std::endl;
   }
 
-  // Metrics Reporting (Only from rank 0 for cleaner output)
   if (rank == 0) {
-    Metrics metrics{elapsed, recv_bytes, size};
-    metrics.Print();
+    PrintAllGatherMetrics(kNumElements, size, elapsed);
   }
 
   // Cleanup
@@ -159,6 +199,8 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;
   }
+
+  return correct;
 }
 
 int main(int argc, char **argv) {
@@ -166,7 +208,8 @@ int main(int argc, char **argv) {
   int profile_iters = 20;
   size_t num_elements = 1 << 20;
 
-  RunAllGatherExample(argc, argv, warmup_iters, profile_iters, num_elements);
-
-  return EXIT_SUCCESS;
+  return RunAllGatherExample(argc, argv, warmup_iters, profile_iters,
+                             num_elements)
+             ? EXIT_SUCCESS
+             : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/all_gather.h
+++ b/src/backends/ccl/common/impl/all_gather.h
@@ -1,0 +1,63 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/all_gather.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredAllGather {
+  using type = AllGather;
+};
+
+template <BackendType backend, Device::Type device>
+class CclAllGatherImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredAllGather<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return AllGatherImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, count, data_type, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(Api::AllGather(
+        send_buff, recv_buff, count, native_type, instance->handle,
+        reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,13 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result AllGather(const void *send_buff, void *recv_buff,
+                          size_t send_count, DataType data_type, Comm comm,
+                          Stream stream) {
+    return mcclAllGather(send_buff, recv_buff, send_count, data_type, comm,
+                         stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/all_gather.h
+++ b/src/backends/ccl/mccl/impl/all_gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/impl/all_gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllGatherImpl<BackendType::kMccl, device>
+    : public CclAllGatherImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<AllGather, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,13 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result AllGather(const void *send_buff, void *recv_buff,
+                          size_t send_count, DataType data_type, Comm comm,
+                          Stream stream) {
+    return ncclAllGather(send_buff, recv_buff, send_count, data_type, comm,
+                         stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/all_gather.h
+++ b/src/backends/ccl/nccl/impl/all_gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/impl/all_gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllGatherImpl<BackendType::kNccl, device>
+    : public CclAllGatherImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<AllGather, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_

--- a/src/backends/mpi/ompi/impl/all_gather.h
+++ b/src/backends/mpi/ompi/impl/all_gather.h
@@ -1,11 +1,14 @@
 #ifndef INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_ALL_GATHER_H_
 #define INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_ALL_GATHER_H_
 
+#include <cstdlib>
+#include <limits>
+
 #include "backends/mpi/ompi/checks.h"
 #include "backends/mpi/ompi/comm_instance.h"
-#include "backends/mpi/ompi/type_map.h"
 #include "base/all_gather.h"
 #include "communicator.h"
+#include "data_type_impl.h"
 #include "dispatcher.h"
 #include "logging.h"
 
@@ -28,19 +31,38 @@ class AllGatherImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kInternalError;
     }
 
-    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
+    if (comm->size() <= 0) {
+      LOG("Invalid world size for `AllGather`.");
+      return ReturnStatus::kInternalError;
+    }
+
     size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Byte size overflow for `AllGather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
     size_t send_bytes = count * type_size;
-    size_t recv_count = count * static_cast<size_t>(comm->size());
-    size_t recv_bytes = recv_count * type_size;
+    if (send_bytes > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("Per-rank byte count exceeds MPI int range for `AllGather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    size_t world_size = static_cast<size_t>(comm->size());
+    if (world_size != 0 &&
+        send_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Receive byte size overflow for `AllGather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    size_t recv_bytes = send_bytes * world_size;
+    int mpi_byte_count = static_cast<int>(send_bytes);
 
     // Handle GPU Memory (Staging Pattern)
     // Note: we simply use host-staging for now.
-    void *host_sendbuf = malloc(send_bytes);
-    void *host_recvbuf = malloc(recv_bytes);
+    void *host_sendbuf = std::malloc(send_bytes == 0 ? 1 : send_bytes);
+    void *host_recvbuf = std::malloc(recv_bytes == 0 ? 1 : recv_bytes);
     if (!host_sendbuf || !host_recvbuf) {
-      free(host_sendbuf);
-      free(host_recvbuf);
+      std::free(host_sendbuf);
+      std::free(host_recvbuf);
       LOG("Failed to allocate host buffers for `AllGather` staging.");
       return ReturnStatus::kSystemError;
     }
@@ -50,14 +72,15 @@ class AllGatherImpl<BackendType::kOmpi, device_type> {
 
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
-    INFINI_CHECK_MPI(MPI_Allgather(host_sendbuf, count, mpi_type, host_recvbuf,
-                                   count, mpi_type, inst->handle));
+    INFINI_CHECK_MPI(MPI_Allgather(host_sendbuf, mpi_byte_count, MPI_BYTE,
+                                   host_recvbuf, mpi_byte_count, MPI_BYTE,
+                                   inst->handle));
 
     CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,
                                 Rt::MemcpyHostToDevice));
 
-    free(host_sendbuf);
-    free(host_recvbuf);
+    std::free(host_sendbuf);
+    std::free(host_recvbuf);
 
     return ReturnStatus::kSuccess;
   }

--- a/src/base/all_gather.h
+++ b/src/base/all_gather.h
@@ -19,9 +19,13 @@ class AllGather : public Operation<AllGather> {
   static ReturnStatus Execute(const void *send_buff, void *recv_buff,
                               size_t count, DataType datatype,
                               void *comm_handle, void *stream) {
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, comm_handle)) {
+    if (HasInvalidArgs(send_buff, recv_buff, count, datatype, comm_handle)) {
       return ReturnStatus::kInvalidArgument;
     }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
     auto *comm = static_cast<Communicator *>(comm_handle);
     return AllGatherImpl<backend_type, device_type>::Apply(
         send_buff, recv_buff, count, datatype, comm, stream);
@@ -29,18 +33,22 @@ class AllGather : public Operation<AllGather> {
 
  private:
   static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, void *comm_handle) {
+                             size_t count, DataType datatype,
+                             void *comm_handle) {
     if (!comm_handle) {
       // TODO(lzm): change to use `glog`.
       LOG("Invalid communicator handle for `AllGather`.");
       return true;
     }
-    if (!send_buff || !recv_buff) {
-      LOG("Invalid buffer pointer for `AllGather`.");
-      return true;
-    }
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `AllGather`.");
+      return true;
+    }
+    if (count == 0) {
+      return false;
+    }
+    if (!send_buff || !recv_buff) {
+      LOG("Invalid buffer pointer for `AllGather`.");
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

This PR adds `AllGather` support to the shared CCL backend abstraction, including native bindings through the existing NCCL and MCCL provider layers for the public `infinicclAllGather()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, corrects the shared OpenMPI/MPICH `AllGather` staging path to use byte counts for all data types, makes the existing MPI example propagate per-block validation failures, and includes CCL-only plus OpenMPI-assisted `AllGather` example programs covering out-of-place and canonical in-place flows with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclAllGather()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `AllGather` after validating the communicator and data type, without requiring non-null buffers or entering a backend.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `AllGather` implementation following the existing `AllReduce` structure.
  - Validate the native communicator backend, device, and handle before dispatch.
  - Map InfiniCCL data types through the configured provider and return `NotSupported` when the provider cannot represent the requested type.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with thin bindings to `ncclAllGather()` and `mcclAllGather()`.
  - Register `AllGather` with the existing NCCL and MCCL provider layers.

- **MPI Correctness**
  - Treat `AllGather` as a movement operation in the shared OpenMPI/MPICH implementation by using `MPI_BYTE` with `count * type_size` bytes per rank.
  - Add world-size, `size_t` multiplication, and MPI `int` count-range checks for staged transfers.
  - Accumulate validation across every gathered source block in the existing MPI example and return a non-zero process status on failure.

- **Examples, Validation, and Metrics**
  - Add a thread-per-GPU single-node CCL `AllGather` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL `AllGather` example that first uses the public `AllGather` API through the OpenMPI inter communicator to distribute the native unique ID, then initializes the native CCL communicator for GPU data movement.
  - Validate both out-of-place and canonical in-place layouts across every source-rank block and propagate cluster-wide validation failures through the process exit status.
  - Report the contribution size per rank, the complete gathered size per rank, average operation time, algorithm bandwidth as `world_size * rank_bytes / time`, and bus bandwidth as algorithm bandwidth multiplied by `(world_size - 1) / world_size`.
  - Parse numeric options without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `AllGather`, avoiding the existing MPI host-staging path when a supported CCL backend and native communicator are available. The shared MPI path remains host-staged, with corrected byte-count handling for movement data types. Other collective operations are intended to remain unchanged. The validation-log timings below are execution references rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch now covers `AllReduce` and `AllGather`; other CCL collective operations remain future work.
- `AllGather` inherits the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The server examples validate `float32` payloads on the default stream. Additional data-type and non-default-stream runtime coverage remain future work.
- The MPI fallback remains host-staged with per-call allocations and rejects per-rank payloads whose byte count exceeds the MPI `int` count range; chunked transfers remain future work.

## Test Results

The implementation commit is `e26a2c2917852c348655dd25155a8e0e0ecdbd8f`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The current-commit evidence contains exactly 15 canonical logs: all 15 targets passed, with `Correct: YES` 20 times and `Correct: NO` 0 times. The five additional positive results are the second `AllGather` layout in each pure CCL and hybrid log plus the two additional expected validation cases in the MPI broadcast log.

All four `AllGather` execution paths passed with a 1,048,576-element `Float32` contribution per rank (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations. The CCL-only and hybrid examples validate both out-of-place and canonical in-place layouts; the heterogeneous MPI example validates its out-of-place layout.

| Path | Layout | Test topology | Data per rank / gathered per rank | Time | Alg BW | Bus BW |
|---|---|---|---:|---:|---:|---:|
| Pure NCCL | Out-of-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.242 ms | 138.78 GB/s | 121.43 GB/s |
| Pure NCCL | In-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.236 ms | 142.09 GB/s | 124.33 GB/s |
| OpenMPI + NCCL hybrid | Out-of-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.251 ms | 133.78 GB/s | 117.06 GB/s |
| OpenMPI + NCCL hybrid | In-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.234 ms | 143.44 GB/s | 125.51 GB/s |
| Heterogeneous OpenMPI | Out-of-place | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 4.00 / 64.00 MiB | 80.735 ms | 0.83 GB/s | 0.78 GB/s |
| Pure MCCL | Out-of-place | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 3.181 ms | 10.55 GB/s | 9.23 GB/s |
| Pure MCCL | In-place | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 3.173 ms | 10.58 GB/s | 9.25 GB/s |

Algorithm bandwidth uses the complete gathered bytes resident on each rank, `world_size * rank_bytes / time`. Bus bandwidth applies the standard `AllGather` correction factor, `(world_size - 1) / world_size`. The values were independently checked while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs. Each `AllGather` log passed both out-of-place and in-place validation; the hybrid log also confirms that the OpenMPI fallback passed before the native NCCL communicator was initialized.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, with ranks 0-7 mapped to devices 0-7, and its `AllGather` log passed both out-of-place and in-place validation.
- All five formal `run_examples.py` invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA**:
[ccl_all_gather.log](https://github.com/user-attachments/files/31346856/ccl_all_gather.log)
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346857/ccl_all_reduce.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_gather.log](https://github.com/user-attachments/files/31346860/ccl_mpi_hybrid_all_gather.log)
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31346861/ccl_mpi_hybrid_all_reduce.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31346867/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31346869/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31346871/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31346872/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31346875/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31346876/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31346877/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31346878/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31346879/mpi_send_recv.log)



**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_gather.log](https://github.com/user-attachments/files/31346880/ccl_all_gather.log)
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346881/ccl_all_reduce.log)

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains a single self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and timing reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclAllGather()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- Four `run_examples.py` matrices passed: 15/15 targets with `Correct: YES` 20 times and no incorrect result. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Byte-count and total-buffer calculations are overflow-checked, and canonical in-place offsets remain within the allocated receive buffer. -->
