### PR TITLE
feat: add collective communication for mccl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(InfiniCCL VERSION 0.1.0 LANGUAGES C CXX)
+include(CTest)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -23,6 +24,9 @@ option(WITH_OMPI "Enable OpenMPI backend" OFF)
 option(WITH_MPICH "Enable MPICH backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
 option(WITH_MCCL "Enable MCCL backend"    OFF)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 # =========================================================
 # --- MISC. BUILD OPTIONS ---

--- a/examples/ccl/collectives.cc
+++ b/examples/ccl/collectives.cc
@@ -1,0 +1,160 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node MCCL Broadcast
+ *
+ * This example demonstrates spawning one CPU thread per GPU on a single node,
+ * generating a shared UniqueID, and performing a Broadcast entirely via
+ * InfiniCCL's native CCL backend.
+ *
+ * Note: to properly run this example, you should specify `--launcher none`
+ * since it requires no MPI process spawning.
+ */
+
+#include <unistd.h>
+
+#include <iostream>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+// Structure to pass execution data to each GPU worker thread.
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iter;
+  int profile_iter;
+};
+
+// Worker function executed by each CPU thread.
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  // Bind this specific CPU thread to its designated local GPU device
+  // In a thread-per-GPU model, `local_rank` is exactly the thread's rank ID.
+  int local_device_id = args.rank;
+  CHECK_RT(Rt, Rt::SetDevice(local_device_id));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  // Prepare Host Data Structures
+  std::vector<float> h_send(args.num_elements);
+  std::vector<float> h_recv(args.num_elements, 0.0f);
+
+  // Each rank provides its own (rank + 1) as data.
+  for (size_t i = 0; i < args.num_elements; i++) {
+    h_send[i] = static_cast<float>(args.rank + 1);
+  }
+
+  // Allocate GPU Memory using InfiniCCL's Runtime abstraction layer.
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  size_t total_bytes = args.num_elements * sizeof(float);
+
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_send, total_bytes));
+  CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, total_bytes));
+
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::Memcpy(d_recv, h_recv.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Warm-up Iterations
+  for (int i = 0; i < args.warmup_iter; ++i) {
+    CHECK_INFINI(infinicclBroadcast(d_send, d_recv, args.num_elements,
+                                    infinicclFloat32, 0, comm,
+                                    nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  // Profiling Iterations
+  Timer timer;
+  for (int i = 0; i < args.profile_iter; i++) {
+    CHECK_INFINI(infinicclBroadcast(d_send, d_recv, args.num_elements,
+                                    infinicclFloat32, 0, comm,
+                                    nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  double elapsed = timer.ElapsedMs() / static_cast<double>(args.profile_iter);
+
+  // Copy broadcast data back from device to host.
+  CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                          Rt::MemcpyDeviceToHost));
+
+  // Result Validation
+  constexpr float expected = 1.0f;
+  Validator::ValidateResult(h_recv.data(), args.num_elements, expected,
+                            args.rank, true, "Broadcast");
+
+  // Metrics Reporting (Only Rank 0)
+  if (args.rank == 0) {
+    std::cout << "\n=== Single-Node Threaded MCCL Broadcast Results ==="
+              << std::endl;
+    std::cout << "Data size: " << args.num_elements << " floats ("
+              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
+    Metrics metrics{elapsed, total_bytes, args.size};
+    metrics.Print();
+  }
+
+  // Cleanup local rank resources.
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iters = 1;
+  int profile_iters = 20;
+  size_t num_elements = 1 << 25;
+
+  (void)argc;
+  (void)argv;
+
+  char hostname[256];
+  gethostname(hostname, sizeof(hostname));
+  std::cout << "[Main Process] Host: " << hostname
+            << " | Target GPUs: " << num_gpus << std::endl;
+
+  infinicclUniqueId shared_id;
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  // Spawn CPU thread pool.
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,     shared_id,
+                    num_elements, warmup_iters, profile_iters};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  // Await execution completion across all threads.
+  for (auto &t : threads) {
+    if (t.joinable()) {
+      t.join();
+    }
+  }
+
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/src/backends/ccl/common/impl/collectives.h
+++ b/src/backends/ccl/common/impl/collectives.h
@@ -1,0 +1,161 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_COLLECTIVES_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_COLLECTIVES_H_
+
+#include "backends/ccl/common/api.h"
+#include "device.h"
+#include "traits.h"
+#include "data_type_impl.h"
+#include "return_status_impl.h"
+#include "base/all_gather.h"
+#include "base/all_reduce.h"
+#include "base/all_to_all.h"
+#include "base/broadcast.h"
+#include "base/gather.h"
+#include "base/reduce.h"
+#include "base/reduce_scatter.h"
+#include "base/scatter.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+struct CclCollective {
+  using Api = CclApi<backend, device>;
+  using TypeMap = CclTypeMap<backend, device>;
+  using CommInstance = CclCommInstance<Api>;
+
+  static CommInstance *Get(Communicator *comm) {
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    return instance && instance->handle ? instance : nullptr;
+  }
+
+  static bool ToDataType(DataType value, typename Api::DataType *result) {
+    return TypeMap::ToBackendDataType(value, result);
+  }
+
+  static bool ToReduction(ReductionOpType value, typename Api::RedOp *result) {
+    return TypeMap::ToBackendRedOp(value, result);
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclBroadcastImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, int root, Communicator *comm,
+                            void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type)) return ReturnStatus::kNotSupported;
+    return C::Api::Check(C::Api::Broadcast(send_buff, recv_buff, count,
+                                            backend_type, root, instance->handle,
+                                            reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclReduceImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, ReductionOpType op, int root,
+                            Communicator *comm, void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    typename C::Api::RedOp backend_op{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type) || !C::ToReduction(op, &backend_op)) {
+      return ReturnStatus::kNotSupported;
+    }
+    return C::Api::Check(C::Api::Reduce(send_buff, recv_buff, count, backend_type,
+                                        backend_op, root, instance->handle,
+                                        reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclReduceScatterImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, ReductionOpType op, Communicator *comm,
+                            void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    typename C::Api::RedOp backend_op{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type) || !C::ToReduction(op, &backend_op)) {
+      return ReturnStatus::kNotSupported;
+    }
+    return C::Api::Check(C::Api::ReduceScatter(send_buff, recv_buff, count,
+                                               backend_type, backend_op,
+                                               instance->handle,
+                                               reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclAllGatherImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, Communicator *comm, void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type)) return ReturnStatus::kNotSupported;
+    return C::Api::Check(C::Api::AllGather(send_buff, recv_buff, count,
+                                            backend_type, instance->handle,
+                                            reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclGatherImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, int root, Communicator *comm,
+                            void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type)) return ReturnStatus::kNotSupported;
+    return C::Api::Check(C::Api::Gather(send_buff, recv_buff, count, backend_type,
+                                         root, instance->handle,
+                                         reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclScatterImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, int root, Communicator *comm,
+                            void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type)) return ReturnStatus::kNotSupported;
+    return C::Api::Check(C::Api::Scatter(send_buff, recv_buff, count, backend_type,
+                                          root, instance->handle,
+                                          reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+template <BackendType backend, Device::Type device>
+struct CclAllToAllImpl {
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff, size_t count,
+                            DataType type, Communicator *comm, void *stream) {
+    using C = CclCollective<backend, device>;
+    auto *instance = C::Get(comm);
+    typename C::Api::DataType backend_type{};
+    if (!instance) return ReturnStatus::kInternalError;
+    if (!C::ToDataType(type, &backend_type)) return ReturnStatus::kNotSupported;
+    return C::Api::Check(C::Api::AllToAll(send_buff, recv_buff, count,
+                                           backend_type, instance->handle,
+                                           reinterpret_cast<typename C::Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_COLLECTIVES_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,51 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+  static Result Broadcast(const void *send_buff, void *recv_buff, size_t count,
+                          DataType data_type, int root, Comm comm,
+                          Stream stream) {
+    return mcclBroadcast(send_buff, recv_buff, count, data_type, root, comm,
+                         stream);
+  }
+
+  static Result Reduce(const void *send_buff, void *recv_buff, size_t count,
+                       DataType data_type, RedOp op, int root, Comm comm,
+                       Stream stream) {
+    return mcclReduce(send_buff, recv_buff, count, data_type, op, root, comm,
+                      stream);
+  }
+
+  static Result ReduceScatter(const void *send_buff, void *recv_buff,
+                              size_t recv_count, DataType data_type, RedOp op,
+                              Comm comm, Stream stream) {
+    return mcclReduceScatter(send_buff, recv_buff, recv_count, data_type, op,
+                             comm, stream);
+  }
+
+  static Result AllGather(const void *send_buff, void *recv_buff,
+                          size_t send_count, DataType data_type, Comm comm,
+                          Stream stream) {
+    return mcclAllGather(send_buff, recv_buff, send_count, data_type, comm,
+                         stream);
+  }
+
+  static Result Gather(const void *send_buff, void *recv_buff, size_t send_count,
+                       DataType data_type, int root, Comm comm, Stream stream) {
+    return mcclGather(send_buff, recv_buff, send_count, data_type, root, comm,
+                      stream);
+  }
+
+  static Result Scatter(const void *send_buff, void *recv_buff,
+                        size_t recv_count, DataType data_type, int root,
+                        Comm comm, Stream stream) {
+    return mcclScatter(send_buff, recv_buff, recv_count, data_type, root, comm,
+                       stream);
+  }
+
+  static Result AllToAll(const void *send_buff, void *recv_buff, size_t count,
+                         DataType data_type, Comm comm, Stream stream) {
+    return mcclAllToAll(send_buff, recv_buff, count, data_type, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/all_gather.h
+++ b/src/backends/ccl/mccl/impl/all_gather.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/all_gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct AllGatherImpl<BackendType::kMccl, device>
+    : CclAllGatherImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<AllGather, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/mccl/impl/all_to_all.h
+++ b/src/backends/ccl/mccl/impl/all_to_all.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/all_to_all.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct AllToAllImpl<BackendType::kMccl, device>
+    : CclAllToAllImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<AllToAll, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_

--- a/src/backends/ccl/mccl/impl/broadcast.h
+++ b/src/backends/ccl/mccl/impl/broadcast.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/broadcast.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct BroadcastImpl<BackendType::kMccl, device>
+    : CclBroadcastImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Broadcast, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_BROADCAST_H_

--- a/src/backends/ccl/mccl/impl/gather.h
+++ b/src/backends/ccl/mccl/impl/gather.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct GatherImpl<BackendType::kMccl, device>
+    : CclGatherImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Gather, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_

--- a/src/backends/ccl/mccl/impl/reduce.h
+++ b/src/backends/ccl/mccl/impl/reduce.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct ReduceImpl<BackendType::kMccl, device>
+    : CclReduceImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Reduce, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_

--- a/src/backends/ccl/mccl/impl/reduce_scatter.h
+++ b/src/backends/ccl/mccl/impl/reduce_scatter.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/reduce_scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct ReduceScatterImpl<BackendType::kMccl, device>
+    : CclReduceScatterImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<ReduceScatter, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_

--- a/src/backends/ccl/mccl/impl/scatter.h
+++ b/src/backends/ccl/mccl/impl/scatter.h
@@ -1,0 +1,18 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_
+
+#include "backends/ccl/common/impl/collectives.h"
+#include "base/scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct ScatterImpl<BackendType::kMccl, device>
+    : CclScatterImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Scatter, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+if(NOT WITH_MCCL)
+  return()
+endif()
+
+add_executable(ccl_collectives_impl_test
+    ccl_collectives_impl.cc
+)
+
+target_include_directories(ccl_collectives_impl_test PRIVATE
+    "${PROJECT_SOURCE_DIR}/include"
+    "${PROJECT_SOURCE_DIR}/src"
+    "${PROJECT_BINARY_DIR}/src"
+)
+target_compile_features(ccl_collectives_impl_test PRIVATE cxx_std_17)
+
+add_test(
+    NAME ccl_collectives_impl
+    COMMAND ccl_collectives_impl_test
+)

--- a/tests/ccl_collectives_impl.cc
+++ b/tests/ccl_collectives_impl.cc
@@ -1,0 +1,89 @@
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+#include "backends/ccl/common/impl/collectives.h"
+
+namespace infini::ccl {
+
+struct FakeMcclApi {
+  static constexpr BackendType kBackendType = BackendType::kMccl;
+  using Comm = int;
+  using DataType = int;
+  using RedOp = int;
+  using Result = int;
+  using Stream = void*;
+  static constexpr Result kSuccess = 0;
+  static constexpr Result kFailure = 1;
+  struct Call { const void* send; void* recv; size_t count; DataType type; RedOp op; int root; Comm comm; Stream stream; };
+  static Call call;
+  static Result next_result;
+  static Result CommDestroy(Comm) { return kSuccess; }
+  static void Reset() { call = {}; next_result = kSuccess; }
+  static ReturnStatus Check(Result result) { return result == kSuccess ? ReturnStatus::kSuccess : ReturnStatus::kSystemError; }
+  static Result Broadcast(const void* s, void* r, size_t n, DataType t, int root, Comm c, Stream x) { call = {s,r,n,t,0,root,c,x}; return next_result; }
+  static Result Reduce(const void* s, void* r, size_t n, DataType t, RedOp o, int root, Comm c, Stream x) { call = {s,r,n,t,o,root,c,x}; return next_result; }
+  static Result ReduceScatter(const void* s, void* r, size_t n, DataType t, RedOp o, Comm c, Stream x) { call = {s,r,n,t,o,-1,c,x}; return next_result; }
+  static Result AllGather(const void* s, void* r, size_t n, DataType t, Comm c, Stream x) { call = {s,r,n,t,0,-1,c,x}; return next_result; }
+  static Result Gather(const void* s, void* r, size_t n, DataType t, int root, Comm c, Stream x) { call = {s,r,n,t,0,root,c,x}; return next_result; }
+  static Result Scatter(const void* s, void* r, size_t n, DataType t, int root, Comm c, Stream x) { call = {s,r,n,t,0,root,c,x}; return next_result; }
+  static Result AllToAll(const void* s, void* r, size_t n, DataType t, Comm c, Stream x) { call = {s,r,n,t,0,-1,c,x}; return next_result; }
+};
+FakeMcclApi::Call FakeMcclApi::call{};
+FakeMcclApi::Result FakeMcclApi::next_result = FakeMcclApi::kSuccess;
+
+template <> struct CclApi<BackendType::kMccl, Device::Type::kMetax> : FakeMcclApi {};
+template <> struct CclTypeMap<BackendType::kMccl, Device::Type::kMetax> {
+  static bool ToBackendDataType(DataType type, int* result) { if (type == DataType::kUInt16) return false; *result = 100 + static_cast<int>(type); return true; }
+  static bool ToBackendRedOp(ReductionOpType op, int* result) { if (op == ReductionOpType::kNumRedOps) return false; *result = 200 + static_cast<int>(op); return true; }
+};
+using Api = CclApi<BackendType::kMccl, Device::Type::kMetax>;
+using Instance = CclCommInstance<Api>;
+std::unique_ptr<Instance> MakeComm() { auto result = std::make_unique<Instance>(); result->handle = 7; return result; }
+
+bool ForwardAllCollectives() {
+  FakeMcclApi::Reset();
+  Communicator comm(Device::Type::kMetax, 0); comm.set_intra_comm(MakeComm());
+  int send = 1, recv = 0; void* stream = reinterpret_cast<void*>(0x1234);
+  using B = CclBroadcastImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using R = CclReduceImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using S = CclReduceScatterImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using G = CclAllGatherImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using H = CclGatherImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using T = CclScatterImpl<BackendType::kMccl, Device::Type::kMetax>;
+  using A = CclAllToAllImpl<BackendType::kMccl, Device::Type::kMetax>;
+  if (B::Apply(&send,&recv,3,DataType::kFloat32,1,&comm,stream) != ReturnStatus::kSuccess || FakeMcclApi::call.root != 1) return false;
+  if (R::Apply(&send,&recv,4,DataType::kInt32,ReductionOpType::kSum,0,&comm,stream) != ReturnStatus::kSuccess || FakeMcclApi::call.op != 200) return false;
+  if (S::Apply(&send,&recv,5,DataType::kFloat32,ReductionOpType::kMax,&comm,stream) != ReturnStatus::kSuccess) return false;
+  if (G::Apply(&send,&recv,6,DataType::kFloat32,&comm,stream) != ReturnStatus::kSuccess) return false;
+  if (H::Apply(&send,&recv,7,DataType::kFloat32,0,&comm,stream) != ReturnStatus::kSuccess) return false;
+  if (T::Apply(&send,&recv,8,DataType::kFloat32,0,&comm,stream) != ReturnStatus::kSuccess) return false;
+  return A::Apply(&send,&recv,9,DataType::kFloat32,&comm,stream) == ReturnStatus::kSuccess;
+}
+
+bool RejectUnsupportedAndPropagateError() {
+  FakeMcclApi::Reset(); Communicator comm(Device::Type::kMetax, 0); comm.set_intra_comm(MakeComm());
+  int send = 1, recv = 0;
+  using B = CclBroadcastImpl<BackendType::kMccl, Device::Type::kMetax>;
+  if (B::Apply(&send,&recv,1,DataType::kUInt16,0,&comm,nullptr) != ReturnStatus::kNotSupported || FakeMcclApi::call.send != nullptr) return false;
+  FakeMcclApi::next_result = FakeMcclApi::kFailure;
+  return B::Apply(&send,&recv,1,DataType::kFloat32,0,&comm,nullptr) == ReturnStatus::kSystemError;
+}
+
+bool RejectInvalidCommunicator() {
+  int send = 1, recv = 0;
+  using A = CclAllToAllImpl<BackendType::kMccl, Device::Type::kMetax>;
+  Communicator comm(Device::Type::kMetax, 0);
+  return A::Apply(&send,&recv,1,DataType::kFloat32,&comm,nullptr) == ReturnStatus::kInternalError;
+}
+
+bool Run(const char* name, bool (*test)()) { if (test()) return true; std::cerr << "FAILED: " << name << std::endl; return false; }
+}  // namespace infini::ccl
+
+int main() {
+  using namespace infini::ccl;
+  bool passed = Run("forward all collectives", ForwardAllCollectives);
+  passed = Run("unsupported type and backend error", RejectUnsupportedAndPropagateError) && passed;
+  passed = Run("invalid communicator", RejectInvalidCommunicator) && passed;
+  return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Add collective communication support for the MCCL backend on MetaX GPUs.

This PR implements the MCCL adapters and bridge registrations for the
collective operations that are already exposed by the InfiniCCL public API.

## Changes

- **MCCL API adapters**
  - Add MCCL wrappers for `Broadcast`, `Reduce`, `ReduceScatter`,
    `AllGather`, `Gather`, `Scatter`, and `AllToAll`.
  - Preserve the existing `CclApi` and `CclTypeMap` abstractions.

- **Collective implementations**
  - Add common CCL forwarding implementations for the supported collective
    operations.
  - Add MCCL backend registrations for each operation.
  - Reuse the existing communicator, data type, reduction operation, and
    return status handling.

- **Tests and examples**
  - Add fake MCCL API tests for argument forwarding and error handling.
  - Cover unsupported data types and invalid communicator states.
  - Add `examples/ccl/collectives.cc` demonstrating MCCL broadcast.
  - Register the collection communication test with CTest.

## Platform and Backend Affected

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [ ] NCCL
- [x] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

This PR adds MCCL collective operation coverage and does not change the
implementation of existing collective operations on other backends.

## Known Issues & Future Work

- Runtime validation of multi-device collective communication depends on a
  working MetaX/MCCL communicator initialization environment.
- Point-to-point communication is covered by the preceding MCCL change and is
  not modified by this PR.

## Test Results

The following checks were run with MetaX and MCCL enabled:

- Clean CMake configuration completed successfully.
- Full project build completed successfully.
- All existing examples compiled successfully.
- The new `examples/ccl/collectives` example compiled successfully.
- The MCCL bridge generated all seven new collective operations.
- CTest passed:
  - `ccl_collectives_impl`
- `git diff --check` passed.

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [ ] NCCL
- [x] MCCL

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows the repository convention:
      `feat/mccl-collectives-20260818`.
- [x] The commit message follows Conventional Commits.
- [x] This PR is organized as a single focused change.
- [x] No unrelated merge commits were added.
- [x] No `fixup!`, `squash!`, or `wip` commits remain.

### Scope and Design

- [x] Changes are limited to MCCL collective communication.
- [x] No unrelated backend or platform behavior was added.
- [x] No dead code or debug output was introduced.
- [x] Existing public operation interfaces are reused.

### General Code Hygiene

- [x] Comments and error messages added by this PR are in English.
- [x] Modified files end with a trailing newline.
- [x] `git diff --check` passes.

### C++ Specific

- [x] No exception-based argument parsing was added.
- [ ] `clang-format` version 16 has been run locally.
      <!-- Run this before submitting because clang-format-16 is unavailable
      in the current environment. -->

### Testing

- [x] The relevant MCCL example was built successfully.
- [x] The MCCL collective forwarding test passed.

### Build, CI, and Tooling

- [ ] GitHub CI workflows are green.
      <!-- Check this after opening the PR. -->

### Documentation

- [ ] No README or API documentation update is required for this internal
      backend implementation and example addition.

### Security and Safety

- [x] No secrets, tokens, internal URLs, customer data, or hardware
      identifiers were committed.
- [x] No unsafe pointer arithmetic or uninitialized reads were introduced.