### PR TITLE
feat: support CCL `Scatter`

### DIFF
--- a/examples/ccl/scatter.cc
+++ b/examples/ccl/scatter.cc
@@ -1,0 +1,332 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Scatter
+ *
+ * This example creates one native CCL rank per GPU and scatters one distinct
+ * block from rank 0 to every rank using grouped point-to-point operations.
+ */
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+// Public API
+#include "infiniccl.h"
+
+// Example-Specific Utilities
+#include "utils.h"
+
+// Internal Headers (Accessible via example-specific include paths, technically
+// not public APIs)
+#include "backend_manifest.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+constexpr int kRoot = 0;
+
+struct ScenarioState {
+  std::atomic<bool> correct{true};
+  std::atomic<int> completed{0};
+  std::vector<float> samples;
+
+  explicit ScenarioState(int world_size)
+      : samples(static_cast<size_t>(world_size), 0.0f) {}
+};
+
+struct ThreadArgs {
+  int rank;
+  int size;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iterations;
+  int profile_iterations;
+  ScenarioState *state;
+};
+
+template <typename T>
+bool ParsePositiveNumber(const char *text, T *value) {
+  if (!text || !value) {
+    return false;
+  }
+
+  T parsed{};
+  const char *end = text + std::strlen(text);
+  const auto result = std::from_chars(text, end, parsed);
+  if (result.ec != std::errc{} || result.ptr != end || parsed <= 0) {
+    return false;
+  }
+
+  *value = parsed;
+  return true;
+}
+
+void FillScatterInput(std::vector<float> *input, size_t num_elements,
+                      int world_size) {
+  for (int destination = 0; destination < world_size; ++destination) {
+    const size_t offset = static_cast<size_t>(destination) * num_elements;
+    std::fill_n(input->begin() + offset, num_elements,
+                static_cast<float>(destination + 1));
+  }
+}
+
+void PrintScatterMetrics(size_t num_elements, int world_size,
+                         double elapsed_ms) {
+  constexpr double kBytesPerMiB = 1024.0 * 1024.0;
+  constexpr double kBytesPerGB = 1.0e9;
+  const double rank_bytes = static_cast<double>(num_elements) * sizeof(float);
+  const double total_bytes = rank_bytes * static_cast<double>(world_size);
+  const auto original_flags = std::cout.flags();
+  const auto original_precision = std::cout.precision();
+
+  std::cout << "Data size per rank: " << num_elements << " floats ("
+            << std::fixed << std::setprecision(2) << rank_bytes / kBytesPerMiB
+            << " MiB)" << std::endl;
+  std::cout << "Total data at root: "
+            << num_elements * static_cast<size_t>(world_size) << " floats ("
+            << total_bytes / kBytesPerMiB << " MiB)" << std::endl;
+  std::cout << "Time:           " << std::setprecision(3) << elapsed_ms << " ms"
+            << std::endl;
+  if (elapsed_ms > 0.0 && std::isfinite(elapsed_ms)) {
+    const double algorithm_bandwidth =
+        total_bytes / kBytesPerGB / (elapsed_ms / 1000.0);
+    const double bus_bandwidth = algorithm_bandwidth *
+                                 static_cast<double>(world_size - 1) /
+                                 static_cast<double>(world_size);
+    std::cout << "Throughput:     " << std::setprecision(2) << bus_bandwidth
+              << " GB/s (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  " << algorithm_bandwidth << " GB/s"
+              << std::endl;
+  } else {
+    std::cout << "Throughput:     N/A (Bus BW)" << std::endl;
+    std::cout << "Alg Bandwidth:  N/A" << std::endl;
+  }
+
+  std::cout.flags(original_flags);
+  std::cout.precision(original_precision);
+}
+
+void WaitForAll(ScenarioState *state, int world_size) {
+  state->completed.fetch_add(1, std::memory_order_acq_rel);
+  while (state->completed.load(std::memory_order_acquire) < world_size) {
+    std::this_thread::yield();
+  }
+}
+
+void PrintResult(bool correct, const std::vector<float> &samples,
+                 size_t num_elements, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== CCL Scatter Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Root rank: " << kRoot << std::endl;
+  std::cout << "Sample receive blocks: ";
+  for (int rank = 0; rank < std::min(world_size, 4); ++rank) {
+    std::cout << "[r" << rank << ": " << samples[static_cast<size_t>(rank)]
+              << "] ";
+  }
+  std::cout << std::endl;
+  PrintScatterMetrics(num_elements, world_size, elapsed_ms);
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for the Scatter worker."
+              << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+  hostname.back() = '\0';
+  std::cout << "[Rank " << args.rank << "] Host: " << hostname.data()
+            << " | GPU: " << Device::StringFromType(kDevType) << " | Device "
+            << args.rank << std::endl;
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, args.size, args.id, args.rank));
+
+  const size_t rank_bytes = args.num_elements * sizeof(float);
+  const size_t total_elements =
+      args.num_elements * static_cast<size_t>(args.size);
+  const size_t total_bytes = total_elements * sizeof(float);
+  std::vector<float> h_send;
+  if (args.rank == kRoot) {
+    h_send.resize(total_elements, 0.0f);
+    FillScatterInput(&h_send, args.num_elements, args.size);
+  }
+  std::vector<float> h_recv(args.num_elements, 0.0f);
+
+  float *d_send = nullptr;
+  float *d_recv = nullptr;
+  if (args.rank == kRoot) {
+    CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_send), total_bytes));
+    CHECK_RT(Rt, Rt::Memcpy(d_send, h_send.data(), total_bytes,
+                            Rt::MemcpyHostToDevice));
+  }
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), rank_bytes));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  for (int i = 0; i < args.warmup_iterations; ++i) {
+    CHECK_INFINI(infinicclScatter(d_send, d_recv, args.num_elements,
+                                  infinicclFloat32, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iterations; ++i) {
+    CHECK_INFINI(infinicclScatter(d_send, d_recv, args.num_elements,
+                                  infinicclFloat32, kRoot, comm, nullptr));
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const double elapsed_ms =
+      timer.ElapsedMs() / static_cast<double>(args.profile_iterations);
+
+  CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, rank_bytes,
+                          Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const bool local_correct =
+      Validator::ValidateResult(h_recv.data(), args.num_elements,
+                                static_cast<float>(args.rank + 1), args.rank);
+  args.state->samples[static_cast<size_t>(args.rank)] = h_recv.front();
+  if (!local_correct) {
+    args.state->correct.store(false, std::memory_order_release);
+  }
+
+  WaitForAll(args.state, args.size);
+  if (args.rank == kRoot) {
+    PrintResult(args.state->correct.load(std::memory_order_acquire),
+                args.state->samples, args.num_elements, args.size, elapsed_ms);
+  }
+
+  if (args.rank == kRoot) {
+    CHECK_RT(Rt, Rt::Free(d_send));
+  }
+  CHECK_RT(Rt, Rt::Free(d_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+void PrintUsage(const char *program) {
+  std::cout << "Usage: " << program << " [options]\n"
+            << "Options:\n"
+            << "  -g <num_gpus>      Number of GPUs (default: 8)\n"
+            << "  -w <warmup_iters>  Warmup iterations (default: 2)\n"
+            << "  -p <profile_iters> Profile iterations (default: 20)\n"
+            << "  -n <num_elements>  Elements sent to each rank "
+               "(default: 1048576)\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int num_gpus = 8;
+  int warmup_iterations = 2;
+  int profile_iterations = 20;
+  size_t num_elements = 1 << 20;
+
+  int opt = 0;
+  while ((opt = getopt(argc, argv, "g:w:p:n:h")) != -1) {
+    bool parsed = false;
+    switch (opt) {
+      case 'g':
+        parsed = ParsePositiveNumber(optarg, &num_gpus);
+        break;
+      case 'w':
+        parsed = ParsePositiveNumber(optarg, &warmup_iterations);
+        break;
+      case 'p':
+        parsed = ParsePositiveNumber(optarg, &profile_iterations);
+        break;
+      case 'n':
+        parsed = ParsePositiveNumber(optarg, &num_elements);
+        break;
+      case 'h':
+        PrintUsage(argv[0]);
+        return EXIT_SUCCESS;
+      default:
+        PrintUsage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    if (!parsed) {
+      std::cerr << "Invalid positive numeric option for Scatter." << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (optind != argc) {
+    std::cerr << "Unexpected positional argument for Scatter." << std::endl;
+    return EXIT_FAILURE;
+  }
+  if (static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / num_elements ||
+      num_elements * static_cast<size_t>(num_gpus) >
+          std::numeric_limits<size_t>::max() / sizeof(float)) {
+    std::cerr << "Scatter buffer size overflows `size_t`." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::array<char, 256> hostname{};
+  if (gethostname(hostname.data(), hostname.size()) != 0) {
+    std::cerr << "Failed to query the hostname for Scatter." << std::endl;
+    return EXIT_FAILURE;
+  }
+  hostname.back() = '\0';
+  std::cout << "[Main Process] Host: " << hostname.data()
+            << " | Target GPUs: " << num_gpus << std::endl;
+  std::cout << "[Main Process] Elements per rank: " << num_elements
+            << " floats | Warmup: " << warmup_iterations
+            << " | Profile: " << profile_iterations << std::endl;
+
+  infinicclUniqueId shared_id{};
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  ScenarioState state(num_gpus);
+  std::vector<std::thread> threads;
+  threads.reserve(num_gpus);
+  for (int rank = 0; rank < num_gpus; ++rank) {
+    ThreadArgs args{rank,         num_gpus,          shared_id,
+                    num_elements, warmup_iterations, profile_iterations,
+                    &state};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+
+  const bool correct = state.correct.load(std::memory_order_acquire);
+  if (correct) {
+    std::cout << "[Main Process] CCL Scatter validation passed." << std::endl;
+  } else {
+    std::cerr << "[Main Process] CCL Scatter validation failed." << std::endl;
+  }
+  std::cout
+      << "[Main Process] All worker threads joined. InfiniCCL finalized safely."
+      << std::endl;
+  return correct ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/examples/ccl_mpi_hybrid/scatter.cc
+++ b/examples/ccl_mpi_hybrid/scatter.cc
@@ -1,8 +1,8 @@
 /**
- * InfiniCCL Example: Scatter (MPI Backend)
+ * InfiniCCL Example: Scatter (OpenMPI + CCL Hybrid)
  *
- * Rank 0 distributes one GPU-resident block to every rank. Each rank validates
- * its full block, and rank 0 reports Scatter-specific bandwidth.
+ * This example first exercises Scatter through its OpenMPI fallback, then
+ * initializes a native CCL communicator and profiles the grouped-P2P path.
  */
 
 #include <unistd.h>
@@ -142,11 +142,35 @@ void PrintScatterMetrics(size_t num_elements, int world_size,
   std::cout.precision(original_precision);
 }
 
-bool RunScatterExample(int argc, char **argv, int warmup_iterations,
-                       int profile_iterations, size_t num_elements) {
+void PrintResult(bool correct, const std::vector<float> &samples,
+                 size_t num_elements, int world_size, double elapsed_ms) {
+  constexpr const char *kGreen = "\033[32m";
+  constexpr const char *kRed = "\033[31m";
+  constexpr const char *kReset = "\033[0m";
+
+  std::cout << "\n=== Hybrid CCL Scatter Results ===" << std::endl;
+  std::cout << "Correct: "
+            << (correct ? (kGreen + std::string("YES") + kReset)
+                        : (kRed + std::string("NO") + kReset))
+            << std::endl;
+  std::cout << "Root rank: " << kRoot << std::endl;
+  std::cout << "Sample receive blocks: ";
+  for (int rank = 0; rank < std::min(world_size, 4); ++rank) {
+    std::cout << "[r" << rank << ": " << samples[static_cast<size_t>(rank)]
+              << "] ";
+  }
+  std::cout << std::endl;
+  PrintScatterMetrics(num_elements, world_size, elapsed_ms);
+}
+
+bool RunScatterExample(int argc, char **argv) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
   using Rt = Runtime<kDevType>;
+
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+  constexpr size_t kNumElements = 1 << 20;
 
   CHECK_INFINI(infinicclInit(&argc, &argv));
 
@@ -155,7 +179,7 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclGetRank(&rank));
   CHECK_INFINI(infinicclGetSize(&size));
   if (size <= 0) {
-    std::cerr << "Invalid world size for MPI Scatter." << std::endl;
+    std::cerr << "Invalid world size for hybrid Scatter." << std::endl;
     std::exit(EXIT_FAILURE);
   }
 
@@ -169,7 +193,8 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
 
   std::array<char, 256> hostname{};
   if (gethostname(hostname.data(), hostname.size()) != 0) {
-    std::cerr << "Failed to query the hostname for MPI Scatter." << std::endl;
+    std::cerr << "Failed to query the hostname for hybrid Scatter."
+              << std::endl;
     std::exit(EXIT_FAILURE);
   }
   hostname.back() = '\0';
@@ -180,22 +205,80 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
   infinicclComm_t comm = nullptr;
   CHECK_INFINI(infinicclCommInitAll(&comm, size, nullptr));
 
+  // Before a native communicator exists, the selected CCL Scatter provider
+  // delegates this rank token distribution to the OpenMPI inter communicator.
+  std::vector<float> h_bootstrap_send;
+  if (rank == kRoot) {
+    h_bootstrap_send.resize(static_cast<size_t>(size));
+    for (int destination = 0; destination < size; ++destination) {
+      h_bootstrap_send[static_cast<size_t>(destination)] =
+          static_cast<float>(destination + 1);
+    }
+  }
+  float h_bootstrap_recv = 0.0f;
+  float *d_bootstrap_send = nullptr;
+  float *d_bootstrap_recv = nullptr;
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_send),
+                            static_cast<size_t>(size) * sizeof(float)));
+    CHECK_RT(Rt, Rt::Memcpy(d_bootstrap_send, h_bootstrap_send.data(),
+                            static_cast<size_t>(size) * sizeof(float),
+                            Rt::MemcpyHostToDevice));
+  }
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_bootstrap_recv),
+                          sizeof(float)));
+  CHECK_INFINI(infinicclScatter(d_bootstrap_send, d_bootstrap_recv, 1,
+                                infinicclFloat32, kRoot, comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(&h_bootstrap_recv, d_bootstrap_recv, sizeof(float),
+                          Rt::MemcpyDeviceToHost));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  const bool bootstrap_local_correct = h_bootstrap_recv == rank + 1.0f;
+  std::vector<float> bootstrap_reports;
+  const bool bootstrap_correct =
+      CollectValidationReports<Rt>(bootstrap_local_correct, h_bootstrap_recv,
+                                   rank, size, comm, &bootstrap_reports);
+  if (rank == kRoot) {
+    CHECK_RT(Rt, Rt::Free(d_bootstrap_send));
+  }
+  CHECK_RT(Rt, Rt::Free(d_bootstrap_recv));
+
+  if (!bootstrap_correct) {
+    if (rank == kRoot) {
+      std::cerr << "OpenMPI Scatter fallback validation failed." << std::endl;
+    }
+    CHECK_INFINI(infinicclCommDestroy(comm));
+    CHECK_INFINI(infinicclFinalize());
+    return false;
+  }
+  if (rank == kRoot) {
+    std::cout << "OpenMPI Scatter fallback validation passed." << std::endl;
+  }
+
+  infinicclUniqueId id{};
+  if (rank == kRoot) {
+    CHECK_INFINI(infinicclGetUniqueId(&id));
+  }
+  CHECK_INFINI(infinicclBroadcast(&id, &id, sizeof(id), infinicclUInt8, kRoot,
+                                  comm, nullptr));
+  CHECK_INFINI(infinicclCommInitRank(&comm, size, id, rank));
+
   const size_t world_size = static_cast<size_t>(size);
-  if (num_elements > std::numeric_limits<size_t>::max() / world_size ||
-      num_elements * world_size >
+  if (kNumElements > std::numeric_limits<size_t>::max() / world_size ||
+      kNumElements * world_size >
           std::numeric_limits<size_t>::max() / sizeof(float)) {
-    std::cerr << "MPI Scatter buffer size overflows `size_t`." << std::endl;
+    std::cerr << "Hybrid Scatter buffer size overflows `size_t`." << std::endl;
     std::exit(EXIT_FAILURE);
   }
-  const size_t rank_bytes = num_elements * sizeof(float);
-  const size_t total_elements = num_elements * world_size;
+  const size_t rank_bytes = kNumElements * sizeof(float);
+  const size_t total_elements = kNumElements * world_size;
   const size_t total_bytes = total_elements * sizeof(float);
   std::vector<float> h_send;
   if (rank == kRoot) {
     h_send.resize(total_elements, 0.0f);
-    FillScatterInput(&h_send, num_elements, size);
+    FillScatterInput(&h_send, kNumElements, size);
   }
-  std::vector<float> h_recv(num_elements, 0.0f);
+  std::vector<float> h_recv(kNumElements, 0.0f);
 
   float *d_send = nullptr;
   float *d_recv = nullptr;
@@ -207,56 +290,32 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
   CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void **>(&d_recv), rank_bytes));
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
-  if (rank == kRoot) {
-    std::cout << "\n=== Performing MPI Scatter on GPU Memory ===" << std::endl;
-    std::cout << "Root rank: " << kRoot << std::endl;
-    std::cout << "Elements per rank: " << num_elements << " floats"
-              << std::endl;
-    std::cout << "Warm-up iterations: " << warmup_iterations << std::endl;
-    std::cout << "Profile iterations: " << profile_iterations << std::endl;
-  }
-
-  for (int i = 0; i < warmup_iterations; ++i) {
-    CHECK_INFINI(infinicclScatter(d_send, d_recv, num_elements,
+  for (int i = 0; i < kWarmupIterations; ++i) {
+    CHECK_INFINI(infinicclScatter(d_send, d_recv, kNumElements,
                                   infinicclFloat32, kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
 
   Timer timer;
-  for (int i = 0; i < profile_iterations; ++i) {
-    CHECK_INFINI(infinicclScatter(d_send, d_recv, num_elements,
+  for (int i = 0; i < kProfileIterations; ++i) {
+    CHECK_INFINI(infinicclScatter(d_send, d_recv, kNumElements,
                                   infinicclFloat32, kRoot, comm, nullptr));
   }
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const double elapsed_ms =
-      timer.ElapsedMs() / static_cast<double>(profile_iterations);
+      timer.ElapsedMs() / static_cast<double>(kProfileIterations);
 
   CHECK_RT(Rt, Rt::Memcpy(h_recv.data(), d_recv, rank_bytes,
                           Rt::MemcpyDeviceToHost));
   CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
   const bool local_correct = Validator::ValidateResult(
-      h_recv.data(), num_elements, static_cast<float>(rank + 1), rank);
+      h_recv.data(), kNumElements, static_cast<float>(rank + 1), rank);
   std::vector<float> validation_reports;
   const bool correct = CollectValidationReports<Rt>(
       local_correct, h_recv.front(), rank, size, comm, &validation_reports);
 
   if (rank == kRoot) {
-    constexpr const char *kGreen = "\033[32m";
-    constexpr const char *kRed = "\033[31m";
-    constexpr const char *kReset = "\033[0m";
-    std::cout << "\n=== MPI Scatter Results ===" << std::endl;
-    std::cout << "Correct: "
-              << (correct ? (kGreen + std::string("YES") + kReset)
-                          : (kRed + std::string("NO") + kReset))
-              << std::endl;
-    std::cout << "Root rank: " << kRoot << std::endl;
-    std::cout << "Sample receive blocks: ";
-    for (int source = 0; source < std::min(size, 4); ++source) {
-      std::cout << "[r" << source << ": "
-                << validation_reports[static_cast<size_t>(source)] << "] ";
-    }
-    std::cout << std::endl;
-    PrintScatterMetrics(num_elements, size, elapsed_ms);
+    PrintResult(correct, validation_reports, kNumElements, size, elapsed_ms);
   }
 
   if (rank == kRoot) {
@@ -267,6 +326,13 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
   CHECK_INFINI(infinicclFinalize());
 
   if (rank == kRoot) {
+    if (correct) {
+      std::cout << "[Main Process] Hybrid CCL Scatter validation passed."
+                << std::endl;
+    } else {
+      std::cerr << "[Main Process] Hybrid CCL Scatter validation failed."
+                << std::endl;
+    }
     std::cout << "InfiniCCL finalized." << std::endl;
   }
   return correct;
@@ -275,11 +341,5 @@ bool RunScatterExample(int argc, char **argv, int warmup_iterations,
 }  // namespace
 
 int main(int argc, char **argv) {
-  constexpr int kWarmupIterations = 2;
-  constexpr int kProfileIterations = 20;
-  constexpr size_t kNumElements = 1 << 20;
-  return RunScatterExample(argc, argv, kWarmupIterations, kProfileIterations,
-                           kNumElements)
-             ? EXIT_SUCCESS
-             : EXIT_FAILURE;
+  return RunScatterExample(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/backends/ccl/common/impl/scatter.h
+++ b/src/backends/ccl/common/impl/scatter.h
@@ -1,0 +1,113 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SCATTER_H_
+
+#include <cstddef>
+#include <limits>
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/scatter.h"
+#include "communicator.h"
+#include "data_type_impl.h"
+#include "logging.h"
+
+namespace infini::ccl {
+
+template <BackendType>
+struct DeferredScatter {
+  using type = Scatter;
+};
+
+template <BackendType backend, Device::Type device>
+class CclScatterImpl {
+ public:
+  static ReturnStatus Apply(const void *send_buff, void *recv_buff,
+                            size_t count, DataType data_type, int root,
+                            Communicator *comm, void *stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    const bool has_native_comm = comm && comm->intra_comm() &&
+                                 comm->intra_comm_backend() == backend &&
+                                 comm->device_type() == device;
+    if (!has_native_comm) {
+      if (!comm || !comm->inter_comm() ||
+          comm->inter_comm_backend() != BackendType::kOmpi) {
+        return ReturnStatus::kInternalError;
+      }
+
+      using FallbackOperation = typename DeferredScatter<backend>::type;
+      if constexpr (BackendEnabled<FallbackOperation,
+                                   BackendType::kOmpi>::value) {
+        return ScatterImpl<BackendType::kOmpi, device>::Apply(
+            send_buff, recv_buff, count, data_type, root, comm, stream);
+      }
+
+      return ReturnStatus::kInternalError;
+    }
+
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size() ||
+        root < 0 || root >= comm->size()) {
+      LOG("Invalid rank, root, or world size for native CCL `Scatter`.");
+      return ReturnStatus::kInternalError;
+    }
+
+    auto *instance = static_cast<CommInstance *>(comm->intra_comm());
+    if (!instance->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType native_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &native_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    const size_t type_size = kDataTypeToSize.at(data_type);
+    if (count > std::numeric_limits<size_t>::max() / type_size) {
+      LOG("Per-rank byte size overflows `size_t` for native CCL `Scatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    const size_t rank_bytes = count * type_size;
+    const size_t world_size = static_cast<size_t>(comm->size());
+    if (rank_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for native CCL `Scatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto native_stream = reinterpret_cast<typename Api::Stream>(stream);
+    ReturnStatus status = Api::Check(Api::GroupStart());
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    ReturnStatus first_error = ReturnStatus::kSuccess;
+    if (comm->rank() == root) {
+      const auto *send_bytes = static_cast<const std::byte *>(send_buff);
+      for (int peer = 0; peer < comm->size(); ++peer) {
+        const size_t offset = static_cast<size_t>(peer) * rank_bytes;
+        status = Api::Check(Api::Send(send_bytes + offset, count, native_type,
+                                      peer, instance->handle, native_stream));
+        if (first_error == ReturnStatus::kSuccess &&
+            status != ReturnStatus::kSuccess) {
+          first_error = status;
+        }
+      }
+    }
+
+    status = Api::Check(Api::Recv(recv_buff, count, native_type, root,
+                                  instance->handle, native_stream));
+    if (first_error == ReturnStatus::kSuccess &&
+        status != ReturnStatus::kSuccess) {
+      first_error = status;
+    }
+
+    const ReturnStatus group_end_status = Api::Check(Api::GroupEnd());
+    return first_error != ReturnStatus::kSuccess ? first_error
+                                                 : group_end_status;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SCATTER_H_

--- a/src/backends/ccl/mccl/api.h
+++ b/src/backends/ccl/mccl/api.h
@@ -49,6 +49,20 @@ struct McclApi {
     return mcclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return mcclGroupStart(); }
+
+  static Result GroupEnd() { return mcclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return mcclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/mccl/impl/scatter.h
+++ b/src/backends/ccl/mccl/impl/scatter.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_
+
+#include "backends/ccl/common/impl/scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ScatterImpl<BackendType::kMccl, device>
+    : public CclScatterImpl<BackendType::kMccl, device> {};
+
+template <>
+struct BackendEnabled<Scatter, BackendType::kMccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_MCCL_IMPL_SCATTER_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -46,6 +46,20 @@ struct NcclApi {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
   }
+
+  static Result GroupStart() { return ncclGroupStart(); }
+
+  static Result GroupEnd() { return ncclGroupEnd(); }
+
+  static Result Send(const void *send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void *recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclRecv(recv_buff, count, data_type, peer, comm, stream);
+  }
 };
 
 }  // namespace infini::ccl

--- a/src/backends/ccl/nccl/impl/scatter.h
+++ b/src/backends/ccl/nccl/impl/scatter.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SCATTER_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SCATTER_H_
+
+#include "backends/ccl/common/impl/scatter.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class ScatterImpl<BackendType::kNccl, device>
+    : public CclScatterImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Scatter, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SCATTER_H_

--- a/src/backends/mpi/ompi/impl/scatter.h
+++ b/src/backends/mpi/ompi/impl/scatter.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <limits>
+#include <memory>
 
 #include "backends/mpi/ompi/checks.h"
 #include "backends/mpi/ompi/comm_instance.h"
@@ -24,9 +25,19 @@ class ScatterImpl<BackendType::kOmpi, device_type> {
         ListGetBest<DevicePriority>(ActiveDevices<Scatter>{});
     using Rt = Runtime<kDev>;
 
-    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
-    if (!inst || inst->handle == MPI_COMM_NULL) {
+    if (!comm || !comm->inter_comm() ||
+        comm->inter_comm_backend() != BackendType::kOmpi) {
       LOG("Invalid OpenMPI communicator instance for `Scatter`.");
+      return ReturnStatus::kInternalError;
+    }
+    auto *inst = static_cast<OmpiInstance *>(comm->inter_comm());
+    if (inst->handle == MPI_COMM_NULL) {
+      LOG("Invalid OpenMPI communicator handle for `Scatter`.");
+      return ReturnStatus::kInternalError;
+    }
+    if (comm->size() <= 0 || comm->rank() < 0 || comm->rank() >= comm->size() ||
+        root < 0 || root >= comm->size()) {
+      LOG("Invalid rank, root, or world size for `Scatter`.");
       return ReturnStatus::kInternalError;
     }
 
@@ -36,44 +47,43 @@ class ScatterImpl<BackendType::kOmpi, device_type> {
       return ReturnStatus::kInvalidArgument;
     }
     size_t recv_bytes = count * type_size;
-    size_t send_bytes = recv_bytes * static_cast<size_t>(comm->size());
-    const bool is_root = comm->rank() == root;
-
-    // Transfer raw bytes so the scatter is correct for every data type,
-    // including `kFloat16` / `kBFloat16`, which map to `MPI_BYTE`.
     if (recv_bytes > static_cast<size_t>(std::numeric_limits<int>::max())) {
       LOG("Per-rank byte count exceeds MPI int range for `Scatter`.");
       return ReturnStatus::kInvalidArgument;
     }
+    const size_t world_size = static_cast<size_t>(comm->size());
+    if (recv_bytes > std::numeric_limits<size_t>::max() / world_size) {
+      LOG("Total byte size overflows `size_t` for `Scatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    const size_t send_bytes = recv_bytes * world_size;
+    const bool is_root = comm->rank() == root;
     int mpi_byte_count = static_cast<int>(recv_bytes);
 
-    // Host staging buffers. Only `root` allocates the send side, since
-    // `MPI_Scatter` reads the distributed blocks only from `root`.
-    void *host_sendbuf = is_root ? std::malloc(send_bytes) : nullptr;
-    void *host_recvbuf = std::malloc(recv_bytes);
+    // Transfer raw bytes so movement-only collectives preserve every InfiniCCL
+    // data type, including float16 and bfloat16.
+    std::unique_ptr<void, decltype(&std::free)> host_sendbuf(
+        is_root ? std::malloc(send_bytes) : nullptr, &std::free);
+    std::unique_ptr<void, decltype(&std::free)> host_recvbuf(
+        std::malloc(recv_bytes), &std::free);
     if ((is_root && !host_sendbuf) || !host_recvbuf) {
-      std::free(host_sendbuf);
-      std::free(host_recvbuf);
       LOG("Failed to allocate host buffers for `Scatter` staging.");
       return ReturnStatus::kSystemError;
     }
 
     if (is_root) {
-      CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf, send_buff, send_bytes,
+      CHECK_STATUS(Rt, Rt::Memcpy(host_sendbuf.get(), send_buff, send_bytes,
                                   Rt::MemcpyDeviceToHost));
     }
     CHECK_STATUS(Rt, Rt::StreamSynchronize(static_cast<Rt::Stream>(stream)));
 
     // Note: `MPI_Scatter`'s `sendcount` is the per-rank count, not the total.
-    INFINI_CHECK_MPI(MPI_Scatter(host_sendbuf, mpi_byte_count, MPI_BYTE,
-                                 host_recvbuf, mpi_byte_count, MPI_BYTE, root,
-                                 inst->handle));
+    INFINI_CHECK_MPI(MPI_Scatter(host_sendbuf.get(), mpi_byte_count, MPI_BYTE,
+                                 host_recvbuf.get(), mpi_byte_count, MPI_BYTE,
+                                 root, inst->handle));
 
-    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf, recv_bytes,
+    CHECK_STATUS(Rt, Rt::Memcpy(recv_buff, host_recvbuf.get(), recv_bytes,
                                 Rt::MemcpyHostToDevice));
-
-    std::free(host_sendbuf);
-    std::free(host_recvbuf);
 
     return ReturnStatus::kSuccess;
   }

--- a/src/base/scatter.h
+++ b/src/base/scatter.h
@@ -18,17 +18,20 @@ class Scatter : public Operation<Scatter> {
   static ReturnStatus Execute(const void *send_buff, void *recv_buff,
                               size_t count, DataType datatype, int root,
                               void *comm_handle, void *stream) {
-    if (!comm_handle) {
-      LOG("Invalid communicator handle for `Scatter`.");
-      return ReturnStatus::kInvalidArgument;
-    }
-
-    auto *comm = static_cast<Communicator *>(comm_handle);
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, root, comm)) {
+    if (HasInvalidRequiredArgs(datatype, root, comm_handle)) {
       return ReturnStatus::kInvalidArgument;
     }
     if (count == 0) {
       return ReturnStatus::kSuccess;
+    }
+    auto *comm = static_cast<Communicator *>(comm_handle);
+    if (!recv_buff) {
+      LOG("Invalid receive buffer pointer for `Scatter`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (comm->rank() == root && !send_buff) {
+      LOG("Invalid root send buffer pointer for `Scatter`.");
+      return ReturnStatus::kInvalidArgument;
     }
 
     return ScatterImpl<backend_type, device_type>::Apply(
@@ -36,22 +39,19 @@ class Scatter : public Operation<Scatter> {
   }
 
  private:
-  static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, int root, Communicator *comm) {
+  static bool HasInvalidRequiredArgs(DataType datatype, int root,
+                                     void *comm_handle) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for `Scatter`.");
+      return true;
+    }
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `Scatter`.");
       return true;
     }
+    auto *comm = static_cast<Communicator *>(comm_handle);
     if (root < 0 || root >= comm->size()) {
       LOG("Invalid root rank for `Scatter`.");
-      return true;
-    }
-    if (!recv_buff) {
-      LOG("Invalid receive buffer pointer for `Scatter`.");
-      return true;
-    }
-    if (comm->rank() == root && !send_buff) {
-      LOG("Invalid root send buffer pointer for `Scatter`.");
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary

This PR adds `Scatter` support to the shared CCL backend abstraction by composing provider-native grouped point-to-point operations through the existing NCCL and MCCL layers for the existing public `infinicclScatter()` API. It also keeps inter-only communicators on the existing OpenMPI staging path during mixed-backend bootstrap flows, hardens the shared OpenMPI/MPICH movement path with communicator validation, byte-count and overflow checks, and automatic host-buffer cleanup, defines zero-count behavior, makes the existing MPI example validate every destination block and propagate failures, and includes CCL-only plus OpenMPI-assisted `Scatter` examples with correctness and communication-bandwidth reporting.

## Changes

- **Public API and Dispatch**
  - Enable the existing `infinicclScatter()` API for configured CCL backends through generated bridge dispatch without changing its public signature.
  - Use a matching native CCL intra communicator when available, and otherwise delegate to the existing OpenMPI provider when the communicator has only an OpenMPI inter communicator.
  - Return success for a zero-count `Scatter` after validating the communicator, data type, and root, without requiring non-null buffers or entering a backend.
  - Require a receive buffer on every rank for non-zero operations while requiring the send buffer only on the root rank.

- **Common CCL Implementation**
  - Add a shared provider-oriented CCL `Scatter` implementation using grouped point-to-point operations because the providers do not expose a native `Scatter` collective.
  - Send one distinct rank-ordered block from the root to every rank, including the root, and receive one block from the root on every rank within one provider group.
  - Validate the native communicator backend, device, rank, world size, root, handle, and data type before dispatch.
  - Check per-rank and total byte-size calculations for `size_t` overflow.
  - Preserve the first point-to-point error and always call `GroupEnd` after a successful `GroupStart`.

- **Existing CCL Provider Bindings**
  - Extend the existing NCCL and MCCL API wrappers with `GroupStart`, `GroupEnd`, `Send`, and `Recv` bindings.
  - Register `Scatter` with the existing NCCL and MCCL provider layers without introducing a dependency on a vendor-specific `Scatter` entry point.

- **MPI Correctness and Safety**
  - Treat `Scatter` as a movement operation in the shared OpenMPI/MPICH implementation by using `MPI_BYTE` with `count * type_size` bytes per rank, preserving every data type including `Float16` and `BFloat16`.
  - Add communicator, rank, world-size, MPI `int` count-range, and total-buffer-size validation.
  - Allocate the send staging buffer only on the root and manage all host staging buffers with automatic cleanup across success and error paths.
  - Validate each destination rank's complete receive block in the existing MPI example and exchange validation reports so failures propagate through every process exit code.

- **Examples, Validation, and Metrics**
  - Add a thread-per-GPU single-node CCL `Scatter` example using one shared unique ID and rank-based communicator initialization.
  - Add an OpenMPI-assisted CCL example that first validates the OpenMPI fallback through an inter-only communicator, then initializes a native CCL communicator and validates the grouped point-to-point path.
  - Validate the complete out-of-place rank-specific receive block in all three `Scatter` examples.
  - Report per-rank and root-total data sizes, root-rank average time, algorithm bandwidth as `world_size * rank_bytes / time`, and bus bandwidth as algorithm bandwidth multiplied by `(world_size - 1) / world_size`.
  - Parse numeric inputs without exceptions and guard example buffer-size calculations against overflow.

## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.).
-->

### Platform

- [ ] CPU
- [x] NVIDIA GPU
- [x] Iluvatar GPU
- [x] MetaX GPU
- [x] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [x] MPICH
- [x] NCCL
- [x] MCCL

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

This adds GPU-native NCCL and MCCL paths for `Scatter`, avoiding the existing MPI host-staging path when a supported CCL backend and matching native communicator are available. The native path composes grouped point-to-point operations because neither provider exposes a vendor `Scatter` collective, while the shared MPI fallback remains host-staged with byte-count movement semantics and additional validation and cleanup. Other collective operations are intended to remain unchanged. The validation-log timings below are execution references rather than a quantified cross-backend performance comparison.

## Known Issues & Future Work

- The CCL collective backend on this branch adds `Scatter` alongside the existing `AllReduce`; other independently developed CCL collectives are outside this branch.
- `Scatter` inherits the backend/device combinations and data type support of the existing CCL providers; this PR does not add a new provider or device integration.
- The native CCL path uses grouped point-to-point operations rather than a vendor `Scatter` entry point. The root sends one block per rank while every rank receives once, so root-side work and storage grow linearly with communicator size.
- The server examples validate out-of-place `Float32` payloads with root rank 0 on the default stream. Additional data types, roots, in-place layouts, non-default streams, and runtime coverage on Iluvatar and Moore Threads remain future work.
- The shared OpenMPI/MPICH fallback remains host-staged with per-call allocations and rejects per-rank byte counts above the MPI `int` range; chunked transfers remain future work.

## Test Results

The implementation commit is `baadfba338f4564e0da038c6d74c96033df0e965`, a single commit directly based on `ef4045a2d99837c75c2acd90aae57dacb83172d2`. The attached evidence contains exactly 15 hash-verified canonical logs from the current commit: all 15 targets passed, with `Correct: YES` 17 times and `Correct: NO` 0 times. The extra two positive results are the additional expected validation cases in the broadcast log.

All four `Scatter` paths passed with a 1,048,576-element `Float32` block per rank (4.00 MiB), 2 warm-up iterations, and 20 profiled iterations:

| Path | Test topology | Data per rank / total at root | Time | Alg BW | Bus BW |
|---|---|---:|---:|---:|---:|
| Pure NCCL | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.108 ms | 309.66 GB/s | 270.95 GB/s |
| OpenMPI + NCCL hybrid | 8 NVIDIA A100 GPUs | 4.00 / 32.00 MiB | 0.314 ms | 106.78 GB/s | 93.43 GB/s |
| Heterogeneous OpenMPI | 8 NVIDIA A100 + 8 MetaX C550 GPUs | 4.00 / 64.00 MiB | 62.226 ms | 1.08 GB/s | 1.01 GB/s |
| Pure MCCL | 8 MetaX C550 GPUs | 4.00 / 32.00 MiB | 0.159 ms | 211.10 GB/s | 184.71 GB/s |

The reported times are the root rank's elapsed time averaged over the 20 profiled calls after the 2 warm-up calls. Algorithm bandwidth uses the total bytes scattered by the root, and bus bandwidth applies the `(world_size - 1) / world_size` correction factor. The values were independently recomputed while accounting for the displayed time being rounded to three decimal places. They are included as execution evidence, not as a cross-platform benchmark comparison.

- The pure NCCL and OpenMPI+NCCL configurations each passed both selected targets, 2/2 and 2/2, on all 8 A100 GPUs. The hybrid `Scatter` log also confirms that the OpenMPI fallback passed before the native NCCL communicator was initialized.
- The heterogeneous OpenMPI configuration passed all 9 MPI targets on 16 ranks. Ranks 0-7 mapped to NVIDIA devices 0-7, and ranks 8-15 mapped to MetaX devices 0-7.
- The pure MCCL configuration passed both selected targets on all 8 MetaX C550 GPUs. `Scatter` and the `AllReduce` baseline ran as two independent single-target invocations.
- All five formal invocations returned zero. There were no harness retries, MetaX vendor queue retries, timeouts, missing canonical logs, or recorded finalization errors.

### Test Involved Platform

- [ ] CPU
- [x] NVIDIA GPU
- [ ] Iluvatar GPU
- [x] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [x] OpenMPI
- [ ] MPICH
- [x] NCCL
- [x] MCCL

**Pure CCL (NCCL) on single-node NVIDIA:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345517/ccl_all_reduce.log)
[ccl_scatter.log](https://github.com/user-attachments/files/31345519/ccl_scatter.log)


**CCL + MPI on single-node NVIDIA:**
[ccl_mpi_hybrid_all_reduce.log](https://github.com/user-attachments/files/31345526/ccl_mpi_hybrid_all_reduce.log)
[ccl_mpi_hybrid_scatter.log](https://github.com/user-attachments/files/31345527/ccl_mpi_hybrid_scatter.log)


**MPI on Heterogeneous Cluster:**
[mpi_all_gather.log](https://github.com/user-attachments/files/31345531/mpi_all_gather.log)
[mpi_all_reduce.log](https://github.com/user-attachments/files/31345532/mpi_all_reduce.log)
[mpi_all_to_all.log](https://github.com/user-attachments/files/31345533/mpi_all_to_all.log)
[mpi_broadcast.log](https://github.com/user-attachments/files/31345534/mpi_broadcast.log)
[mpi_gather.log](https://github.com/user-attachments/files/31345535/mpi_gather.log)
[mpi_reduce.log](https://github.com/user-attachments/files/31345536/mpi_reduce.log)
[mpi_reduce_scatter.log](https://github.com/user-attachments/files/31345537/mpi_reduce_scatter.log)
[mpi_scatter.log](https://github.com/user-attachments/files/31345538/mpi_scatter.log)
[mpi_send_recv.log](https://github.com/user-attachments/files/31345539/mpi_send_recv.log)


**Pure CCL (MCCL) on single-node MetaX:**
[ccl_all_reduce.log](https://github.com/user-attachments/files/31345551/ccl_all_reduce.log)
[ccl_scatter.log](https://github.com/user-attachments/files/31345552/ccl_scatter.log)


---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests). <!-- The branch contains one self-contained feature commit. -->
- [x] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`. <!-- The branch contains one commit directly on `ef4045a` and no merge commit. -->
- [x] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [x] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link. <!-- Example output is intentional validation and metrics reporting, not debug output. -->
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests. <!-- No public signature was added or changed; the existing `infinicclScatter()` API gains CCL-backend support. -->

### General Code Hygiene

- [x] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [x] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean. <!-- Verified with clang-format 16.0.6. -->
- [x] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++). <!-- Error paths use the repository's `LOG`/`ReturnStatus` and `CHECK_*` conventions; numeric parsing uses non-throwing `std::from_chars`. -->
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- N/A- Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++). <!-- No constructor initializer list was added or modified. -->
- [x] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [x] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- N/A- Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml). <!-- No Python files changed. -->
- N/A- `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result. <!-- No Python files changed. -->
- N/A- Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python). <!-- No Python files changed. -->
- N/A- A blank line appears **before** each `return`, except when it directly follows a control-flow statement like `if` or `for`. <!-- No Python files changed. -->
- N/A- Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) conventions. <!-- No Python files changed. -->
- N/A- Type hints are added / kept consistent with the surrounding code. <!-- No Python files changed. -->

### Testing

- [x] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup. <!-- The final hash-verified current-commit evidence contains 15/15 passing canonical logs, `Correct: YES` 17 times, and `Correct: NO` 0 times on the full 8-A100 + 8-C550 matrix. -->

### Build, CI, and Tooling

- N/A- New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable. <!-- No backend or device was added. -->
- [x] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI). <!-- clang-format 16.0.6 passes for every modified C++ file; no Python file changed, so Ruff is not applicable. -->

### Documentation

- N/A- `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. <!-- No public signature, build flag, or developer workflow changed; the README has no per-collective backend matrix to update. -->
- N/A- Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. <!-- The change is additive and non-breaking. -->

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- N/A- Third-party code is license-compatible and attributed. <!-- No third-party code was added. -->
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced. <!-- Communicator, rank, root, data-type, per-rank byte-size, and total-size validation occurs before native pointer offsets, staging allocation, or backend dispatch. -->
