### PR TITLE
feat: support CCL `AllToAll`

### DIFF
--- a/examples/ccl/all_to_all.cc
+++ b/examples/ccl/all_to_all.cc
@@ -1,0 +1,330 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node AllToAll
+ *
+ * This example creates one native CCL rank per GPU and validates an
+ * out-of-place all-to-all exchange composed from grouped point-to-point calls.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+struct ScenarioState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t count_per_peer;
+  int warmup_iterations;
+  int profile_iterations;
+  ScenarioState *state;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+float BlockValue(int source_rank, int destination_rank) {
+  return static_cast<float>((source_rank + 1) * 1000 + destination_rank + 1);
+}
+
+void FillInput(std::vector<float> *input, size_t count_per_peer, int world_size,
+               int rank) {
+  for (int destination = 0; destination < world_size; ++destination) {
+    const size_t offset = static_cast<size_t>(destination) * count_per_peer;
+    std::fill_n(input->begin() + offset, count_per_peer,
+                BlockValue(rank, destination));
+  }
+}
+
+bool ValidateAllToAll(const std::vector<float> &result, size_t count_per_peer,
+                      int world_size, int rank) {
+  bool correct = true;
+  for (int source = 0; source < world_size; ++source) {
+    const size_t offset = static_cast<size_t>(source) * count_per_peer;
+    const bool block_correct = Validator::ValidateResult(
+        result.data() + offset, count_per_peer, BlockValue(source, rank), rank);
+    correct = block_correct && correct;
+  }
+  return correct;
+}
+
+void PrintAllToAllMetrics(size_t count_per_peer, int world_size,
+                          double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double peer_bytes = static_cast<double>(count_per_peer) * sizeof(float);
+  const double total_bytes = peer_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per peer: " << count_per_peer << " floats ("
+            << std::fixed << std::setprecision(2) << peer_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data per rank: "
+            << count_per_peer * static_cast<size_t>(world_size) << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void WaitForAll(ScenarioState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_acq_rel);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+void PrintResult(bool correct, const std::vector<float> &result,
+                 size_t count_per_peer, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== CCL AllToAll Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  PrintAllToAllMetrics(count_per_peer, world_size, elapsed_ms);
+  std::cout << "Sample receive blocks: ";
+  for (int source = 0; source < std::min(world_size, 4); ++source) {
+    const size_t offset = static_cast<size_t>(source) * count_per_peer;
+    std::cout << "[src" << source << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the AllToAll worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const size_t total_elements =
+      args.count_per_peer * static_cast<size_t>(args.size);
+  const size_t total_bytes = total_elements * sizeof(float);
+  std::vector<float> h_send(total_elements);
+  std::vector<float> h_recv(total_elements, 0.0f);
+  FillInput(&h_send, args.count_per_peer, args.size, args.rank);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), total_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), total_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  for (int i = 0; i < args.warmup_iterations; ++i) {
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, args.count_per_peer,
+                                   infinicclFloat32, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iterations; ++i) {
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, args.count_per_peer,
+                                   infinicclFloat32, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const double elapsed_ms =
+      timer.ElapsedMs() / static_cast<double>(args.profile_iterations);
+
+  CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                          Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const bool local_correct =
+      ValidateAllToAll(h_recv, args.count_per_peer, args.size, args.rank);
+  if (!local_correct) {
+    args.state->correct.store(false, std::memory_order_relaxed);
+  }
+  WaitForAll(args.state, args.size);
+
+  if (args.rank == 0) {
+    PrintResult(args.state->correct.load(std::memory_order_acquire), h_recv,
+                args.count_per_peer, args.size, elapsed_ms);
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>        Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>    Warmup iterations (default: 2)\n"
+            << "  -p <profile_iters>   Profile iterations (default: 20)\n"
+            << "  -n <count_per_peer>  Elements sent to each peer (default: "
+               "1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iterations = 2;
+  int profile_iterations = 20;
+  size_t count_per_peer = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iterations);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iterations);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &count_per_peer);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for AllToAll." << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for AllToAll." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / count_per_peer ||
+      count_per_peer * static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "AllToAll buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for AllToAll." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+  std::cout << "[Main Process] Count per peer: " << count_per_peer
+            << " floats | Warmup: " << warmup_iterations
+            << " | Profile: " << profile_iterations << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  ScenarioState state;
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,           num_gpus,          shared_id,
+                    count_per_peer, warmup_iterations, profile_iterations,
+                    &state};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = state.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] CCL AllToAll validation passed." << std::endl;
+  } else {
+    std::cerr << "[Main Process] CCL AllToAll validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/all_to_all.cc
+++ b/examples/ccl_mpi_hybrid/all_to_all.cc
@@ -1,8 +1,9 @@
 /**
- * InfiniCCL Example: AllToAll (MPI Backend)
+ * InfiniCCL Example: AllToAll (OpenMPI + CCL Hybrid)
  *
- * This example exchanges a distinct block with every rank, validates every
- * received source block, and propagates validation failures to all ranks.
+ * This example first uses AllToAll through an OpenMPI inter communicator to
+ * distribute a native CCL unique ID. It then initializes a native CCL
+ * communicator and validates an out-of-place GPU all-to-all exchange.
  */
 
 #include <unistd.h>
@@ -114,11 +115,34 @@ void PrintAllToAllMetrics(size_t count_per_peer, int world_size,
   std::cout.precision(original_precision);
 }
 
-bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
-                        int profile_iterations, size_t count_per_peer) {
+void PrintResult(bool correct, const std::vector<float> &result,
+                 size_t count_per_peer, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== Hybrid CCL AllToAll Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  PrintAllToAllMetrics(count_per_peer, world_size, elapsed_ms);
+  std::cout << "Sample receive blocks: ";
+  for (int source = 0; source < std::min(world_size, 4); ++source) {
+    const size_t offset = static_cast<size_t>(source) * count_per_peer;
+    std::cout << "[src" << source << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+}
+
+bool RunAllToAllExample(int argc, char **argv) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kCountPerPeer = 1 << 20;
 
   CHECK_INFINI(infinicclInit(&argc, &argv));
 
@@ -127,7 +151,7 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclGetRank(&rank));
   CHECK_INFINI(infinicclGetSize(&size));
   if (size <= 0) {
-    std::cerr << "Invalid world size for MPI AllToAll." << std::endl;
+    std::cerr << "Invalid world size for hybrid AllToAll." << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
@@ -141,7 +165,8 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
 
   std::array<char, 256> hostname{};
   if (gethostname(hostname.data(), hostname.size()) != 0) {
-    std::cerr << "Failed to query the hostname for MPI AllToAll." << std::endl;
+    std::cerr << "Failed to query the hostname for hybrid AllToAll."
+              << std::endl;
     std::exit(EXIT_FAILURE);
   }
   hostname.back() = '\0';
@@ -153,18 +178,57 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
   const size_t world_size = static_cast<size_t>(size);
-  if (count_per_peer > std::numeric_limits<size_t>::max() / world_size ||
-      count_per_peer * world_size >
-          std::numeric_limits<size_t>::max() / sizeof(float)) {
-    std::cerr << "MPI AllToAll buffer size overflows `size_t`." << std::endl;
+  const size_t id_bytes = sizeof(infinicclUniqueId);
+  if (id_bytes > std::numeric_limits<size_t>::max() / world_size) {
+    std::cerr << "AllToAll bootstrap buffer size overflows `size_t`."
+              << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  const size_t total_elements = count_per_peer * world_size;
-  const size_t total_bytes = total_elements * sizeof(float);
+  const size_t all_id_bytes = id_bytes * world_size;
 
+  // Bootstrap the native communicator with AllToAll itself. Rank 0 repeats
+  // its unique ID in every destination block; each rank then takes the block
+  // received from source rank 0. With only the OpenMPI inter communicator
+  // initialized, the CCL provider delegates this call to `MPI_Alltoall`.
+  infinicclUniqueId id{};
+  if (rank == 0) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  std::vector<uint8_t> h_id_send(all_id_bytes, 0);
+  if (rank == 0) {
+    for (int destination = 0; destination < size; ++destination) {
+      std::memcpy(
+          h_id_send.data() + static_cast<size_t>(destination) * id_bytes, &id,
+          id_bytes);
+    }
+  }
+
+  uint8_t *d_id_send = nullptr;
+  uint8_t *d_id_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_id_send), all_id_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_id_recv), all_id_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(d_id_send, h_id_send.data(), all_id_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclAllToAll(d_id_send, d_id_recv, id_bytes, infinicclUInt8,
+                                 comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(&id, d_id_recv, id_bytes, Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  CHECK_RT(Rt, Rt::Free(d_id_send));
+  CHECK_RT(Rt, Rt::Free(d_id_recv));
+
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
+  if (kCountPerPeer > std::numeric_limits<size_t>::max() / world_size ||
+      kCountPerPeer * world_size >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Hybrid AllToAll buffer size overflows `size_t`." << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  const size_t total_elements = kCountPerPeer * world_size;
+  const size_t total_bytes = total_elements * sizeof(float);
   std::vector<float> h_send(total_elements);
   std::vector<float> h_recv(total_elements, 0.0f);
-  FillInput(&h_send, count_per_peer, size, rank);
+  FillInput(&h_send, kCountPerPeer, size, rank);
 
   float *d_send = nullptr;
   float *d_recv = nullptr;
@@ -174,38 +238,30 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
-  if (rank == 0) {
-    std::cout << "\n=== Performing MPI AllToAll on GPU Memory ===" << std::endl;
-    std::cout << "Count per peer: " << count_per_peer << " floats" << std::endl;
-    std::cout << "Total per rank: " << total_elements << " floats ("
-              << total_bytes / 1024 / 1024 << " MB)" << std::endl;
-    std::cout << "Warm-up iterations: " << warmup_iterations << std::endl;
-    std::cout << "Profile iterations: " << profile_iterations << std::endl;
-  }
-
-  for (int i = 0; i < warmup_iterations; ++i) {
-    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, count_per_peer,
+  for (int i = 0; i < kWarmupIterations; ++i) {
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, kCountPerPeer,
                                    infinicclFloat32, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   Timer timer;
-  for (int i = 0; i < profile_iterations; ++i) {
-    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, count_per_peer,
+  for (int i = 0; i < kProfileIterations; ++i) {
+    CHECK_INFINI(infinicclAllToAll(d_send, d_recv, kCountPerPeer,
                                    infinicclFloat32, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const double elapsed_ms =
-      timer.ElapsedMs() / static_cast<double>(profile_iterations);
+      timer.ElapsedMs() / static_cast<double>(kProfileIterations);
 
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
                           Rt::MemcpyDeviceToHost));
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const bool local_correct =
-      ValidateAllToAll(h_recv, count_per_peer, size, rank);
+      ValidateAllToAll(h_recv, kCountPerPeer, size, rank);
 
-  // Exchange each rank's validation flag with every destination so all ranks
-  // derive the same final process status.
+  // Use native AllToAll once more to exchange every rank's validation flag.
+  // This makes all ranks derive the same final process status without direct
+  // MPI or vendor-library calls in the example.
   std::vector<int32_t> h_status_send(world_size, local_correct ? 1 : 0);
   std::vector<int32_t> h_status_recv(world_size, 0);
   int32_t *d_status_send = nullptr;
@@ -227,21 +283,7 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
                                    [](int32_t value) { return value == 1; });
 
   if (rank == 0) {
-    constexpr const char *kGreen = "\033[32m";
-    constexpr const char *kRed = "\033[31m";
-    constexpr const char *kReset = "\033[0m";
-    std::cout << "\n=== MPI AllToAll Results ===" << std::endl;
-    std::cout << "Correct: "
-              << (correct ? (kGreen + std::string("YES") + kReset)
-                          : (kRed + std::string("NO") + kReset))
-              << std::endl;
-    PrintAllToAllMetrics(count_per_peer, size, elapsed_ms);
-    std::cout << "Sample receive blocks: ";
-    for (int source = 0; source < std::min(size, 4); ++source) {
-      const size_t offset = static_cast<size_t>(source) * count_per_peer;
-      std::cout << "[src" << source << ": " << h_recv[offset] << "] ";
-    }
-    std::cout << std::endl;
+    PrintResult(correct, h_recv, kCountPerPeer, size, elapsed_ms);
   }
 
   CHECK_RT(Rt, Rt::Free(d_status_send));
@@ -252,6 +294,13 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclFinalize());
 
   if (rank == 0) {
+    if (correct) {
+      std::cout << "[Main Process] Hybrid CCL AllToAll validation passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid CCL AllToAll validation failed."
+                << std::endl;
+    }
     std::cout << "InfiniCCL finalized." << std::endl;
   }
   return correct;
@@ -260,11 +309,5 @@ bool RunAllToAllExample(int argc, char **argv, int warmup_iterations,
 }  // namespace
 
 int main(int argc, char **argv) {
-  constexpr int kWarmupIterations = 2;
-  constexpr int kProfileIterations = 20;
-  constexpr size_t kCountPerPeer = 1 << 18;
-  return RunAllToAllExample(argc, argv, kWarmupIterations, kProfileIterations,
-                            kCountPerPeer)
-             ? EXIT_SUCCESS
-             : EXIT_FAILURE;
+  return RunAllToAllExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/all_to_all.h
+++ b/src/backends/ccl/common/impl/all_to_all.h
@@ -1,0 +1,118 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_TO_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_TO_ALL_H_
+
+#include <cstddef>
+#include <limits>
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/all_to_all.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredAllToAll {
+  using type = AllToAll;
+};
+
+template <BackendType backend, Device::Type device>
+class CclAllToAllImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredAllToAll<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return AllToAllImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, count, data_type, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    if (send_buff == recv_buff) {
+      LOG("In-place buffers are not supported by the native CCL `AllToAll` "
+          "implementation.");
+      return ReturnStatus::kNotSupported;
+    }
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size()) {
+      LOG("Invalid rank or world size for native CCL `AllToAll`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    const size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Per-peer byte size overflows `size_t` for native CCL "
+          "`AllToAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    const size_t peer_bytes = count * type_size;
+    const size_t world_size = static_cast<size_t>(comm->size());
+    if (peer_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for native CCL `AllToAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    const auto *send_bytes = static_cast<const std::byte *>(send_buff);
+    auto *recv_bytes = static_cast<std::byte *>(recv_buff);
+    auto native_stream = reinterpret_cast<typename Api::Stream>(stream);
+
+    ReturnStatus status = Api::Check(Api::GroupStart());
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    ReturnStatus first_error = ReturnStatus::kSuccess;
+    for (int peer = 0; peer < comm->size(); ++peer) {
+      const size_t offset = static_cast<size_t>(peer) * peer_bytes;
+      status = Api::Check(Api::Send(send_bytes + offset, count, native_type,
+                                    peer, instance->handle, native_stream));
+      if (first_error == ReturnStatus::kSuccess &&
+          status != ReturnStatus::kSuccess) {
+        first_error = status;
+      }
+
+      status = Api::Check(Api::Recv(recv_bytes + offset, count, native_type,
+                                    peer, instance->handle, native_stream));
+      if (first_error == ReturnStatus::kSuccess &&
+          status != ReturnStatus::kSuccess) {
+        first_error = status;
+      }
+    }
+
+    const ReturnStatus group_end_status = Api::Check(Api::GroupEnd());
+    return first_error != ReturnStatus::kSuccess ? first_error
+                                                 : group_end_status;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_TO_ALL_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,20 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return mcclGroupStart(); }
+
+  static Result GroupEnd() { return mcclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/all_to_all.h
+++ b/src/backends/ccl/mccl/impl/all_to_all.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_
+
+#include "backends/ccl/common/impl/all_to_all.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllToAllImpl<BackendType::kMccl, device>
+    : public CclAllToAllImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<AllToAll, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_ALL_TO_ALL_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,20 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return ncclGroupStart(); }
+
+  static Result GroupEnd() { return ncclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/all_to_all.h
+++ b/src/backends/ccl/nccl/impl/all_to_all.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_TO_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_TO_ALL_H_
+
+#include "backends/ccl/common/impl/all_to_all.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllToAllImpl<BackendType::kNccl, device>
+    : public CclAllToAllImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<AllToAll, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_TO_ALL_H_

--- a/src/backends/mpi/ompi/impl/all_to_all.h
+++ b/src/backends/mpi/ompi/impl/all_to_all.h
@@ -1,15 +1,18 @@
 #ifndef INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_ALL_TO_ALL_H_
 #define INFINI_CCL_BACKENDS_MPI_OMPI_IMPL_ALL_TO_ALL_H_
 
+#include <cstdlib>
 #include <limits>
+#include <memory>
 
 #include "backends/mpi/ompi/checks.h"
 #include "backends/mpi/ompi/comm_instance.h"
-#include "backends/mpi/ompi/type_map.h"
 #include "base/all_to_all.h"
 #include "communicator.h"
+#include "data_type_impl.h"
 #include "dispatcher.h"
 #include "logging.h"
+#include "runtime.h"
 
 namespace infini::ccl {
 
@@ -23,50 +26,63 @@ class AllToAllImpl<BackendType::kOmpi, device_type> {
         ListGetBest<DevicePriority>(ActiveDevices<AllToAll>{});
     using Rt = Runtime<kDev>;
 
-    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
-
-    if (!inst || inst->handle == MPI_COMM_NULL) {
+    if (!comm || !comm->inter_comm() ||
+        comm->inter_comm_backend() != BackendType::kOmpi) {
       LOG("Invalid OpenMPI communicator instance for `AllToAll`.");
       return ReturnStatus::kInternalError;
     }
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator handle for `AllToAll`.");
+      return ReturnStatus::kInternalError;
+    }
+    if (comm->size() <= 0) {
+      LOG("Invalid world size for `AllToAll`.");
+      return ReturnStatus::kInternalError;
+    }
 
-    if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
-      LOG("count exceeds MPI `int` range for `AllToAll`.");
+    size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Per-peer byte size overflows `size_t` for `AllToAll`.");
       return ReturnStatus::kInvalidArgument;
     }
-    int mpi_count = static_cast<int>(count);
+    size_t peer_bytes = count * type_size;
+    if (peer_bytes > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      LOG("Per-peer byte count exceeds MPI `int` range for `AllToAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
 
     size_t world_size = static_cast<size_t>(comm->size());
-    MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
-    size_t type_size = kDataTypeToSize.at(data_type);
-    size_t total_count = count * world_size;
-    size_t total_bytes = total_count * type_size;
+    if (peer_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for `AllToAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    size_t total_bytes = peer_bytes * world_size;
+    int mpi_peer_bytes = static_cast<int>(peer_bytes);
 
     // Handle GPU Memory (Staging Pattern)
     // Note: we simply use host-staging for now.
-    void *host_sendbuf = malloc(total_bytes);
-    void *host_recvbuf = malloc(total_bytes);
+    std::unique_ptr<void, decltype(&std::free)> host_sendbuf(
+        std::malloc(total_bytes), &std::free);
+    std::unique_ptr<void, decltype(&std::free)> host_recvbuf(
+        std::malloc(total_bytes), &std::free);
     if (!host_sendbuf || !host_recvbuf) {
-      free(host_sendbuf);
-      free(host_recvbuf);
       LOG("Failed to allocate host buffers for `AllToAll` staging.");
       return ReturnStatus::kSystemError;
     }
 
-    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, total_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf.get(), send_buff, total_bytes,
                                 Rt::MemcpyDeviceToHost));
 
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
-    INFINI_CHECK_MPI(MPI_Alltoall(host_sendbuf, mpi_count, mpi_type,
-                                  host_recvbuf, mpi_count, mpi_type,
+    INFINI_CHECK_MPI(MPI_Alltoall(host_sendbuf.get(), mpi_peer_bytes, MPI_BYTE,
+                                  host_recvbuf.get(), mpi_peer_bytes, MPI_BYTE,
                                   inst->handle));
 
-    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, total_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf.get(), total_bytes,
                                 Rt::MemcpyHostToDevice));
 
-    free(host_sendbuf);
-    free(host_recvbuf);
     return ReturnStatus::kSuccess;
   }
 };

--- a/src/base/all_to_all.h
+++ b/src/base/all_to_all.h
@@ -1,8 +1,8 @@
 #ifndef INFINI_CCL_BASE_ALL_TO_ALL_H_
 #define INFINI_CCL_BASE_ALL_TO_ALL_H_
 
-#include "comm_impl.h"
 #include "communicator.h"
+#include "data_type_impl.h"
 #include "logging.h"
 #include "operation.h"
 #include "return_status_impl.h"
@@ -19,7 +19,14 @@ class AllToAll : public Operation<AllToAll> {
   static ReturnStatus Execute(const void *send_buff, void *recv_buff,
                               size_t count, DataType datatype,
                               void *comm_handle, void *stream) {
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, comm_handle)) {
+    if (HasInvalidRequiredArgs(datatype, comm_handle)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+    if (!send_buff || !recv_buff) {
+      LOG("Invalid buffer pointer for `AllToAll`.");
       return ReturnStatus::kInvalidArgument;
     }
     auto *comm = static_cast<Communicator *>(comm_handle);
@@ -28,15 +35,10 @@ class AllToAll : public Operation<AllToAll> {
   }
 
  private:
-  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, void *comm_handle) {
+  static bool HasInvalidRequiredArgs(DataType datatype, void *comm_handle) {
     if (!comm_handle) {
       // TODO(lzm): change to use `glog`.
       LOG("Invalid communicator handle for `AllToAll`.");
-      return true;
-    }
-    if (!send_buff || !recv_buff) {
-      LOG("Invalid buffer pointer for `AllToAll`.");
       return true;
     }
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {


### PR DESCRIPTION
## Summary

This PR adds `AllToAll` support to the shared CCL backend abstraction by composing provider-native grouped point-to-point operations through the existing NCCL and MCCL layers for the public `infinicclAllToAll()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, corrects the shared OpenMPI/MPICH movement path to use byte counts for all data types, defines zero-count behavior, makes the existing MPI example validate every received source block and propagate failures, and includes CCL-only plus OpenMPI-assisted `AllToAll` example programs.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclAllToAll()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `AllToAll` after validating the communicator and data type, without requiring non-null buffers or entering a backend.
  - Reject non-zero in-place buffers on the native CCL path with `NotSupported`.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `AllToAll` implementation using one grouped `Send`/`Recv` pair per peer, including self.
  - Validate the native communicator backend, device, rank, world size, and handle before dispatch.
  - Map InfiniCCL data types through the configured provider and check per-peer and total byte-size calculations for `size_t` overflow.
  - Preserve the first point-to-point error, continue issuing operations for the remaining peers, and always call `GroupEnd` after a successful `GroupStart`.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with `GroupStart`, `GroupEnd`, `Send`, and `Recv` bindings.
  - Register `AllToAll` with the existing NCCL and MCCL provider layers without introducing a dependency on a vendor-specific `AllToAll` entry point.

- **MPI Correctness and Safety**
  - Treat `AllToAll` as a movement operation in the shared OpenMPI/MPICH implementation by using `MPI_BYTE` with `count * type_size` bytes per peer.
  - Add communicator, world-size, `size_t` multiplication, total-buffer-size, and MPI `int` count-range checks.
  - Manage host staging buffers with automatic cleanup across success and error paths.
  - Validate every received source block in the existing MPI example and exchange validation status so failures propagate through the process exit code.

- **Examples and Validation**
  - Add a thread-per-GPU single-node CCL `AllToAll` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL example that first uses the public `AllToAll` API through the OpenMPI inter communicator to distribute the native unique ID, then initializes the native CCL communicator for grouped GPU point-to-point exchange.
  - Validate the complete out-of-place receive layout with source/destination-specific values on every rank.
  - Propagate validation failures across all ranks through shared atomic state in the thread-per-GPU example and a second public `AllToAll` status exchange in the process-based examples.
  - Report per-peer and per-rank data sizes, rank-0 average time, algorithmic bandwidth as `world_size * peer_bytes / time`, and bus bandwidth as algorithmic bandwidth multiplied by `(world_size - 1) / world_size`.
  - Parse numeric options without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `AllToAll`, avoiding the existing MPI host-staging path when a supported CCL backend and matching native communicator are available. The native implementation uses grouped point-to-point operations because neither provider exposes a vendor `AllToAll` entry point, while the shared MPI fallback remains host-staged with corrected byte-count handling. Other collective operations are intended to remain unchanged. The validation-log timing output is reference data rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch now covers `AllReduce` and `AllToAll`; other CCL collective operations remain future work.
- `AllToAll` inherits the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The native CCL path uses one grouped `Send`/`Recv` pair per peer, including self, rather than a vendor-specific `AllToAll` entry point. The number of point-to-point operations therefore grows linearly per rank and quadratically across the communicator.
- Non-zero in-place buffers are not supported by the native CCL path.
- The server examples validate out-of-place `Float32` payloads on the default stream. Additional data types, non-default streams, and runtime coverage on Iluvatar and Moore Threads remain future work.
- The shared OpenMPI/MPICH fallback remains host-staged with per-call allocations and rejects per-peer byte counts above the MPI `int` range; chunked transfers remain future work.

## Test Results

The implementation commit is `a4ada89dffe7b22afd595124df304efc0f5ce7ac`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached evidence contains exactly 15 hash-verified canonical logs from the current commit: all 15 targets passed, with `Correct: YES` 17 times and `Correct: NO` 0 times. The extra two positive results are the additional expected validation cases in the broadcast log.

All four current-commit `AllToAll` paths passed:

| Path | Test topology | Data per peer / rank | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.205 ms | 163.82 GB/s | 143.34 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.211 ms | 158.97 GB/s | 139.10 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 1.00 / 16.00 MiB | 34.164 ms | 0.49 GB/s | 0.46 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 0.233 ms | 144.11 GB/s | 126.10 GB/s |

The reported times are the rank-0 averages over 20 profiled payload calls after 2 warm-up calls. Algorithm bandwidth uses the total per-rank transfer size, and bus bandwidth applies the `(world_size - 1) / world_size` correction factor. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform performance comparison or an all-rank aggregate.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs. The `AllToAll` log reports 8 target GPUs and validates all eight source blocks at every destination.
- All five formal invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA**:
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345253/ccl_all_reduce.log)
[ccl_all_to_all.log](https://github.com/user-attachments/files/31345254/ccl_all_to_all.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31345257/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_all_to_all.log](https://github.com/user-attachments/files/31345258/ccl_mpi_hybrid_all_to_all.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31345259/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31345260/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31345261/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31345263/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31345264/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31345265/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31345266/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31345268/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31345269/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345277/ccl_all_reduce.log)
[ccl_all_to_all.log](https://github.com/user-attachments/files/31345279/ccl_all_to_all.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains one self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and timing reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclAllToAll()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The strict current-commit full-matrix evidence contains 15/15 passing canonical logs, `Correct: YES` 17 times, and `Correct: NO` 0 times on 8 A100 and 8 C550 GPUs. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Rank/world validation and per-peer/total byte-size calculations precede native pointer offsets and allocations; non-zero native in-place buffers are rejected. -->
