### PR TITLE
feat: support CCL `Reduce`

### DIFF
--- a/examples/ccl/reduce.cc
+++ b/examples/ccl/reduce.cc
@@ -1,0 +1,307 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Reduce
+ *
+ * This example creates one native CCL rank per GPU and validates a rooted
+ * reduction without an MPI launcher.
+ */
+
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+constexpr int kRoot = 0;
+
+struct RunState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t count;
+  int warmup_iterations;
+  int profile_iterations;
+  RunState *state;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+float ExpectedValue(int world_size) {
+  return static_cast<float>(world_size) *
+         (static_cast<float>(world_size) + 1.0f) / 2.0f;
+}
+
+void PrintReduceMetrics(size_t count, double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double payload_bytes = static_cast<double>(count) * sizeof(float);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size:      " << count << " floats (" << std::fixed
+            << std::setprecision(2) << payload_bytes / kBytesPerMiB << " MiB)"
+            << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        payload_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    // `nccl-tests` uses a bus-bandwidth correction factor of 1 for Reduce.
+    const double bus_bandwidth = algorithm_bandwidth;
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << std::setprecision(2)
+              << algorithm_bandwidth << " GB/s" << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void PrintResult(bool correct, float expected, float actual, size_t count,
+                 double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== CCL Reduce Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Root rank: " << kRoot << std::endl;
+  std::cout << "Expect:  " << expected << std::endl;
+  std::cout << "Actual:  " << actual << std::endl;
+  PrintReduceMetrics(count, elapsed_ms);
+}
+
+void WaitForAll(RunState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_acq_rel);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the Reduce worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const bool is_root = args.rank == kRoot;
+  const size_t total_bytes = args.count * sizeof(float);
+  std::vector<float> h_send(args.count, static_cast<float>(args.rank + 1));
+  std::vector<float> h_recv(is_root ? args.count : 0, 0.0f);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), total_bytes));
+  if (is_root) {
+    CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), total_bytes));
+  }
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  for (int i = 0; i < args.warmup_iterations; ++i) {
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, args.count, infinicclFloat32,
+                                 infinicclSum, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iterations; ++i) {
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, args.count, infinicclFloat32,
+                                 infinicclSum, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const double elapsed_ms =
+      timer.ElapsedMs() / static_cast<double>(args.profile_iterations);
+
+  bool local_correct = true;
+  const float expected = ExpectedValue(args.size);
+  if (is_root) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    local_correct = Validator::ValidateResult(
+        h_recv.data(), args.count, expected, args.rank, false, "Reduce");
+    if (!local_correct) {
+      args.state->correct.store(false, std::memory_order_relaxed);
+    }
+  }
+
+  WaitForAll(args.state, args.size);
+  if (is_root) {
+    PrintResult(args.state->correct.load(std::memory_order_acquire), expected,
+                h_recv.front(), args.count, elapsed_ms);
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  if (is_root) {
+    CHECK_RT(Rt, Rt::Free(d_recv));
+  }
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>      Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>  Warm-up iterations (default: 2)\n"
+            << "  -p <profile_iters> Profile iterations (default: 20)\n"
+            << "  -n <count>         Elements reduced per rank (default: "
+               "1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iterations = 2;
+  int profile_iterations = 20;
+  size_t count = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iterations);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iterations);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &count);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for Reduce." << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for Reduce." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (count > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Reduce buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for Reduce." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+  std::cout << "[Main Process] Count: " << count
+            << " floats | Warmup: " << warmup_iterations
+            << " | Profile: " << profile_iterations << " | Root: " << kRoot
+            << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  RunState state;
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,  num_gpus,          shared_id,
+                    count, warmup_iterations, profile_iterations,
+                    &state};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = state.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] CCL Reduce validation passed." << std::endl;
+  } else {
+    std::cerr << "[Main Process] CCL Reduce validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/reduce.cc
+++ b/examples/ccl_mpi_hybrid/reduce.cc
@@ -1,9 +1,8 @@
 /**
- * InfiniCCL Example: Reduce (MPI Backend)
+ * InfiniCCL Example: Reduce (OpenMPI + CCL Hybrid)
  *
- * This example performs a rooted reduction across multiple accelerators and
- * nodes, validates the root result, and propagates validation failure through
- * the process exit status.
+ * This example uses an OpenMPI inter communicator to distribute a native CCL
+ * unique ID, then validates a rooted GPU reduction on the native communicator.
  */
 
 #include <unistd.h>
@@ -97,7 +96,7 @@ void PrintResult(bool correct, float expected, float actual, size_t count,
   constexpr const char *kRed = "\033[31m";
   constexpr const char *kReset = "\033[0m";
 
-  std::cout << "\n=== MPI Reduce Results ===" << std::endl;
+  std::cout << "\n=== Hybrid CCL Reduce Results ===" << std::endl;
   std::cout << "Correct: "
             << (correct ? (kGreen + std::string("YES") + kReset)
                         : (kRed + std::string("NO") + kReset))
@@ -108,11 +107,14 @@ void PrintResult(bool correct, float expected, float actual, size_t count,
   PrintReduceMetrics(count, elapsed_ms);
 }
 
-bool RunReduceExample(int argc, char **argv, int warmup_iterations,
-                      int profile_iterations, size_t count) {
+bool RunReduceExample(int argc, char **argv) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kCount = 1 << 20;
 
   CHECK_INFINI(infinicclInit(&argc, &argv));
 
@@ -121,7 +123,7 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclGetRank(&rank));
   CHECK_INFINI(infinicclGetSize(&size));
   if (size <= 0 || kRoot >= size) {
-    std::cerr << "Invalid world size for MPI Reduce." << std::endl;
+    std::cerr << "Invalid world size for hybrid Reduce." << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
@@ -135,7 +137,7 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
 
   std::array<char, 256> hostname{};
   if (gethostname(hostname.data(), hostname.size()) != 0) {
-    std::cerr << "Failed to query the hostname for MPI Reduce." << std::endl;
+    std::cerr << "Failed to query the hostname for hybrid Reduce." << std::endl;
     std::exit(EXIT_FAILURE);
   }
   hostname.back() = '\0';
@@ -146,15 +148,55 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
   infinicclComm_t comm = nullptr;
   CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
-  if (count == 0 ||
-      count > std::numeric_limits<size_t>::max() / sizeof(float)) {
-    std::cerr << "Invalid MPI Reduce buffer size." << std::endl;
+  // Exercise Reduce before the native communicator exists. The CCL backend
+  // must delegate this call to the OpenMPI inter communicator.
+  constexpr size_t kBootstrapCount = 1;
+  const float bootstrap_send = static_cast<float>(rank + 1);
+  float bootstrap_recv = 0.0f;
+  float *d_bootstrap_send = nullptr;
+  float *d_bootstrap_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_send),
+                          kBootstrapCount * sizeof(float)));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_recv),
+                            kBootstrapCount * sizeof(float)));
+  }
+  CHECK_RT(Rt, Rt::Memcpy(d_bootstrap_send, &bootstrap_send, sizeof(float),
+                          Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclReduce(d_bootstrap_send, d_bootstrap_recv,
+                               kBootstrapCount, infinicclFloat32, infinicclSum,
+                               kRoot, comm, nullptr));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Memcpy(&bootstrap_recv, d_bootstrap_recv, sizeof(float),
+                            Rt::MemcpyDeviceToHost));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  int32_t bootstrap_status =
+      rank != kRoot || bootstrap_recv == ExpectedValue(size) ? 1 : 0;
+  CHECK_INFINI(infinicclBroadcast(&bootstrap_status, &bootstrap_status, 1,
+                                  infinicclInt32, kRoot, comm, nullptr));
+  CHECK_RT(Rt, Rt::Free(d_bootstrap_send));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Free(d_bootstrap_recv));
+  }
+
+  infinicclUniqueId id{};
+  if (rank == kRoot) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  CHECK_INFINI(infinicclBroadcast(&id, &id, sizeof(id), infinicclChar, kRoot,
+                                  comm, nullptr));
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
+  if (kCount > std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Hybrid Reduce buffer size overflows `size_t`." << std::endl;
     std::exit(EXIT_FAILURE);
   }
   const bool is_root = rank == kRoot;
-  const size_t total_bytes = count * sizeof(float);
-  std::vector<float> h_send(count, static_cast<float>(rank + 1));
-  std::vector<float> h_recv(is_root ? count : 0, 0.0f);
+  const size_t total_bytes = kCount * sizeof(float);
+  std::vector<float> h_send(kCount, static_cast<float>(rank + 1));
+  std::vector<float> h_recv(is_root ? kCount : 0, 0.0f);
 
   float *d_send = nullptr;
   float *d_recv = nullptr;
@@ -167,37 +209,39 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   if (is_root) {
-    std::cout << "\n=== Performing MPI Reduce on GPU Memory ===" << std::endl;
+    std::cout << "\n=== Performing Hybrid CCL Reduce on GPU Memory ==="
+              << std::endl;
     std::cout << "Operation: Sum" << std::endl;
     std::cout << "Root rank: " << kRoot << std::endl;
-    std::cout << "Warm-up iterations: " << warmup_iterations << std::endl;
-    std::cout << "Profile iterations: " << profile_iterations << std::endl;
+    std::cout << "Warm-up iterations: " << kWarmupIterations << std::endl;
+    std::cout << "Profile iterations: " << kProfileIterations << std::endl;
   }
 
-  for (int i = 0; i < warmup_iterations; ++i) {
-    CHECK_INFINI(infinicclReduce(d_send, d_recv, count, infinicclFloat32,
+  for (int i = 0; i < kWarmupIterations; ++i) {
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, kCount, infinicclFloat32,
                                  infinicclSum, kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   Timer timer;
-  for (int i = 0; i < profile_iterations; ++i) {
-    CHECK_INFINI(infinicclReduce(d_send, d_recv, count, infinicclFloat32,
+  for (int i = 0; i < kProfileIterations; ++i) {
+    CHECK_INFINI(infinicclReduce(d_send, d_recv, kCount, infinicclFloat32,
                                  infinicclSum, kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const double elapsed_ms =
-      timer.ElapsedMs() / static_cast<double>(profile_iterations);
+      timer.ElapsedMs() / static_cast<double>(kProfileIterations);
 
-  bool correct = true;
+  bool correct = bootstrap_status == 1;
   const float expected = ExpectedValue(size);
   if (is_root) {
     CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, total_bytes,
                             Rt::MemcpyDeviceToHost));
     CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
-    correct = Validator::ValidateResult(h_recv.data(), count, expected, rank,
-                                        false, "Reduce");
-    PrintResult(correct, expected, h_recv.front(), count, elapsed_ms);
+    correct = Validator::ValidateResult(h_recv.data(), kCount, expected, rank,
+                                        false, "Reduce") &&
+              correct;
+    PrintResult(correct, expected, h_recv.front(), kCount, elapsed_ms);
   }
 
   int32_t validation_status = correct ? 1 : 0;
@@ -213,6 +257,13 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclFinalize());
 
   if (is_root) {
+    if (correct) {
+      std::cout << "[Main Process] Hybrid CCL Reduce validation passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid CCL Reduce validation failed."
+                << std::endl;
+    }
     std::cout << "InfiniCCL finalized." << std::endl;
   }
   return correct;
@@ -221,11 +272,5 @@ bool RunReduceExample(int argc, char **argv, int warmup_iterations,
 }  // namespace
 
 int main(int argc, char **argv) {
-  constexpr int kWarmupIterations = 2;
-  constexpr int kProfileIterations = 20;
-  constexpr size_t kCount = 1 << 20;
-  return RunReduceExample(argc, argv, kWarmupIterations, kProfileIterations,
-                          kCount)
-             ? EXIT_SUCCESS
-             : EXIT_FAILURE;
+  return RunReduceExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/reduce.h
+++ b/src/backends/ccl/common/impl/reduce.h
@@ -1,0 +1,76 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/reduce.h"
+#include "communicator.h"
+#include "logging.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredReduce {
+  using type = Reduce;
+};
+
+template <BackendType backend, Device::Type device>
+class CclReduceImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type,
+                            ReductionOpType op, int root, Communicator *comm,
+                            void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredReduce<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return ReduceImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, count, data_type, op, root, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size() ||
+        root < 0 || root >= comm->size()) {
+      LOG("Invalid rank, root, or world size for native CCL `Reduce`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    typename Api::RedOp native_op{};
+    if (!TypeMap::ToBackendRedOp(op, &native_op)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(Api::Reduce(
+        send_buff, recv_buff, count, native_type, native_op, root,
+        instance->handle, reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_REDUCE_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,13 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result Reduce(const void *send_buff, void *recv_buff, size_t count,
+                       DataType data_type, RedOp op, int root, Comm comm,
+                       Stream stream) {
+    return mcclReduce(send_buff, recv_buff, count, data_type, op, root, comm,
+                      stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/reduce.h
+++ b/src/backends/ccl/mccl/impl/reduce.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_
+
+#include "backends/ccl/common/impl/reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ReduceImpl<BackendType::kMccl, device>
+    : public CclReduceImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Reduce, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_REDUCE_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,13 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result Reduce(const void *send_buff, void *recv_buff, size_t count,
+                       DataType data_type, RedOp op, int root, Comm comm,
+                       Stream stream) {
+    return ncclReduce(send_buff, recv_buff, count, data_type, op, root, comm,
+                      stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/reduce.h
+++ b/src/backends/ccl/nccl/impl/reduce.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_H_
+
+#include "backends/ccl/common/impl/reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ReduceImpl<BackendType::kNccl, device>
+    : public CclReduceImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Reduce, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_REDUCE_H_

--- a/src/backends/mpi/ompi/impl/reduce.h
+++ b/src/backends/mpi/ompi/impl/reduce.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <limits>
+#include <memory>
 #include <type_traits>
 
 #include "backends/mpi/ompi/checks.h"
@@ -28,14 +29,27 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
         ListGetBest<DevicePriority>(ActiveDevices<Reduce>{});
     using Rt = Runtime<kDev>;
 
+    if (!comm || comm->inter_comm_backend() != BackendType::kOmpi) {
+      LOG("Invalid OpenMPI communicator for `Reduce`.");
+      return ReturnStatus::kInternalError;
+    }
+
     auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
     if (!inst || inst->handle == MPI_COMM_NULL) {
       LOG("Invalid OpenMPI communicator instance for `Reduce`.");
       return ReturnStatus::kInternalError;
     }
+    if (comm->size() <= 0) {
+      LOG("Invalid world size for `Reduce`.");
+      return ReturnStatus::kInternalError;
+    }
 
     MPI_Datatype mpi_type = DataTypeToOmpiType(data_type);
     MPI_Op mpi_op = RedOpToOmpiOp(op);
+    if (mpi_type == MPI_BYTE) {
+      LOG("Data type is not supported by OpenMPI reductions for `Reduce`.");
+      return ReturnStatus::kNotSupported;
+    }
 
     if (count > static_cast<size_t>(std::numeric_limits<int>::max())) {
       LOG("`count` exceeds MPI int range for `Reduce`.");
@@ -44,26 +58,31 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
     int mpi_count = static_cast<int>(count);
 
     size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Buffer byte size overflows `size_t` for `Reduce`.");
+      return ReturnStatus::kInvalidArgument;
+    }
     size_t total_bytes = count * type_size;
     const bool is_root = comm->rank() == root;
 
     // Host staging buffers. Only `root` allocates the receive side, since
     // `MPI_Reduce` writes the output only on `root`.
-    void *host_sendbuf = std::malloc(total_bytes);
-    void *host_recvbuf = is_root ? std::malloc(total_bytes) : nullptr;
+    std::unique_ptr<void, decltype(&std::free)> host_sendbuf(
+        std::malloc(total_bytes), &std::free);
+    std::unique_ptr<void, decltype(&std::free)> host_recvbuf(
+        is_root ? std::malloc(total_bytes) : nullptr, &std::free);
     if (!host_sendbuf || (is_root && !host_recvbuf)) {
-      std::free(host_sendbuf);
-      std::free(host_recvbuf);
       LOG("Failed to allocate host buffers for `Reduce` staging.");
       return ReturnStatus::kSystemError;
     }
 
-    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, total_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf.get(), send_buff, total_bytes,
                                 Rt::MemcpyDeviceToHost));
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
-    INFINI_CHECK_MPI(MPI_Reduce(host_sendbuf, host_recvbuf, mpi_count, mpi_type,
-                                mpi_op, root, inst->handle));
+    INFINI_CHECK_MPI(MPI_Reduce(host_sendbuf.get(), host_recvbuf.get(),
+                                mpi_count, mpi_type, mpi_op, root,
+                                inst->handle));
 
     if (is_root) {
       if (op == ReductionOpType::kAvg) {
@@ -72,7 +91,7 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
         DispatchFunc<kDev, AllTypes>(data_type, [&](auto dtype) {
           using T = typename decltype(dtype)::type;
 
-          T *typed_buf = static_cast<T *>(host_recvbuf);
+          T *typed_buf = static_cast<T *>(host_recvbuf.get());
 
           // Simply do the averaging on the CPU before the H2D copy.
           for (size_t i = 0; i < count; ++i) {
@@ -92,12 +111,9 @@ class ReduceImpl<BackendType::kOmpi, device_type> {
         });
       }
 
-      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, total_bytes,
+      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf.get(), total_bytes,
                                   Rt::MemcpyHostToDevice));
     }
-
-    std::free(host_sendbuf);
-    std::free(host_recvbuf);
 
     return ReturnStatus::kSuccess;
   }

--- a/src/base/reduce.h
+++ b/src/base/reduce.h
@@ -26,7 +26,7 @@ class Reduce : public Operation<Reduce> {
     }
 
     auto *comm = static_cast<Communicator *>(comm_handle);
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, op, root, comm)) {
+    if (HasInvalidArgs(send_buff, recv_buff, count, datatype, op, root, comm)) {
       return ReturnStatus::kInvalidArgument;
     }
     if (count == 0) {
@@ -39,8 +39,8 @@ class Reduce : public Operation<Reduce> {
 
  private:
   static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, ReductionOpType op, int root,
-                             Communicator *comm) {
+                             size_t count, DataType datatype,
+                             ReductionOpType op, int root, Communicator *comm) {
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `Reduce`.");
       return true;
@@ -52,6 +52,9 @@ class Reduce : public Operation<Reduce> {
     if (root < 0 || root >= comm->size()) {
       LOG("Invalid root rank for `Reduce`.");
       return true;
+    }
+    if (count == 0) {
+      return false;
     }
     if (!send_buff) {
       LOG("Invalid send buffer pointer for `Reduce`.");


### PR DESCRIPTION
## Summary

This PR adds `Reduce` support to the shared CCL backend abstraction, including native bindings through the existing NCCL and MCCL provider layers for the existing public `infinicclReduce()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, hardens the shared OpenMPI/MPICH `Reduce` implementation with typed-reduction validation, overflow checks, automatic host-buffer cleanup, and correct integer `Avg` scaling, defines zero-count behavior, makes the existing MPI example propagate validation failures, and includes CCL-only plus OpenMPI-assisted `Reduce` examples with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclReduce()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `Reduce` after validating the communicator, data type, reduction operation, and root, without requiring non-null buffers or entering a backend.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `Reduce` implementation following the existing `AllReduce` structure.
  - Validate the native communicator backend, device, rank, world size, root, and handle before dispatch.
  - Map InfiniCCL data types and reduction operations through the configured provider and return `NotSupported` when the provider cannot represent either value.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with thin bindings to `ncclReduce()` and `mcclReduce()`.
  - Register `Reduce` with the existing NCCL and MCCL provider layers.

- **MPI Correctness and Safety**
  - Keep arithmetic reduction on typed `MPI_Reduce()` calls and reject data types that map to `MPI_BYTE`, avoiding invalid byte-wise reductions for `Float16` and `BFloat16`.
  - Add communicator, world-size, `size_t` byte-size, and MPI `int` count-range validation.
  - Manage host staging buffers with automatic cleanup across success and error paths.
  - Scale integer `Avg` results in floating point before converting them back to the destination type.

- **Examples, Validation, and Metrics**
  - Add a thread-per-GPU single-node CCL `Reduce` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL `Reduce` example that first exercises the MPI fallback through an inter-only communicator, then initializes the native CCL communicator for GPU reduction.
  - Update the existing MPI example to validate the complete root result and propagate failure through the process exit status.
  - Report per-iteration time, algorithm bandwidth, and bus bandwidth using the `nccl-tests` `Reduce` convention, whose bus correction factor is `1`.
  - Parse numeric options without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `Reduce`, avoiding the existing MPI host-staging path when a supported CCL backend and matching native communicator are available. The shared MPI path remains host-staged and retains typed reduction semantics with additional validation and cleanup. Other collective operations are intended to remain unchanged. The validation-log timings below are execution references rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch adds `Reduce` alongside the existing `AllReduce`; other independently developed CCL collectives are outside this branch.
- `Reduce` inherits the backend/device combinations, data types, and reduction operations supported by the existing CCL providers; this PR does not add a new provider or device integration.
- The server examples validate `Float32` `Sum` payloads on the default stream. Additional data types, reduction operations, non-default streams, in-place layouts, and runtime coverage on Iluvatar and Moore Threads remain future work.
- The shared OpenMPI/MPICH fallback remains host-staged with per-call allocations, rejects `Float16` and `BFloat16` arithmetic reductions until a typed host-conversion path is available, and rejects counts above the MPI `int` range; chunked transfers remain future work.

## Test Results

The implementation commit is `5d8ac19c11e989caded690b75ed884653a25bfa5`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached final evidence contains exactly 15 hash-verified canonical logs: all 15 targets passed, with `Correct: YES` 17 times and `Correct: NO` 0 times. The extra two positive results are the additional expected validation cases in the broadcast log.

All four current-commit `Reduce` paths passed with a 1,048,576-element `Float32` `Sum` payload (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations:

| Path | Test topology | Expect / Actual | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 36 / 36 | 0.044 ms | 94.34 GB/s | 94.34 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 36 / 36 | 0.047 ms | 89.56 GB/s | 89.56 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 136 / 136 | 13.441 ms | 0.31 GB/s | 0.31 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 36 / 36 | 0.438 ms | 9.57 GB/s | 9.57 GB/s |

The reported times are root-rank averages over the 20 profiled calls after the 2 warm-up calls. `Reduce` uses a bus-bandwidth correction factor of `1`, so the reported algorithm and bus bandwidths are equal. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, with ranks 0-7 mapped to devices 0-7.
- All five formal invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345317/ccl_all_reduce.log)
[ccl_reduce.log](https://github.com/user-attachments/files/31345320/ccl_reduce.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31345328/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_reduce.log](https://github.com/user-attachments/files/31345331/ccl_mpi_hybrid_reduce.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31345343/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31345346/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31345348/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31345350/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31345351/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31345352/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31345353/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31345355/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31345356/mpi_send_recv.log)



**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345361/ccl_all_reduce.log)
[ccl_reduce.log](https://github.com/user-attachments/files/31345362/ccl_reduce.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains one self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclReduce()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) conventions. <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The strict current-commit full-matrix evidence contains 15/15 passing canonical logs, `Correct: YES` 17 times, and `Correct: NO` 0 times on 8 A100 and 8 C550 GPUs. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed, so Ruff is not applicable. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Communicator, rank, root, count, MPI range, and byte-size validation occurs before backend dispatch, allocation, or memory transfer. -->
