### PR TITLE
feat: support CCL `Gather`

### DIFF
--- a/examples/ccl/gather.cc
+++ b/examples/ccl/gather.cc
@@ -1,0 +1,331 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Gather
+ *
+ * This example creates one native CCL rank per GPU and gathers one block from
+ * every rank into rank 0 using grouped point-to-point operations.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+constexpr int kRoot = 0;
+
+struct ScenarioState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iterations;
+  int profile_iterations;
+  ScenarioState *state;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+bool ValidateGather(const std::vector<float> &result, size_t num_elements,
+                    int world_size) {
+  bool correct = true;
+  for (int source = 0; source < world_size; ++source) {
+    const size_t offset = static_cast<size_t>(source) * num_elements;
+    const bool block_correct =
+        Validator::ValidateResult(result.data() + offset, num_elements,
+                                  static_cast<float>(source + 1), kRoot);
+    correct = block_correct && correct;
+  }
+  return correct;
+}
+
+void PrintGatherMetrics(size_t num_elements, int world_size,
+                        double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double rank_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const double gathered_bytes = rank_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per rank: " << num_elements << " floats ("
+            << std::fixed << std::setprecision(2) << rank_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data at root: "
+            << num_elements * static_cast<size_t>(world_size) << " floats ("
+            << gathered_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        gathered_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void WaitForAll(ScenarioState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_acq_rel);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+void PrintResult(bool correct, const std::vector<float> &result,
+                 size_t num_elements, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== CCL Gather Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Root rank: " << kRoot << std::endl;
+  std::cout << "Sample receive blocks: ";
+  for (int source = 0; source < std::min(world_size, 4); ++source) {
+    const size_t offset = static_cast<size_t>(source) * num_elements;
+    std::cout << "[r" << source << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+  PrintGatherMetrics(num_elements, world_size, elapsed_ms);
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the Gather worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const size_t rank_bytes = args.num_elements * sizeof(float);
+  const size_t gathered_elements =
+      args.num_elements * static_cast<size_t>(args.size);
+  const size_t gathered_bytes = gathered_elements * sizeof(float);
+  std::vector<float> h_send(args.num_elements,
+                            static_cast<float>(args.rank + 1));
+  std::vector<float> h_recv;
+  if (args.rank == kRoot) {
+    h_recv.resize(gathered_elements, 0.0f);
+  }
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), rank_bytes));
+  if (args.rank == kRoot) {
+    CHECK_RT(Rt,
+             Rt::Malloc(reinterpret_cast<void **>(&d_recv), gathered_bytes));
+  }
+  CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), rank_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  for (int i = 0; i < args.warmup_iterations; ++i) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, args.num_elements,
+                                 infinicclFloat32, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iterations; ++i) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, args.num_elements,
+                                 infinicclFloat32, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const double elapsed_ms =
+      timer.ElapsedMs() / static_cast<double>(args.profile_iterations);
+
+  if (args.rank == kRoot) {
+    CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, gathered_bytes,
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    args.state->correct.store(
+        ValidateGather(h_recv, args.num_elements, args.size),
+        std::memory_order_release);
+  }
+
+  WaitForAll(args.state, args.size);
+  if (args.rank == kRoot) {
+    PrintResult(args.state->correct.load(std::memory_order_acquire), h_recv,
+                args.num_elements, args.size, elapsed_ms);
+  }
+
+  CHECK_RT(Rt, Rt::Free(d_send));
+  if (args.rank == kRoot) {
+    CHECK_RT(Rt, Rt::Free(d_recv));
+  }
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>      Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>  Warmup iterations (default: 2)\n"
+            << "  -p <profile_iters> Profile iterations (default: 20)\n"
+            << "  -n <num_elements>  Elements contributed by each rank "
+               "(default: 1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iterations = 2;
+  int profile_iterations = 20;
+  size_t num_elements = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iterations);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iterations);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &num_elements);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for Gather." << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for Gather." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / num_elements ||
+      num_elements * static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Gather buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for Gather." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+  std::cout << "[Main Process] Elements per rank: " << num_elements
+            << " floats | Warmup: " << warmup_iterations
+            << " | Profile: " << profile_iterations << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  ScenarioState state;
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,          shared_id,
+                    num_elements, warmup_iterations, profile_iterations,
+                    &state};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = state.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] CCL Gather validation passed." << std::endl;
+  } else {
+    std::cerr << "[Main Process] CCL Gather validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/gather.cc
+++ b/examples/ccl_mpi_hybrid/gather.cc
@@ -1,8 +1,8 @@
 /**
- * InfiniCCL Example: Gather (MPI Backend)
+ * InfiniCCL Example: Gather (OpenMPI + CCL Hybrid)
  *
- * Every rank contributes one GPU-resident block. Rank 0 receives the blocks
- * in rank order, validates them, and reports Gather-specific bandwidth.
+ * This example first exercises Gather through its OpenMPI fallback, then
+ * initializes a native CCL communicator and profiles the grouped-P2P path.
  */
 
 #include <unistd.h>
@@ -105,11 +105,35 @@ void PrintGatherMetrics(size_t num_elements, int world_size,
   std::cout.precision(original_precision);
 }
 
-bool RunGatherExample(int argc, char **argv, int warmup_iterations,
-                      int profile_iterations, size_t num_elements) {
+void PrintResult(bool correct, const std::vector<float> &result,
+                 size_t num_elements, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== Hybrid CCL Gather Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Root rank: " << kRoot << std::endl;
+  std::cout << "Sample receive blocks: ";
+  for (int source = 0; source < std::min(world_size, 4); ++source) {
+    const size_t offset = static_cast<size_t>(source) * num_elements;
+    std::cout << "[r" << source << ": " << result[offset] << "] ";
+  }
+  std::cout << std::endl;
+  PrintGatherMetrics(num_elements, world_size, elapsed_ms);
+}
+
+bool RunGatherExample(int argc, char **argv) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kNumElements = 1 << 20;
 
   CHECK_INFINI(infinicclInit(&argc, &argv));
 
@@ -118,7 +142,7 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclGetRank(&rank));
   CHECK_INFINI(infinicclGetSize(&size));
   if (size <= 0) {
-    std::cerr << "Invalid world size for MPI Gather." << std::endl;
+    std::cerr << "Invalid world size for hybrid Gather." << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
@@ -132,7 +156,7 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
 
   std::array<char, 256> hostname{};
   if (gethostname(hostname.data(), hostname.size()) != 0) {
-    std::cerr << "Failed to query the hostname for MPI Gather." << std::endl;
+    std::cerr << "Failed to query the hostname for hybrid Gather." << std::endl;
     std::exit(EXIT_FAILURE);
   }
   hostname.back() = '\0';
@@ -143,17 +167,77 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
   infinicclComm_t comm = nullptr;
   CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
+  // Before a native communicator exists, the selected CCL Gather provider
+  // delegates this rank token exchange to the OpenMPI inter communicator.
+  const float bootstrap_value = static_cast<float>(rank + 1);
+  std::vector<float> h_bootstrap_recv;
+  if (rank == kRoot) {
+    h_bootstrap_recv.resize(static_cast<size_t>(size), 0.0f);
+  }
+  float *d_bootstrap_send = nullptr;
+  float *d_bootstrap_recv = nullptr;
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_send),
+                          sizeof(float)));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_recv),
+                            static_cast<size_t>(size) * sizeof(float)));
+  }
+  CHECK_RT(Rt, Rt::Memcpy(d_bootstrap_send, &bootstrap_value, sizeof(float),
+                          Rt::MemcpyHostToDevice));
+  CHECK_INFINI(infinicclGather(d_bootstrap_send, d_bootstrap_recv, 1,
+                               infinicclFloat32, kRoot, comm, nullptr));
+
+  int32_t bootstrap_status = 1;
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Memcpy(h_bootstrap_recv.data(), d_bootstrap_recv,
+                            static_cast<size_t>(size) * sizeof(float),
+                            Rt::MemcpyDeviceToHost));
+    CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+    for (int source = 0; source < size; ++source) {
+      if (h_bootstrap_recv[static_cast<size_t>(source)] !=
+          static_cast<float>(source + 1)) {
+        bootstrap_status = 0;
+      }
+    }
+  }
+  CHECK_INFINI(infinicclBroadcast(&bootstrap_status, &bootstrap_status, 1,
+                                  infinicclInt32, kRoot, comm, nullptr));
+  CHECK_RT(Rt, Rt::Free(d_bootstrap_send));
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Free(d_bootstrap_recv));
+  }
+
+  if (bootstrap_status != 1) {
+    if (rank == kRoot) {
+      std::cerr << "OpenMPI Gather fallback validation failed." << std::endl;
+    }
+    CHECK_INFINI(infinicclCommDestroy(comm));
+    CHECK_INFINI(infinicclFinalize());
+    return false;
+  }
+  if (rank == kRoot) {
+    std::cout << "OpenMPI Gather fallback validation passed." << std::endl;
+  }
+
+  infinicclUniqueId id{};
+  if (rank == kRoot) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  CHECK_INFINI(infinicclBroadcast(&id, &id, sizeof(id), infinicclUInt8, kRoot,
+                                  comm, nullptr));
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
   const size_t world_size = static_cast<size_t>(size);
-  if (num_elements > std::numeric_limits<size_t>::max() / world_size ||
-      num_elements * world_size >
+  if (kNumElements > std::numeric_limits<size_t>::max() / world_size ||
+      kNumElements * world_size >
           std::numeric_limits<size_t>::max() / sizeof(float)) {
-    std::cerr << "MPI Gather buffer size overflows `size_t`." << std::endl;
+    std::cerr << "Hybrid Gather buffer size overflows `size_t`." << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  const size_t rank_bytes = num_elements * sizeof(float);
-  const size_t gathered_elements = num_elements * world_size;
+  const size_t rank_bytes = kNumElements * sizeof(float);
+  const size_t gathered_elements = kNumElements * world_size;
   const size_t gathered_bytes = gathered_elements * sizeof(float);
-  std::vector<float> h_send(num_elements, static_cast<float>(rank + 1));
+  std::vector<float> h_send(kNumElements, static_cast<float>(rank + 1));
   std::vector<float> h_recv;
   if (rank == kRoot) {
     h_recv.resize(gathered_elements, 0.0f);
@@ -170,29 +254,20 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
                           Rt::MemcpyHostToDevice));
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
-  if (rank == kRoot) {
-    std::cout << "\n=== Performing MPI Gather on GPU Memory ===" << std::endl;
-    std::cout << "Root rank: " << kRoot << std::endl;
-    std::cout << "Elements per rank: " << num_elements << " floats"
-              << std::endl;
-    std::cout << "Warm-up iterations: " << warmup_iterations << std::endl;
-    std::cout << "Profile iterations: " << profile_iterations << std::endl;
-  }
-
-  for (int i = 0; i < warmup_iterations; ++i) {
-    CHECK_INFINI(infinicclGather(d_send, d_recv, num_elements, infinicclFloat32,
+  for (int i = 0; i < kWarmupIterations; ++i) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, kNumElements, infinicclFloat32,
                                  kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   Timer timer;
-  for (int i = 0; i < profile_iterations; ++i) {
-    CHECK_INFINI(infinicclGather(d_send, d_recv, num_elements, infinicclFloat32,
+  for (int i = 0; i < kProfileIterations; ++i) {
+    CHECK_INFINI(infinicclGather(d_send, d_recv, kNumElements, infinicclFloat32,
                                  kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const double elapsed_ms =
-      timer.ElapsedMs() / static_cast<double>(profile_iterations);
+      timer.ElapsedMs() / static_cast<double>(kProfileIterations);
 
   int32_t validation_status = 1;
   if (rank == kRoot) {
@@ -200,29 +275,14 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
                             Rt::MemcpyDeviceToHost));
     CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
     validation_status =
-        ValidateGather(h_recv, num_elements, size) ? int32_t{1} : int32_t{0};
+        ValidateGather(h_recv, kNumElements, size) ? int32_t{1} : int32_t{0};
   }
   CHECK_INFINI(infinicclBroadcast(&validation_status, &validation_status, 1,
                                   infinicclInt32, kRoot, comm, nullptr));
   const bool correct = validation_status == 1;
 
   if (rank == kRoot) {
-    constexpr const char *kGreen = "\033[32m";
-    constexpr const char *kRed = "\033[31m";
-    constexpr const char *kReset = "\033[0m";
-    std::cout << "\n=== MPI Gather Results ===" << std::endl;
-    std::cout << "Correct: "
-              << (correct ? (kGreen + std::string("YES") + kReset)
-                          : (kRed + std::string("NO") + kReset))
-              << std::endl;
-    std::cout << "Root rank: " << kRoot << std::endl;
-    std::cout << "Sample receive blocks: ";
-    for (int source = 0; source < std::min(size, 4); ++source) {
-      const size_t offset = static_cast<size_t>(source) * num_elements;
-      std::cout << "[r" << source << ": " << h_recv[offset] << "] ";
-    }
-    std::cout << std::endl;
-    PrintGatherMetrics(num_elements, size, elapsed_ms);
+    PrintResult(correct, h_recv, kNumElements, size, elapsed_ms);
   }
 
   CHECK_RT(Rt, Rt::Free(d_send));
@@ -233,6 +293,13 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclFinalize());
 
   if (rank == kRoot) {
+    if (correct) {
+      std::cout << "[Main Process] Hybrid CCL Gather validation passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid CCL Gather validation failed."
+                << std::endl;
+    }
     std::cout << "InfiniCCL finalized." << std::endl;
   }
   return correct;
@@ -241,11 +308,5 @@ bool RunGatherExample(int argc, char **argv, int warmup_iterations,
 }  // namespace
 
 int main(int argc, char **argv) {
-  constexpr int kWarmupIterations = 2;
-  constexpr int kProfileIterations = 20;
-  constexpr size_t kNumElements = 1 << 20;
-  return RunGatherExample(argc, argv, kWarmupIterations, kProfileIterations,
-                          kNumElements)
-             ? EXIT_SUCCESS
-             : EXIT_FAILURE;
+  return RunGatherExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/gather.h
+++ b/src/backends/ccl/common/impl/gather.h
@@ -1,0 +1,108 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_GATHER_H_
+
+#include <cstddef>
+#include <limits>
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/gather.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredGather {
+  using type = Gather;
+};
+
+template <BackendType backend, Device::Type device>
+class CclGatherImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type, int root,
+                            Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredGather<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return GatherImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, count, data_type, root, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size() ||
+        root < 0 || root >= comm->size()) {
+      LOG("Invalid rank, root, or world size for native CCL `Gather`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    const size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Per-rank byte size overflows `size_t` for native CCL `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    const size_t rank_bytes = count * type_size;
+    const size_t world_size = static_cast<size_t>(comm->size());
+    if (rank_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for native CCL `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto native_stream = reinterpret_cast<typename Api::Stream>(stream);
+    ReturnStatus status = Api::Check(Api::GroupStart());
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    ReturnStatus first_error = Api::Check(Api::Send(
+        send_buff, count, native_type, root, instance->handle, native_stream));
+
+    if (comm->rank() == root) {
+      auto *recv_bytes = static_cast<std::byte *>(recv_buff);
+      for (int peer = 0; peer < comm->size(); ++peer) {
+        const size_t offset = static_cast<size_t>(peer) * rank_bytes;
+        status = Api::Check(Api::Recv(recv_bytes + offset, count, native_type,
+                                      peer, instance->handle, native_stream));
+        if (first_error == ReturnStatus::kSuccess &&
+            status != ReturnStatus::kSuccess) {
+          first_error = status;
+        }
+      }
+    }
+
+    const ReturnStatus group_end_status = Api::Check(Api::GroupEnd());
+    return first_error != ReturnStatus::kSuccess ? first_error
+                                                 : group_end_status;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_GATHER_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,20 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return mcclGroupStart(); }
+
+  static Result GroupEnd() { return mcclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/gather.h
+++ b/src/backends/ccl/mccl/impl/gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_
+
+#include "backends/ccl/common/impl/gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class GatherImpl<BackendType::kMccl, device>
+    : public CclGatherImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Gather, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_GATHER_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,20 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return ncclGroupStart(); }
+
+  static Result GroupEnd() { return ncclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/gather.h
+++ b/src/backends/ccl/nccl/impl/gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_GATHER_H_
+
+#include "backends/ccl/common/impl/gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class GatherImpl<BackendType::kNccl, device>
+    : public CclGatherImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Gather, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_GATHER_H_

--- a/src/backends/mpi/ompi/impl/gather.h
+++ b/src/backends/mpi/ompi/impl/gather.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <limits>
+#include <memory>
 
 #include "backends/mpi/ompi/checks.h"
 #include "backends/mpi/ompi/comm_instance.h"
@@ -24,9 +25,18 @@ class GatherImpl<BackendType::kOmpi, device_type> {
         ListGetBest<DevicePriority>(ActiveDevices<Gather>{});
     using Rt = Runtime<kDev>;
 
-    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
-    if (!inst || inst->handle == MPI_COMM_NULL) {
+    if (!comm || !comm->inter_comm() ||
+        comm->inter_comm_backend() != BackendType::kOmpi) {
       LOG("Invalid OpenMPI communicator instance for `Gather`.");
+      return ReturnStatus::kInternalError;
+    }
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator handle for `Gather`.");
+      return ReturnStatus::kInternalError;
+    }
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size()) {
+      LOG("Invalid rank or world size for `Gather`.");
       return ReturnStatus::kInternalError;
     }
 
@@ -36,44 +46,43 @@ class GatherImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kInvalidArgument;
     }
     size_t send_bytes = count * type_size;
-    size_t recv_bytes = send_bytes * static_cast<size_t>(comm->size());
-    const bool is_root = comm->rank() == root;
-
-    // Transfer raw bytes so the gather is correct for every data type,
-    // including `kFloat16` / `kBFloat16`, which map to `MPI_BYTE`.
     if (send_bytes > static_cast<size_t>(std::numeric_limits<int>::max())) {
       LOG("Per-rank byte count exceeds MPI int range for `Gather`.");
       return ReturnStatus::kInvalidArgument;
     }
+    const size_t world_size = static_cast<size_t>(comm->size());
+    if (send_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    const size_t recv_bytes = send_bytes * world_size;
+    const bool is_root = comm->rank() == root;
     int mpi_byte_count = static_cast<int>(send_bytes);
 
-    // Host staging buffers. Only `root` allocates the receive side, since
-    // `MPI_Gather` writes the gathered result only on `root`.
-    void *host_sendbuf = std::malloc(send_bytes);
-    void *host_recvbuf = is_root ? std::malloc(recv_bytes) : nullptr;
+    // Transfer raw bytes so movement-only collectives preserve every InfiniCCL
+    // data type, including float16 and bfloat16.
+    std::unique_ptr<void, decltype(&std::free)> host_sendbuf(
+        std::malloc(send_bytes), &std::free);
+    std::unique_ptr<void, decltype(&std::free)> host_recvbuf(
+        is_root ? std::malloc(recv_bytes) : nullptr, &std::free);
     if (!host_sendbuf || (is_root && !host_recvbuf)) {
-      std::free(host_sendbuf);
-      std::free(host_recvbuf);
       LOG("Failed to allocate host buffers for `Gather` staging.");
       return ReturnStatus::kSystemError;
     }
 
-    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, send_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf.get(), send_buff, send_bytes,
                                 Rt::MemcpyDeviceToHost));
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
     // Note: `MPI_Gather`'s `recvcount` is the per-rank count, not the total.
-    INFINI_CHECK_MPI(MPI_Gather(host_sendbuf, mpi_byte_count, MPI_BYTE,
-                                host_recvbuf, mpi_byte_count, MPI_BYTE, root,
-                                inst->handle));
+    INFINI_CHECK_MPI(MPI_Gather(host_sendbuf.get(), mpi_byte_count, MPI_BYTE,
+                                host_recvbuf.get(), mpi_byte_count, MPI_BYTE,
+                                root, inst->handle));
 
     if (is_root) {
-      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,
+      CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf.get(), recv_bytes,
                                   Rt::MemcpyHostToDevice));
     }
-
-    std::free(host_sendbuf);
-    std::free(host_recvbuf);
 
     return ReturnStatus::kSuccess;
   }

--- a/src/base/gather.h
+++ b/src/base/gather.h
@@ -18,17 +18,20 @@ class Gather : public Operation<Gather> {
   static ReturnStatus Execute(const void *send_buff, void *recv_buff,
                               size_t count, DataType datatype, int root,
                               void *comm_handle, void *stream) {
-    if (!comm_handle) {
-      LOG("Invalid communicator handle for `Gather`.");
-      return ReturnStatus::kInvalidArgument;
-    }
-
-    auto *comm = static_cast<Communicator *>(comm_handle);
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, root, comm)) {
+    if (HasInvalidRequiredArgs(datatype, root, comm_handle)) {
       return ReturnStatus::kInvalidArgument;
     }
     if (count == 0) {
       return ReturnStatus::kSuccess;
+    }
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (!send_buff) {
+      LOG("Invalid send buffer pointer for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (comm->rank() == root && !recv_buff) {
+      LOG("Invalid root receive buffer pointer for `Gather`.");
+      return ReturnStatus::kInvalidArgument;
     }
 
     return GatherImpl<backend_type, device_type>::Apply(
@@ -36,22 +39,19 @@ class Gather : public Operation<Gather> {
   }
 
  private:
-  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, int root, Communicator *comm) {
+  static bool HasInvalidRequiredArgs(DataType datatype, int root,
+                                     void *comm_handle) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for `Gather`.");
+      return true;
+    }
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `Gather`.");
       return true;
     }
+    auto *comm = static_cast<Communicator *>(comm_handle);
     if (root < 0 || root >= comm->size()) {
       LOG("Invalid root rank for `Gather`.");
-      return true;
-    }
-    if (!send_buff) {
-      LOG("Invalid send buffer pointer for `Gather`.");
-      return true;
-    }
-    if (comm->rank() == root && !recv_buff) {
-      LOG("Invalid root receive buffer pointer for `Gather`.");
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

This PR adds `Gather` support to the shared CCL backend abstraction by composing provider-native grouped point-to-point operations through the existing NCCL and MCCL layers for the existing public `infinicclGather()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, hardens the shared OpenMPI/MPICH movement path with communicator validation, byte-count and overflow checks, and automatic host-buffer cleanup, defines zero-count behavior, makes the existing MPI example validate every received source block and propagate failures, and includes CCL-only plus OpenMPI-assisted `Gather` examples with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclGather()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `Gather` after validating the communicator, data type, and root, without requiring non-null buffers or entering a backend.
  - Require a send buffer on every rank for non-zero operations while requiring the receive buffer only on the root rank.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `Gather` implementation using grouped point-to-point operations because the providers do not expose a native `Gather` collective.
  - Send one contribution from every rank, including the root, and receive every peer block at the root in rank order within one provider group.
  - Validate the native communicator backend, device, rank, world size, root, handle, and data type before dispatch.
  - Check per-rank and total byte-size calculations for `size_t` overflow.
  - Preserve the first point-to-point error and always call `GroupEnd` after a successful `GroupStart`.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with `GroupStart`, `GroupEnd`, `Send`, and `Recv` bindings.
  - Register `Gather` with the existing NCCL and MCCL provider layers without introducing a dependency on a vendor-specific `Gather` entry point.

- **MPI Correctness and Safety**
  - Treat `Gather` as a movement operation in the shared OpenMPI/MPICH implementation by using `MPI_BYTE` with `count * type_size` bytes per rank, preserving every data type including `Float16` and `BFloat16`.
  - Add communicator, rank, world-size, MPI `int` count-range, and total-buffer-size validation.
  - Allocate the receive staging buffer only on the root and manage all host staging buffers with automatic cleanup across success and error paths.
  - Validate every received source-rank block in the existing MPI example and broadcast the validation status so failures propagate through every process exit code.

- **Examples, Validation, and Metrics**
  - Add a thread-per-GPU single-node CCL `Gather` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL example that first validates the OpenMPI fallback through an inter-only communicator, then initializes a native CCL communicator and validates the grouped point-to-point path.
  - Validate the complete out-of-place rank-ordered receive layout in all three `Gather` examples.
  - Report per-rank and root-total data sizes, root-rank average time, algorithm bandwidth as `world_size * rank_bytes / time`, and bus bandwidth as algorithm bandwidth multiplied by `(world_size - 1) / world_size`.
  - Parse numeric inputs without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `Gather`, avoiding the existing MPI host-staging path when a supported CCL backend and matching native communicator are available. The native path composes grouped point-to-point operations because neither provider exposes a vendor `Gather` collective, while the shared MPI fallback remains host-staged with byte-count movement semantics and additional validation and cleanup. Other collective operations are intended to remain unchanged. The validation-log timings below are execution references rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch adds `Gather` alongside the existing `AllReduce`; other independently developed CCL collectives are outside this branch.
- `Gather` inherits the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The native CCL path uses grouped point-to-point operations rather than a vendor `Gather` entry point. Each rank sends once, while the root receives one block per rank, so root-side work and storage grow linearly with communicator size.
- The server examples validate out-of-place `Float32` payloads with root rank 0 on the default stream. Additional data types, in-place layouts, non-default streams, and runtime coverage on Iluvatar and Moore Threads remain future work.
- The shared OpenMPI/MPICH fallback remains host-staged with per-call allocations and rejects per-rank byte counts above the MPI `int` range; chunked transfers remain future work.

## Test Results

The implementation commit is `773a7d32846a547c83effb5f0db9f5d8a208424e`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached evidence contains exactly 15 hash-verified canonical logs from the current commit: all 15 targets passed, with `Correct: YES` 17 times and `Correct: NO` 0 times. The extra two positive results are the additional expected validation cases in the broadcast log.

All four `Gather` paths passed with a 1,048,576-element `Float32` contribution per rank (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations:

| Path | Test topology | Data per rank / total at root | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.141 ms | 237.33 GB/s | 207.66 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.140 ms | 239.26 GB/s | 209.35 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 4.00 / 64.00 MiB | 39.644 ms | 1.69 GB/s | 1.59 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 0.131 ms | 255.98 GB/s | 223.98 GB/s |

The reported times are the root rank's elapsed time averaged over the 20 profiled calls after the 2 warm-up calls. Algorithm bandwidth uses the total bytes gathered at the root, and bus bandwidth applies the `(world_size - 1) / world_size` correction factor. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs. The hybrid `Gather` log also confirms that the OpenMPI fallback passed before the native NCCL communicator was initialized.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs, with ranks 0-7 mapped to devices 0-7.
- All six formal invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345476/ccl_all_reduce.log)
[ccl_gather.log](https://github.com/user-attachments/files/31345477/ccl_gather.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31345479/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_gather.log](https://github.com/user-attachments/files/31345481/ccl_mpi_hybrid_gather.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31345482/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31345483/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31345484/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31345485/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31345487/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31345488/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31345490/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31345491/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31345492/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345495/ccl_all_reduce.log)
[ccl_gather.log](https://github.com/user-attachments/files/31345496/ccl_gather.log)



---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains one self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclGather()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) conventions. <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The final hash-verified current-commit evidence contains 15/15 passing canonical logs, `Correct: YES` 17 times, and `Correct: NO` 0 times on the full 8-A100 + 8-C550 matrix. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed, so Ruff is not applicable. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Communicator, rank, root, data-type, per-rank byte-size, and total-size validation occurs before native pointer offsets, staging allocation, or backend dispatch. -->
