### PR TITLE
feat: support CCL `ReduceScatter`

### DIFF
--- a/examples/ccl/reduce_scatter.cc
+++ b/examples/ccl/reduce_scatter.cc
@@ -1,0 +1,360 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node ReduceScatter
+ *
+ * This example creates one native CCL rank per GPU, then validates
+ * out-of-place and canonical in-place ReduceScatter without an MPI launcher.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+struct ScenarioState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t recv_count;
+  int warmup_iter;
+  int profile_iter;
+  ScenarioState *out_of_place;
+  ScenarioState *in_place;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+void FillInput(std::vector<float> *input, size_t recv_count, int world_size,
+               int rank) {
+  for (int dest_rank = 0; dest_rank < world_size; ++dest_rank) {
+    const float value =
+        static_cast<float>(rank + 1) * static_cast<float>(dest_rank + 1);
+    const size_t offset = static_cast<size_t>(dest_rank) * recv_count;
+    std::fill_n(input->begin() + offset, recv_count, value);
+  }
+}
+
+float ExpectedValue(int rank, int world_size) {
+  const float rank_sum = static_cast<float>(world_size) *
+                         (static_cast<float>(world_size) + 1.0f) / 2.0f;
+  return rank_sum * static_cast<float>(rank + 1);
+}
+
+void WaitForScenario(ScenarioState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_release);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+void PrintReduceScatterMetrics(size_t recv_count, int world_size,
+                               double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const size_t total_count = recv_count * static_cast<size_t>(world_size);
+  const double recv_bytes = static_cast<double>(recv_count) * sizeof(float);
+  const double total_bytes = static_cast<double>(total_count) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Received data per rank: " << recv_count << " floats ("
+            << std::fixed << std::setprecision(2) << recv_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total reduced data:    " << total_count << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:                  " << std::setprecision(3) << elapsed_ms
+            << " ms" << std::endl;
+  if (world_size > 0 && elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:            " << std::setprecision(2)
+              << bus_bandwidth << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:            N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void PrintResult(const char *scenario, bool correct,
+                 const std::vector<float> &result, float expected,
+                 size_t recv_count, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== " << scenario
+            << " CCL ReduceScatter Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Expect:  " << expected << std::endl;
+  std::cout << "Actual:  " << result.front() << std::endl;
+  PrintReduceScatterMetrics(recv_count, world_size, elapsed_ms);
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the ReduceScatter worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const size_t send_count = args.recv_count * static_cast<size_t>(args.size);
+  const size_t send_bytes = send_count * sizeof(float);
+  const size_t recv_bytes = args.recv_count * sizeof(float);
+  const size_t local_offset = static_cast<size_t>(args.rank) * args.recv_count;
+
+  std::vector<float> h_send(send_count);
+  std::vector<float> h_recv(args.recv_count, 0.0f);
+  FillInput(&h_send, args.recv_count, args.size, args.rank);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), recv_bytes));
+
+  auto run_scenario = [&](bool in_place) {
+    CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    float *active_recv = in_place ? d_send + local_offset : d_recv;
+    auto restore_local_block = [&]() {
+      if (in_place) {
+        CHECK_RT(Rt, Rt::Memcpy(active_recv, h_send.data() + local_offset,
+                                recv_bytes, Rt::MemcpyHostToDevice));
+        CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+      }
+    };
+
+    for (int i = 0; i < args.warmup_iter; ++i) {
+      restore_local_block();
+      CHECK_INFINI(infinicclReduceScatter(d_send, active_recv, args.recv_count,
+                                          infinicclFloat32, infinicclSum, comm,
+                                          nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    double elapsed_ms = 0.0;
+    if (in_place) {
+      for (int i = 0; i < args.profile_iter; ++i) {
+        restore_local_block();
+        Timer timer;
+        CHECK_INFINI(infinicclReduceScatter(d_send, active_recv,
+                                            args.recv_count, infinicclFloat32,
+                                            infinicclSum, comm, nullptr));
+        CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+        elapsed_ms += timer.ElapsedMs();
+      }
+      elapsed_ms /= static_cast<double>(args.profile_iter);
+    } else {
+      Timer timer;
+      for (int i = 0; i < args.profile_iter; ++i) {
+        CHECK_INFINI(infinicclReduceScatter(d_send, active_recv,
+                                            args.recv_count, infinicclFloat32,
+                                            infinicclSum, comm, nullptr));
+      }
+      CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+      elapsed_ms = timer.ElapsedMs() / static_cast<double>(args.profile_iter);
+    }
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), active_recv, recv_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    const float expected = ExpectedValue(args.rank, args.size);
+    const bool correct = Validator::ValidateResult(
+        h_recv.data(), args.recv_count, expected, args.rank);
+    ScenarioState *state = in_place ? args.in_place : args.out_of_place;
+    if (!correct) {
+      state->correct.store(false, std::memory_order_relaxed);
+    }
+    WaitForScenario(state, args.size);
+
+    if (args.rank == 0) {
+      PrintResult(in_place ? "In-Place" : "Out-of-Place",
+                  state->correct.load(std::memory_order_acquire), h_recv,
+                  expected, args.recv_count, args.size, elapsed_ms);
+    }
+  };
+
+  run_scenario(false);
+  run_scenario(true);
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>        Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>    Warmup iterations (default: 2)\n"
+            << "  -p <profile_iters>   Profile iterations (default: 20)\n"
+            << "  -n <recv_count>      Elements received per rank (default: "
+               "1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iters = 2;
+  int profile_iters = 20;
+  size_t recv_count = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iters);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iters);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &recv_count);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for ReduceScatter."
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for ReduceScatter."
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (recv_count > std::numeric_limits<size_t>::max() / sizeof(float) ||
+      static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / recv_count ||
+      recv_count * static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "ReduceScatter buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for ReduceScatter." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  ScenarioState out_of_place;
+  ScenarioState in_place;
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,      shared_id,     recv_count,
+                    warmup_iters, profile_iters, &out_of_place, &in_place};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = out_of_place.correct.load(std::memory_order_acquire) &&
+                       in_place.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] All ReduceScatter scenarios passed."
+              << std::endl;
+  } else {
+    std::cerr << "[Main Process] ReduceScatter validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/reduce_scatter.cc
+++ b/examples/ccl_mpi_hybrid/reduce_scatter.cc
@@ -1,0 +1,359 @@
+/**
+ * InfiniCCL Example: ReduceScatter (OpenMPI + CCL Hybrid)
+ *
+ * This example first uses ReduceScatter through an OpenMPI inter communicator
+ * to distribute a native CCL unique ID. It then initializes a native CCL
+ * communicator and validates out-of-place and canonical in-place GPU
+ * ReduceScatter.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+#include "device.h"
+#include "runtime.h"
+#include "traits.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+bool ParseLocalRank(const char *text, int *local_rank) {
+  if (!text || !local_rank) {
+    return false;
+  }
+
+  int parsed = -1;
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed < 0) {
+    return false;
+  }
+
+  *local_rank = parsed;
+  return true;
+}
+
+void FillInput(std::vector<float> *input, size_t recv_count, int world_size,
+               int rank) {
+  for (int dest_rank = 0; dest_rank < world_size; ++dest_rank) {
+    const float value =
+        static_cast<float>(rank + 1) * static_cast<float>(dest_rank + 1);
+    const size_t offset = static_cast<size_t>(dest_rank) * recv_count;
+    std::fill_n(input->begin() + offset, recv_count, value);
+  }
+}
+
+float ExpectedValue(int rank, int world_size) {
+  const float rank_sum = static_cast<float>(world_size) *
+                         (static_cast<float>(world_size) + 1.0f) / 2.0f;
+  return rank_sum * static_cast<float>(rank + 1);
+}
+
+void PrintReduceScatterMetrics(size_t recv_count, int world_size,
+                               double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const size_t total_count = recv_count * static_cast<size_t>(world_size);
+  const double recv_bytes = static_cast<double>(recv_count) * sizeof(float);
+  const double total_bytes = static_cast<double>(total_count) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Received data per rank: " << recv_count << " floats ("
+            << std::fixed << std::setprecision(2) << recv_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total reduced data:    " << total_count << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:                  " << std::setprecision(3) << elapsed_ms
+            << " ms" << std::endl;
+  if (world_size > 0 && elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:            " << std::setprecision(2)
+              << bus_bandwidth << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:            N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void PrintResult(const char *scenario, bool correct, float actual,
+                 float expected, size_t recv_count, int world_size,
+                 double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== " << scenario
+            << " Hybrid CCL ReduceScatter Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Expect:  " << expected << std::endl;
+  std::cout << "Actual:  " << actual << std::endl;
+  PrintReduceScatterMetrics(recv_count, world_size, elapsed_ms);
+}
+
+bool RunReduceScatterExample(int argc, char **argv) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kRecvCount = 1 << 20;
+
+  CHECK_INFINI(infinicclInit(&argc, &argv));
+
+  int rank = -1;
+  int size = 0;
+  CHECK_INFINI(infinicclGetRank(&rank));
+  CHECK_INFINI(infinicclGetSize(&size));
+  if (size <= 0) {
+    std::cerr << "Invalid world size for hybrid ReduceScatter." << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  int local_rank = -1;
+  if (!ParseLocalRank(std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"), &local_rank)) {
+    std::cerr << "Missing or invalid `OMPI_COMM_WORLD_LOCAL_RANK`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  CHECK_RT(Rt, Rt::SetDevice(local_rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for hybrid ReduceScatter."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << local_rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
+
+  // Bootstrap the native communicator with ReduceScatter itself. Rank 0
+  // repeats the same unique ID in every destination block; all other ranks
+  // contribute zeros. With only the OpenMPI inter communicator initialized,
+  // the CCL provider delegates this call to MPI_Reduce_scatter_block.
+  infinicclUniqueId id{};
+  if (rank == 0) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  const size_t id_bytes = sizeof(id);
+  const size_t world_size = static_cast<size_t>(size);
+  if (world_size > std::numeric_limits<size_t>::max() / id_bytes) {
+    std::cerr << "ReduceScatter bootstrap buffer size overflows `size_t`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  const size_t id_send_bytes = id_bytes * world_size;
+  std::vector<uint8_t> h_id_send(id_send_bytes, 0);
+  if (rank == 0) {
+    for (int dest_rank = 0; dest_rank < size; ++dest_rank) {
+      std::memcpy(h_id_send.data() + static_cast<size_t>(dest_rank) * id_bytes,
+                  &id, id_bytes);
+    }
+  }
+
+  uint8_t *d_id_send = nullptr;
+  uint8_t *d_id_recv = nullptr;
+  CHECK_RT(Rt,
+           Rt::Malloc(reinterpret_cast<void **>(&d_id_send), id_send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_id_recv), id_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_id_send, h_id_send.data(), id_send_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclReduceScatter(d_id_send, d_id_recv, id_bytes,
+                                      infinicclUInt8, infinicclSum, comm,
+                                      nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(&id, d_id_recv, id_bytes, Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_RT(Rt, Rt::Free(d_id_send));
+  CHECK_RT(Rt, Rt::Free(d_id_recv));
+
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
+  if (kRecvCount > std::numeric_limits<size_t>::max() / world_size ||
+      kRecvCount * world_size >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Hybrid ReduceScatter buffer size overflows `size_t`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
+  const size_t send_count = kRecvCount * world_size;
+  const size_t send_bytes = send_count * sizeof(float);
+  const size_t recv_bytes = kRecvCount * sizeof(float);
+  const size_t local_offset = static_cast<size_t>(rank) * kRecvCount;
+  std::vector<float> h_send(send_count);
+  std::vector<float> h_recv(kRecvCount, 0.0f);
+  FillInput(&h_send, kRecvCount, size, rank);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), recv_bytes));
+
+  std::array<bool, 2> local_correct{true, true};
+  std::array<double, 2> elapsed_ms{};
+  std::array<float, 2> actual{};
+  for (int scenario = 0; scenario < 2; ++scenario) {
+    const bool in_place = scenario == 1;
+    CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), send_bytes,
+                            Rt::MemcpyHostToDevice));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    float *active_recv = in_place ? d_send + local_offset : d_recv;
+    auto restore_local_block = [&]() {
+      if (in_place) {
+        CHECK_RT(Rt, Rt::Memcpy(active_recv, h_send.data() + local_offset,
+                                recv_bytes, Rt::MemcpyHostToDevice));
+        CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+      }
+    };
+
+    for (int i = 0; i < kWarmupIterations; ++i) {
+      restore_local_block();
+      CHECK_INFINI(infinicclReduceScatter(d_send, active_recv, kRecvCount,
+                                          infinicclFloat32, infinicclSum, comm,
+                                          nullptr));
+    }
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+    if (in_place) {
+      for (int i = 0; i < kProfileIterations; ++i) {
+        restore_local_block();
+        Timer timer;
+        CHECK_INFINI(infinicclReduceScatter(d_send, active_recv, kRecvCount,
+                                            infinicclFloat32, infinicclSum,
+                                            comm, nullptr));
+        CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+        elapsed_ms[scenario] += timer.ElapsedMs();
+      }
+      elapsed_ms[scenario] /= static_cast<double>(kProfileIterations);
+    } else {
+      Timer timer;
+      for (int i = 0; i < kProfileIterations; ++i) {
+        CHECK_INFINI(infinicclReduceScatter(d_send, active_recv, kRecvCount,
+                                            infinicclFloat32, infinicclSum,
+                                            comm, nullptr));
+      }
+      CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+      elapsed_ms[scenario] =
+          timer.ElapsedMs() / static_cast<double>(kProfileIterations);
+    }
+
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), active_recv, recv_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    const float expected = ExpectedValue(rank, size);
+    local_correct[scenario] =
+        Validator::ValidateResult(h_recv.data(), kRecvCount, expected, rank);
+    actual[scenario] = h_recv.front();
+  }
+
+  // Reduce both validation flags into every destination block. Every rank then
+  // receives the same cluster-wide minimum and exits consistently.
+  if (world_size > std::numeric_limits<size_t>::max() / 2 ||
+      world_size * 2 > std::numeric_limits<size_t>::max() / sizeof(int32_t)) {
+    std::cerr << "ReduceScatter status buffer size overflows `size_t`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  std::vector<int32_t> h_status_send(world_size * 2, 0);
+  for (int dest_rank = 0; dest_rank < size; ++dest_rank) {
+    const size_t offset = static_cast<size_t>(dest_rank) * 2;
+    h_status_send[offset] = local_correct[0] ? 1 : 0;
+    h_status_send[offset + 1] = local_correct[1] ? 1 : 0;
+  }
+  std::array<int32_t, 2> h_status_recv{};
+  int32_t *d_status_send = nullptr;
+  int32_t *d_status_recv = nullptr;
+  const size_t status_send_bytes =
+      h_status_send.size() * sizeof(h_status_send[0]);
+  const size_t status_recv_bytes =
+      h_status_recv.size() * sizeof(h_status_recv[0]);
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_status_send),
+                          status_send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_status_recv),
+                          status_recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_status_send, h_status_send.data(),
+                          status_send_bytes, Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclReduceScatter(d_status_send, d_status_recv,
+                                      h_status_recv.size(), infinicclInt32,
+                                      infinicclMin, comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(h_status_recv.data(), d_status_recv,
+                          status_recv_bytes, Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  const std::array<bool, 2> global_correct{h_status_recv[0] == 1,
+                                           h_status_recv[1] == 1};
+  if (rank == 0) {
+    const float expected = ExpectedValue(rank, size);
+    PrintResult("Out-of-Place", global_correct[0], actual[0], expected,
+                kRecvCount, size, elapsed_ms[0]);
+    PrintResult("In-Place", global_correct[1], actual[1], expected, kRecvCount,
+                size, elapsed_ms[1]);
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_status_send));
+  CHECK_RT(Rt, Rt::Free(d_status_recv));
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+  CHECK_INFINI(infinicclFinalize());
+
+  if (rank == 0) {
+    if (global_correct[0] && global_correct[1]) {
+      std::cout << "[Main Process] All hybrid ReduceScatter scenarios passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid ReduceScatter validation failed."
+                << std::endl;
+    }
+    std::cout << "InfiniCCL finalized." << std::endl;
+  }
+  return global_correct[0] && global_correct[1];
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  return RunReduceScatterExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/mpi/reduce_scatter.cc
+++ b/examples/mpi/reduce_scatter.cc
@@ -6,7 +6,16 @@
 
 #include <unistd.h>
 
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
 #include <iostream>
+#include <limits>
+#include <system_error>
 #include <vector>
 
 // Public API
@@ -24,30 +33,93 @@
 
 using namespace infini::ccl;
 
-void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
-                             int profile_iter, const size_t kRecvCount) {
+namespace {
+
+bool ParseLocalRank(const char *text, int *local_rank) {
+  if (!text || !local_rank) {
+    return false;
+  }
+
+  int parsed = -1;
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed < 0) {
+    return false;
+  }
+
+  *local_rank = parsed;
+  return true;
+}
+
+void PrintReduceScatterMetrics(size_t recv_count, int world_size,
+                               double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const size_t total_count = recv_count * static_cast<size_t>(world_size);
+  const double recv_bytes = static_cast<double>(recv_count) * sizeof(float);
+  const double total_bytes = static_cast<double>(total_count) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Received data per rank: " << recv_count << " floats ("
+            << std::fixed << std::setprecision(2) << recv_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total reduced data:    " << total_count << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:                  " << std::setprecision(3) << elapsed_ms
+            << " ms" << std::endl;
+  if (world_size > 0 && elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:            " << std::setprecision(2)
+              << bus_bandwidth << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:            N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:         N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+bool RunReduceScatterExample(int argc, char **argv, int warmup_iter,
+                             int profile_iter, size_t recv_count) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
 
   CHECK_INFINI(infinicclInit(&argc, &argv));
 
-  int rank, size;
+  int rank = -1;
+  int size = 0;
   CHECK_INFINI(infinicclGetRank(&rank));
   CHECK_INFINI(infinicclGetSize(&size));
-
-  char hostname[256];
-  gethostname(hostname, sizeof(hostname));
-
-  // Map local rank to GPU device.
-  // Note: this is just for info printing. In practice, this part is not needed.
-  const char *local_rank_str = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK");
-  int local_rank = 0;
-  if (local_rank_str != nullptr) {
-    local_rank = std::atoi(local_rank_str);
+  if (size <= 0) {
+    std::cerr << "Invalid world size for ReduceScatter." << std::endl;
+    std::exit(EXIT_FAILURE);
   }
 
-  std::cout << "[Rank " << rank << "] Host: " << hostname
+  int local_rank = -1;
+  if (!ParseLocalRank(std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"), &local_rank)) {
+    std::cerr << "Missing or invalid `OMPI_COMM_WORLD_LOCAL_RANK`."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  CHECK_RT(Rt, Rt::SetDevice(local_rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for ReduceScatter." << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+
+  std::cout << "[Rank " << rank << "] Host: " << hostname.data()
             << " | GPU: " << Device::StringFromType(kDevType) << " "
             << " | Device " << local_rank << std::endl;
 
@@ -55,21 +127,34 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   infinicclComm_t comm = nullptr;
   CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
-  // ReduceScatter requires `send_count = recv_count * world_size`.
-  const size_t kSendCount = kRecvCount * static_cast<size_t>(size);
-
-  // Prepare Data
-  std::vector<float> h_send(kSendCount);
-  std::vector<float> h_recv(kRecvCount, 0.0f);
-
-  // Initialize: each rank provides its (rank + 1) as data.
-  for (size_t i = 0; i < kSendCount; ++i) {
-    h_send[i] = static_cast<float>(rank + 1);
+  const size_t world_size = static_cast<size_t>(size);
+  if (recv_count > std::numeric_limits<size_t>::max() / world_size) {
+    std::cerr << "ReduceScatter element count overflows `size_t`." << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  const size_t send_count = recv_count * world_size;
+  if (send_count > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "ReduceScatter buffer size overflows `size_t`." << std::endl;
+    std::exit(EXIT_FAILURE);
   }
 
-  float *d_send, *d_recv;
-  size_t send_bytes = kSendCount * sizeof(*d_send);
-  size_t recv_bytes = kRecvCount * sizeof(*d_recv);
+  // Prepare Data
+  std::vector<float> h_send(send_count);
+  std::vector<float> h_recv(recv_count, 0.0f);
+
+  // Give each destination block a distinct reduced value so validation also
+  // checks that the scattered block matches this rank.
+  for (int dest_rank = 0; dest_rank < size; ++dest_rank) {
+    const float value =
+        static_cast<float>(rank + 1) * static_cast<float>(dest_rank + 1);
+    const size_t offset = static_cast<size_t>(dest_rank) * recv_count;
+    std::fill_n(h_send.begin() + offset, recv_count, value);
+  }
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  size_t send_bytes = send_count * sizeof(*d_send);
+  size_t recv_bytes = recv_count * sizeof(*d_recv);
 
   CHECK_RT(Rt, Rt::Malloc((void **)&d_send, send_bytes));
   CHECK_RT(Rt, Rt::Malloc((void **)&d_recv, recv_bytes));
@@ -81,9 +166,9 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   if (rank == 0) {
     std::cout << "\n=== Performing ReduceScatter on GPU Memory ==="
               << std::endl;
-    std::cout << "Recv data size per rank: " << kRecvCount << " floats ("
+    std::cout << "Recv data size per rank: " << recv_count << " floats ("
               << recv_bytes / 1024 / 1024 << " MB)" << std::endl;
-    std::cout << "Send data size per rank: " << kSendCount << " floats ("
+    std::cout << "Send data size per rank: " << send_count << " floats ("
               << send_bytes / 1024 / 1024 << " MB)" << std::endl;
     std::cout << "Operation: Sum" << std::endl;
     std::cout << "Warm-up iterations: " << warmup_iter << std::endl;
@@ -93,14 +178,14 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   // Warm-up and D2H transfer the answer.
-  CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+  CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, recv_count,
                                       infinicclFloat32, infinicclSum, comm,
                                       nullptr));
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, recv_bytes,
                           Rt::MemcpyDeviceToHost));
 
   for (int i = 1; i < warmup_iter; ++i) {
-    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, recv_count,
                                         infinicclFloat32, infinicclSum, comm,
                                         nullptr));
   }
@@ -110,7 +195,7 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   Timer timer;
 
   for (int i = 0; i < profile_iter; ++i) {
-    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, kRecvCount,
+    CHECK_INFINI(infinicclReduceScatter(d_send, d_recv, recv_count,
                                         infinicclFloat32, infinicclSum, comm,
                                         nullptr));
   }
@@ -122,18 +207,16 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   double elapsed = timer.ElapsedMs() / static_cast<double>(profile_iter);
 
   // Result Validation:
-  float expected = 0.0f;
-  for (int r = 0; r < size; ++r) {
-    expected += static_cast<float>(r + 1);
-  }
+  const float rank_sum =
+      static_cast<float>(size) * (static_cast<float>(size) + 1.0f) / 2.0f;
+  const float expected = rank_sum * static_cast<float>(rank + 1);
 
-  Validator::ValidateResult(h_recv.data(), kRecvCount, expected, rank, true,
-                            "ReduceScatter");
+  const bool correct = Validator::ValidateResult(
+      h_recv.data(), recv_count, expected, rank, true, "ReduceScatter");
 
   // Metrics Reporting (Only from rank 0 for cleaner output)
   if (rank == 0) {
-    Metrics metrics{elapsed, recv_bytes, size};
-    metrics.Print();
+    PrintReduceScatterMetrics(recv_count, size, elapsed);
   }
 
   // Cleanup
@@ -146,14 +229,17 @@ void RunReduceScatterExample(int argc, char **argv, int warmup_iter,
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;
   }
+  return correct;
 }
+
+}  // namespace
 
 int main(int argc, char **argv) {
   int warmup_iters = 2;
   int profile_iters = 20;
   size_t recv_count = 1 << 20;
 
-  RunReduceScatterExample(argc, argv, warmup_iters, profile_iters, recv_count);
-
-  return EXIT_SUCCESS;
+  const bool correct = RunReduceScatterExample(argc, argv, warmup_iters,
+                                               profile_iters, recv_count);
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/reduce_scatter.h
+++ b/src/backends/ccl/common/impl/reduce_scatter.h
@@ -1,0 +1,69 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_SCATTER_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/reduce_scatter.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredReduceScatter {
+  using type = ReduceScatter;
+};
+
+template <BackendType backend, Device::Type device>
+class CclReduceScatterImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t recv_count, DataType data_type,
+                            ReductionOpType op, Communicator *comm,
+                            void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredReduceScatter<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return ReduceScatterImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, recv_count, data_type, op, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    typename Api::RedOp native_op{};
+    if (!TypeMap::ToBackendRedOp(op, &native_op)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(Api::ReduceScatter(
+        send_buff, recv_buff, recv_count, native_type, native_op,
+        instance->handle, reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_SCATTER_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,13 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result ReduceScatter(const void *send_buff, void *recv_buff,
+                              size_t recv_count, DataType data_type, RedOp op,
+                              Comm comm, Stream stream) {
+    return mcclReduceScatter(send_buff, recv_buff, recv_count, data_type, op,
+                             comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/reduce_scatter.h
+++ b/src/backends/ccl/mccl/impl/reduce_scatter.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_
+
+#include "backends/ccl/common/impl/reduce_scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ReduceScatterImpl<BackendType::kMccl, device>
+    : public CclReduceScatterImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<ReduceScatter, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_SCATTER_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,13 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result ReduceScatter(const void *send_buff, void *recv_buff,
+                              size_t recv_count, DataType data_type, RedOp op,
+                              Comm comm, Stream stream) {
+    return ncclReduceScatter(send_buff, recv_buff, recv_count, data_type, op,
+                             comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/reduce_scatter.h
+++ b/src/backends/ccl/nccl/impl/reduce_scatter.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_SCATTER_H_
+
+#include "backends/ccl/common/impl/reduce_scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ReduceScatterImpl<BackendType::kNccl, device>
+    : public CclReduceScatterImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<ReduceScatter, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_SCATTER_H_

--- a/src/backends/mpi/ompi/impl/reduce_scatter.h
+++ b/src/backends/mpi/ompi/impl/reduce_scatter.h
@@ -1,7 +1,9 @@
 #ifndef INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_REDUCE_SCATTER_H_
 #define INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_REDUCE_SCATTER_H_
 
+#include <cstdlib>
 #include <limits>
+#include <memory>
 #include <type_traits>
 
 #include "backends/mpi/ompi/checks.h"
@@ -31,42 +33,58 @@ class ReduceScatterImpl<BackendType::kOmpi, device_type> {
       LOG("Invalid OpenMPI communicator instance for `ReduceScatter`.");
       return ReturnStatus::kInternalError;
     }
+    if (comm->size() <= 0) {
+      LOG("Invalid world size for `ReduceScatter`.");
+      return ReturnStatus::kInternalError;
+    }
 
     MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
     MPI_Op mpi_op = RedOpToOmpiOp(op);
+    if (mpi_type == MPI_BYTE) {
+      LOG("Data type is not supported by OpenMPI reductions for "
+          "`ReduceScatter`.");
+      return ReturnStatus::kNotSupported;
+    }
 
     size_t world_size = static_cast<size_t>(comm->size());
     size_t type_size = kDataTypeToSize.at(data_type);
+    if (recv_count > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Send element count overflows `size_t` for `ReduceScatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
     size_t send_count = recv_count * world_size;
+    if (send_count > std::numeric_limits<size_t>::max() / type_size ||
+        recv_count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Buffer byte size overflows `size_t` for `ReduceScatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
     size_t send_bytes = send_count * type_size;
     size_t recv_bytes = recv_count * type_size;
 
-    // Handle GPU Memory (Staging Pattern)
-    // Note: we simply use host-staging for now.
-    void *host_sendbuf = malloc(send_bytes);
-    void *host_recvbuf = malloc(recv_bytes);
-    if (!host_sendbuf || !host_recvbuf) {
-      free(host_sendbuf);
-      free(host_recvbuf);
-      LOG("Failed to allocate host buffers for `ReduceScatter` staging.");
-      return ReturnStatus::kSystemError;
-    }
-
-    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, send_bytes,
-                                Rt::MemcpyDeviceToHost));
-    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
-
     if (recv_count > static_cast<size_t>(std::numeric_limits<int>::max())) {
-      LOG("recv_count exceeds MPI int range for `ReduceScatter`.");
-      free(host_sendbuf);
-      free(host_recvbuf);
+      LOG("Receive count exceeds MPI int range for `ReduceScatter`.");
       return ReturnStatus::kInvalidArgument;
     }
     int mpi_recv_count = static_cast<int>(recv_count);
 
-    INFINI_CHECK_MPI(MPI_Reduce_scatter_block(host_sendbuf, host_recvbuf,
-                                              mpi_recv_count, mpi_type, mpi_op,
-                                              inst->handle));
+    // Handle GPU Memory (Staging Pattern)
+    // Note: we simply use host-staging for now.
+    std::unique_ptr<void, decltype(&std::free)> host_sendbuf(
+        std::malloc(send_bytes), &std::free);
+    std::unique_ptr<void, decltype(&std::free)> host_recvbuf(
+        std::malloc(recv_bytes), &std::free);
+    if (!host_sendbuf || !host_recvbuf) {
+      LOG("Failed to allocate host buffers for `ReduceScatter` staging.");
+      return ReturnStatus::kSystemError;
+    }
+
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf.get(), send_buff, send_bytes,
+                                Rt::MemcpyDeviceToHost));
+    CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
+
+    INFINI_CHECK_MPI(MPI_Reduce_scatter_block(
+        host_sendbuf.get(), host_recvbuf.get(), mpi_recv_count, mpi_type,
+        mpi_op, inst->handle));
 
     if (op == ReductionOpType::kAvg) {
       float scale = 1.0f / static_cast<float>(world_size);
@@ -74,7 +92,7 @@ class ReduceScatterImpl<BackendType::kOmpi, device_type> {
       DispatchFunc<kDev, AllTypes>(data_type, [&](auto dtype) {
         using T = typename decltype(dtype)::type;
 
-        T *typed_buf = static_cast<T *>(host_recvbuf);
+        T *typed_buf = static_cast<T *>(host_recvbuf.get());
 
         // Simply do the averaging on the CPU before the H2D copy.
         for (size_t i = 0; i < recv_count; ++i) {
@@ -94,11 +112,8 @@ class ReduceScatterImpl<BackendType::kOmpi, device_type> {
       });
     }
 
-    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf.get(), recv_bytes,
                                 Rt::MemcpyHostToDevice));
-
-    free(host_sendbuf);
-    free(host_recvbuf);
 
     return ReturnStatus::kSuccess;
   }

--- a/src/base/reduce_scatter.h
+++ b/src/base/reduce_scatter.h
@@ -20,9 +20,14 @@ class ReduceScatter : public Operation<ReduceScatter> {
                               size_t recv_count, DataType datatype,
                               ReductionOpType op, void *comm_handle,
                               void *stream) {
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, op, comm_handle)) {
+    if (HasInvalidArgs(send_buff, recv_buff, recv_count, datatype, op,
+                       comm_handle)) {
       return ReturnStatus::kInvalidArgument;
     }
+    if (recv_count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
     auto *comm = static_cast<Communicator *>(comm_handle);
     return ReduceScatterImpl<backend_type, device_type>::Apply(
         send_buff, recv_buff, recv_count, datatype, op, comm, stream);
@@ -30,15 +35,11 @@ class ReduceScatter : public Operation<ReduceScatter> {
 
  private:
   static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, ReductionOpType op,
-                             void *comm_handle) {
+                             size_t recv_count, DataType datatype,
+                             ReductionOpType op, void *comm_handle) {
     if (!comm_handle) {
       // TODO(lzm): change to use `glog`.
       LOG("Invalid communicator handle for `ReduceScatter`.");
-      return true;
-    }
-    if (!send_buff || !recv_buff) {
-      LOG("Invalid buffer pointer for `ReduceScatter`.");
       return true;
     }
     if (op < ReductionOpType::kSum || op >= ReductionOpType::kNumRedOps) {
@@ -47,6 +48,13 @@ class ReduceScatter : public Operation<ReduceScatter> {
     }
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `ReduceScatter`.");
+      return true;
+    }
+    if (recv_count == 0) {
+      return false;
+    }
+    if (!send_buff || !recv_buff) {
+      LOG("Invalid buffer pointer for `ReduceScatter`.");
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

This PR adds `ReduceScatter` support to the shared CCL backend abstraction, including native bindings through the existing NCCL and MCCL provider layers for the public `infinicclReduceScatter()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, hardens the shared OpenMPI/MPICH `ReduceScatter` implementation with typed-reduction validation, overflow checks, and automatic host-buffer cleanup, defines zero-count behavior, makes the existing MPI example validate rank-specific destination blocks and propagate failures, and includes CCL-only plus OpenMPI-assisted `ReduceScatter` example programs covering out-of-place and canonical in-place flows with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclReduceScatter()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `ReduceScatter` after validating the communicator, data type, and reduction operation, without requiring non-null buffers or entering a backend.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `ReduceScatter` implementation following the existing `AllReduce` structure.
  - Validate the native communicator backend, device, and handle before dispatch.
  - Map InfiniCCL data types and reduction operations through the configured provider and return `NotSupported` when the provider cannot represent either value.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with thin bindings to `ncclReduceScatter()` and `mcclReduceScatter()`.
  - Register `ReduceScatter` with the existing NCCL and MCCL provider layers.

- **MPI Correctness and Safety**
  - Keep arithmetic reduction on typed `MPI_Reduce_scatter_block()` calls and reject data types that map to `MPI_BYTE`, avoiding invalid byte-wise reductions for `Float16` and `BFloat16`.
  - Add world-size, `size_t` multiplication, buffer-size, and MPI `int` count-range checks for staged transfers.
  - Manage host staging buffers with automatic cleanup across success and error paths.
  - Validate the rank-specific destination block in the existing MPI example and return a non-zero process status on failure.

- **Examples, Validation, and Metrics**
  - Add a thread-per-GPU single-node CCL `ReduceScatter` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL `ReduceScatter` example that first uses the public `ReduceScatter` API through the OpenMPI inter communicator to distribute the native unique ID, then initializes the native CCL communicator for GPU reduction and scatter.
  - Validate both out-of-place and canonical in-place layouts with destination-block-dependent expected values on every rank.
  - Restore the local input block before every in-place iteration and propagate cluster-wide validation failures through a native `ReduceScatter` status operation.
  - Report per-rank receive size, total reduced data size, average time, algorithm bandwidth as `world_size * receive_bytes / time`, and bus bandwidth as algorithm bandwidth multiplied by `(world_size - 1) / world_size`.
  - Parse numeric options without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `ReduceScatter`, avoiding the existing MPI host-staging path when a supported CCL backend and native communicator are available. The shared MPI path remains host-staged and retains typed reduction semantics with additional validation and cleanup. Other collective operations are intended to remain unchanged. The validation-log timings below are execution references rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch now covers `AllReduce` and `ReduceScatter`; other CCL collective operations remain future work.
- `ReduceScatter` inherits the backend/device combinations, data types, and reduction operations supported by the existing CCL providers; this PR does not add a new provider or device integration.
- The server examples validate `Float32` `Sum` payloads on the default stream. Additional payload data types, reduction operations, non-default streams, and runtime coverage on Iluvatar and Moore Threads remain future work.
- The shared OpenMPI/MPICH fallback remains host-staged with per-call allocations, rejects `Float16` and `BFloat16` arithmetic reductions until a typed host conversion path is available, and rejects per-rank counts above the MPI `int` range; chunked transfers remain future work.

## Test Results

The implementation commit is `752bc4e3714ac3e7b4605cd1af0c9dd60df1d5fe`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached evidence contains exactly 15 canonical logs from the current commit: all 15 targets passed, with `Correct: YES` 20 times and `Correct: NO` 0 times. The five additional positive results come from the second out-of-place/in-place cases in the three native `ReduceScatter` logs and the two additional expected validation cases in the broadcast log.

All four `ReduceScatter` paths passed with a 1,048,576-element `Float32` receive block per rank (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations. The native paths validate both out-of-place and canonical in-place layouts; the heterogeneous MPI path validates its out-of-place layout.

| Path and layout | Test topology | Receive per rank / total reduced | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL, out-of-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.240 ms | 139.90 GB/s | 122.41 GB/s |
| Pure NCCL, in-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.523 ms | 64.11 GB/s | 56.10 GB/s |
| OpenMPI + NCCL hybrid, out-of-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.250 ms | 134.40 GB/s | 117.60 GB/s |
| OpenMPI + NCCL hybrid, in-place | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.345 ms | 97.38 GB/s | 85.21 GB/s |
| Heterogeneous OpenMPI, out-of-place | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 4.00 / 64.00 MiB | 142.754 ms | 0.47 GB/s | 0.44 GB/s |
| Pure MCCL, out-of-place | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 0.219 ms | 153.38 GB/s | 134.21 GB/s |
| Pure MCCL, in-place | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 1.385 ms | 24.22 GB/s | 21.19 GB/s |

Algorithm bandwidth uses the total logical reduced input size, `world_size * receive_bytes`, divided by the measured time. Bus bandwidth applies the standard `ReduceScatter` correction factor `(world_size - 1) / world_size`. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs. Each native `ReduceScatter` log passed both out-of-place and in-place validation.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, with ranks 0-7 mapped to devices 0-7. Its `ReduceScatter` log passed both out-of-place and in-place validation.
- All five formal runner invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA**:
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346902/ccl_all_reduce.log)
[ccl_reduce_scatter.log](https://github.com/user-attachments/files/31346904/ccl_reduce_scatter.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31346906/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_reduce_scatter.log](https://github.com/user-attachments/files/31346907/ccl_mpi_hybrid_reduce_scatter.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31346909/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31346910/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31346911/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31346912/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31346914/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31346916/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31346918/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31346925/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31346927/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31346931/ccl_all_reduce.log)
[ccl_reduce_scatter.log](https://github.com/user-attachments/files/31346932/ccl_reduce_scatter.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains a single self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclReduceScatter()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The current-commit evidence contains 15/15 passing canonical logs, `Correct: YES` 20 times, and `Correct: NO` 0 times on the full 8-A100 + 8-C550 matrix. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- World-size, count, byte-size, and canonical in-place offset calculations are checked before allocation or pointer use. -->
