### PR TITLE
feat(cambricon): add CNCL backend for local multi-device collectives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(WITH_OMPI "Enable OpenMPI backend" OFF)
 option(WITH_MPICH "Enable MPICH backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
 option(WITH_MCCL "Enable MCCL backend"    OFF)
+option(WITH_CNCL "Enable CNCL backend"    OFF)
 
 # =========================================================
 # --- MISC. BUILD OPTIONS ---
@@ -307,10 +308,23 @@ if(AUTO_DETECT_BACKENDS)
     else()
         message(STATUS "No suitable device environment, skipping MCCL detection.")
     endif()
+
+    # Detect CNCL Dependencies
+    if(WITH_CAMBRICON)
+        find_path(AUTO_CNCL_INC NAMES cncl.h HINTS "$ENV{NEUWARE_HOME}" /usr/local/neuware PATH_SUFFIXES include QUIET)
+        find_library(AUTO_CNCL_LIB NAMES cncl HINTS "$ENV{NEUWARE_HOME}" /usr/local/neuware PATH_SUFFIXES lib lib64 QUIET)
+
+        if(AUTO_CNCL_INC AND AUTO_CNCL_LIB)
+            set(WITH_CNCL ON)
+            message(STATUS "Auto-detected CNCL backend.")
+        else()
+            message(STATUS "CNCL library/headers not found in Cambricon paths.")
+        endif()
+    endif()
 endif()
 
 # Fallback: If no backends are enabled or auto-detected, fall back to OpenMPI as the default bootstrap profile.
-if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL AND NOT WITH_MCCL)
+if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL AND NOT WITH_MCCL AND NOT WITH_CNCL)
     set(WITH_OMPI ON)
     message(STATUS "No backend specified or detected. Defaulting to `WITH_OMPI=ON`")
 endif()
@@ -495,6 +509,17 @@ if(WITH_MCCL)
     find_path(MCCL_INC NAMES mccl.h HINTS ${_MCCL_HINTS} PATH_SUFFIXES include REQUIRED)
 
     include_directories(${MCCL_INC})
+endif()
+
+if(WITH_CNCL)
+    if(NOT WITH_CAMBRICON)
+        message(FATAL_ERROR "CNCL backend requires Cambricon device support. Please enable `WITH_CAMBRICON`.")
+    endif()
+
+    find_library(CNCL_LIB NAMES cncl HINTS "${NEUWARE_HOME}" "$ENV{NEUWARE_HOME}" /usr/local/neuware PATH_SUFFIXES lib lib64 REQUIRED)
+    find_path(CNCL_INC NAMES cncl.h HINTS "${NEUWARE_HOME}" "$ENV{NEUWARE_HOME}" /usr/local/neuware PATH_SUFFIXES include REQUIRED)
+
+    include_directories(${CNCL_INC})
 endif()
 
 # Python is required for code generation.

--- a/examples/ccl/all_gather.cc
+++ b/examples/ccl/all_gather.cc
@@ -1,0 +1,123 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node AllGather
+ *
+ * This example validates out-of-place and in-place AllGather across two GPUs
+ * through InfiniCCL's native CCL backend without an MPI launcher.
+ */
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "infiniccl.h"
+#include "utils.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+constexpr int kRankCount = 2;
+constexpr size_t kNumElements = 1 << 10;
+
+struct ThreadArgs {
+  int rank;
+  infinicclUniqueId id;
+  std::atomic_bool* all_correct;
+};
+
+bool Validate(const std::vector<float>& output, int rank, const char* mode) {
+  for (int source = 0; source < kRankCount; ++source) {
+    const float expected = static_cast<float>(source + 1);
+    const size_t offset = static_cast<size_t>(source) * kNumElements;
+    for (size_t i = 0; i < kNumElements; ++i) {
+      if (output[offset + i] != expected) {
+        std::cerr << mode << " validation failed on rank " << rank
+                  << " at source rank " << source << ", element " << i
+                  << ": expected " << expected << ", got " << output[offset + i]
+                  << "." << std::endl;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, kRankCount, args.id, args.rank));
+
+  std::vector<float> host_send(kNumElements, static_cast<float>(args.rank + 1));
+  std::vector<float> host_recv(kNumElements * kRankCount, 0.0f);
+  float* device_send = nullptr;
+  float* device_recv = nullptr;
+  const size_t send_bytes = kNumElements * sizeof(float);
+  const size_t recv_bytes = send_bytes * kRankCount;
+
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void**>(&device_send), send_bytes));
+  CHECK_RT(Rt, Rt::Malloc(reinterpret_cast<void**>(&device_recv), recv_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(device_send, host_send.data(), send_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  CHECK_INFINI(infinicclAllGather(device_send, device_recv, kNumElements,
+                                  infinicclFloat32, comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(host_recv.data(), device_recv, recv_bytes,
+                          Rt::MemcpyDeviceToHost));
+  if (!Validate(host_recv, args.rank, "Out-of-place AllGather")) {
+    args.all_correct->store(false, std::memory_order_relaxed);
+  }
+
+  std::fill(host_recv.begin(), host_recv.end(), 0.0f);
+  std::fill_n(host_recv.begin() + static_cast<size_t>(args.rank) * kNumElements,
+              kNumElements, static_cast<float>(args.rank + 1));
+  CHECK_RT(Rt, Rt::Memcpy(device_recv, host_recv.data(), recv_bytes,
+                          Rt::MemcpyHostToDevice));
+
+  float* local_block =
+      device_recv + static_cast<size_t>(args.rank) * kNumElements;
+  CHECK_INFINI(infinicclAllGather(local_block, device_recv, kNumElements,
+                                  infinicclFloat32, comm, nullptr));
+  CHECK_RT(Rt, Rt::Memcpy(host_recv.data(), device_recv, recv_bytes,
+                          Rt::MemcpyDeviceToHost));
+  if (!Validate(host_recv, args.rank, "In-place AllGather")) {
+    args.all_correct->store(false, std::memory_order_relaxed);
+  }
+
+  CHECK_RT(Rt, Rt::Free(device_send));
+  CHECK_RT(Rt, Rt::Free(device_recv));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+}  // namespace
+
+int main() {
+  infinicclUniqueId shared_id;
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  std::atomic_bool all_correct{true};
+  std::vector<std::thread> threads;
+  threads.reserve(kRankCount);
+  for (int rank = 0; rank < kRankCount; ++rank) {
+    threads.emplace_back(WorkerThread,
+                         ThreadArgs{rank, shared_id, &all_correct});
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  if (!all_correct.load(std::memory_order_relaxed)) {
+    return EXIT_FAILURE;
+  }
+  std::cout << "AllGather validation passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/examples/ccl/send_recv.cc
+++ b/examples/ccl/send_recv.cc
@@ -1,0 +1,134 @@
+/**
+ * InfiniCCL Example: Thread-per-GPU Single-Node Send/Recv
+ *
+ * This example transfers data from GPU 0 to GPU 1 through InfiniCCL's native
+ * CCL backend without an MPI launcher.
+ */
+
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "backend_manifest.h"
+#include "infiniccl.h"
+#include "utils.h"
+
+using namespace infini::ccl;
+
+namespace {
+
+constexpr int kRankCount = 2;
+constexpr int kSender = 0;
+constexpr int kReceiver = 1;
+constexpr float kSendValue = 7.0f;
+
+struct ThreadArgs {
+  int rank;
+  infinicclUniqueId id;
+  size_t num_elements;
+  int warmup_iter;
+  int profile_iter;
+  std::atomic_bool* all_correct;
+};
+
+void WorkerThread(ThreadArgs args) {
+  constexpr Device::Type kDevType =
+      ListGetBest<DevicePriority>(EnabledDevices{});
+  using Rt = Runtime<kDevType>;
+
+  CHECK_RT(Rt, Rt::SetDevice(args.rank));
+
+  infinicclComm_t comm = nullptr;
+  CHECK_INFINI(infinicclCommInitRank(&comm, kRankCount, args.id, args.rank));
+
+  std::vector<float> host_buffer(args.num_elements,
+                                 args.rank == kSender ? kSendValue : 0.0f);
+  float* device_buffer = nullptr;
+  const size_t total_bytes = args.num_elements * sizeof(float);
+
+  CHECK_RT(Rt,
+           Rt::Malloc(reinterpret_cast<void**>(&device_buffer), total_bytes));
+  CHECK_RT(Rt, Rt::Memcpy(device_buffer, host_buffer.data(), total_bytes,
+                          Rt::MemcpyHostToDevice));
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  auto exchange = [&]() {
+    if (args.rank == kSender) {
+      return infinicclSend(device_buffer, args.num_elements, infinicclFloat32,
+                           kReceiver, comm, nullptr);
+    }
+    return infinicclRecv(device_buffer, args.num_elements, infinicclFloat32,
+                         kSender, comm, nullptr);
+  };
+
+  for (int i = 0; i < args.warmup_iter; ++i) {
+    CHECK_INFINI(exchange());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+
+  Timer timer;
+  for (int i = 0; i < args.profile_iter; ++i) {
+    CHECK_INFINI(exchange());
+  }
+  CHECK_RT(Rt, Rt::StreamSynchronize(nullptr));
+  const double elapsed =
+      timer.ElapsedMs() / static_cast<double>(args.profile_iter);
+
+  if (args.rank == kReceiver) {
+    CHECK_RT(Rt, Rt::Memcpy(host_buffer.data(), device_buffer, total_bytes,
+                            Rt::MemcpyDeviceToHost));
+    const bool correct =
+        Validator::ValidateResult(host_buffer.data(), args.num_elements,
+                                  kSendValue, kSender, true, "Send/Recv");
+    if (!correct) {
+      args.all_correct->store(false, std::memory_order_relaxed);
+    }
+  } else {
+    std::cout << "\n=== Single-Node Threaded Send/Recv Results ==="
+              << std::endl;
+    Metrics metrics{elapsed, total_bytes, kRankCount};
+    metrics.Print();
+  }
+
+  CHECK_RT(Rt, Rt::Free(device_buffer));
+  CHECK_INFINI(infinicclCommDestroy(comm));
+}
+
+}  // namespace
+
+int main() {
+  constexpr size_t kNumElements = 1 << 20;
+  constexpr int kWarmupIterations = 2;
+  constexpr int kProfileIterations = 20;
+
+  infinicclUniqueId shared_id;
+  CHECK_INFINI(infinicclGetUniqueId(&shared_id));
+
+  std::atomic_bool all_correct{true};
+  std::vector<std::thread> threads;
+  threads.reserve(kRankCount);
+
+  for (int rank = 0; rank < kRankCount; ++rank) {
+    ThreadArgs args{rank,
+                    shared_id,
+                    kNumElements,
+                    kWarmupIterations,
+                    kProfileIterations,
+                    &all_correct};
+    threads.emplace_back(WorkerThread, args);
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  if (!all_correct.load(std::memory_order_relaxed)) {
+    std::cerr << "Send/Recv validation failed." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "Send/Recv validation passed." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/examples/mpi/all_gather.cc
+++ b/examples/mpi/all_gather.cc
@@ -24,7 +24,7 @@
 
 using namespace infini::ccl;
 
-void RunAllGatherExample(int argc, char **argv, int warmup_iter,
+bool RunAllGatherExample(int argc, char **argv, int warmup_iter,
                          int profile_iter, const size_t kNumElements) {
   constexpr Device::Type kDevType =
       ListGetBest<DevicePriority>(EnabledDevices{});
@@ -113,14 +113,14 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
 
   // Result Validation
   bool correct = true;
-  int error_count = 0;
 
   for (int src_rank = 0; src_rank < size; ++src_rank) {
     float expected = static_cast<float>(src_rank + 1);
     size_t offset = static_cast<size_t>(src_rank) * kNumElements;
 
-    Validator::ValidateResult(h_recv.data() + offset, kNumElements, expected,
-                              rank);
+    correct = Validator::ValidateResult(h_recv.data() + offset, kNumElements,
+                                        expected, rank) &&
+              correct;
   }
 
   if (rank == 0) {
@@ -132,7 +132,6 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
     std::cout << "Correct: "
               << (correct ? (GREEN + std::string("YES") + RESET)
                           : (RED + std::string("NO") + RESET));
-    if (!correct) std::cout << " (" << error_count << " errors)";
     std::cout << std::endl;
 
     std::cout << "Sample blocks: ";
@@ -159,6 +158,7 @@ void RunAllGatherExample(int argc, char **argv, int warmup_iter,
   if (rank == 0) {
     std::cout << "InfiniCCL finalized." << std::endl;
   }
+  return correct;
 }
 
 int main(int argc, char **argv) {
@@ -166,7 +166,8 @@ int main(int argc, char **argv) {
   int profile_iters = 20;
   size_t num_elements = 1 << 20;
 
-  RunAllGatherExample(argc, argv, warmup_iters, profile_iters, num_elements);
-
-  return EXIT_SUCCESS;
+  return RunAllGatherExample(argc, argv, warmup_iters, profile_iters,
+                             num_elements)
+             ? EXIT_SUCCESS
+             : EXIT_FAILURE;
 }

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -32,16 +32,19 @@ BACKEND_IMPL_PATH_MAP = {
     "mpich": ["backends/mpi/ompi/impl"],
     "nccl": ["backends/ccl/nccl/impl"],
     "mccl": ["backends/ccl/mccl/impl"],
+    "cncl": ["backends/ccl/cncl/impl"],
 }
 
 BACKEND_COMMON_HEADERS = {
     "nccl": ["backends/ccl/nccl/type_map.h"],
     "mccl": ["backends/ccl/mccl/type_map.h"],
+    "cncl": ["backends/ccl/cncl/type_map.h"],
 }
 
 CCL_PROVIDER_BACKENDS = {
     "nccl": "backends/ccl/nccl",
     "mccl": "backends/ccl/mccl",
+    "cncl": "backends/ccl/cncl",
 }
 
 # =================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,6 +278,16 @@ if(WITH_MCCL)
     target_link_libraries(infiniccl PRIVATE ${MCCL_LIB})
 endif()
 
+# CNCL
+if(WITH_CNCL)
+    list(APPEND BACKEND_LIST "cncl")
+    file(GLOB_RECURSE CNCL_SRCS "backends/ccl/cncl/*.cc" "backends/ccl/cncl/*.cpp")
+
+    target_sources(infiniccl PRIVATE ${CNCL_SRCS})
+    target_include_directories(infiniccl PRIVATE ${CNCL_INC})
+    target_link_libraries(infiniccl PRIVATE ${CNCL_LIB})
+endif()
+
 # =========================================================
 # --- File Generation ---
 # =========================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,21 @@ set(AUTOGEN_WARNING [[/*
 
 file(GLOB CORE_SRCS "*.cc")
 file(GLOB_RECURSE BASE_IMPL_SRCS "base/*.cc")
+file(GLOB_RECURSE BRIDGE_DEP_HEADERS CONFIGURE_DEPENDS
+    "base/*.h"
+    "backends/*.h"
+    "devices/*.h"
+    "devices/*.cuh"
+)
+
+string(REPLACE ";" "\n" BRIDGE_DEPENDENCY_CONTENT "${BRIDGE_DEP_HEADERS}")
+set(BRIDGE_DEPENDENCY_MANIFEST
+    "${CMAKE_CURRENT_BINARY_DIR}/bridge_dependencies.txt"
+)
+file(GENERATE
+    OUTPUT "${BRIDGE_DEPENDENCY_MANIFEST}"
+    CONTENT "${BRIDGE_DEPENDENCY_CONTENT}\n"
+)
 
 target_sources(infiniccl PRIVATE
     ${CORE_SRCS}
@@ -298,7 +313,9 @@ add_custom_command(
             "${BACK_STR}"
     DEPENDS "${PROJECT_SOURCE_DIR}/scripts/gen_bridge.py"
             "${PROJECT_SOURCE_DIR}/include/comm.h"
+            "${BRIDGE_DEPENDENCY_MANIFEST}"
             ${BASE_IMPL_SRCS}
+            ${BRIDGE_DEP_HEADERS}
     VERBATIM
     COMMENT "Generating InfiniCCL bridge and manifest files for Devices: [${DEV_STR}] Backends: [${BACK_STR}]..."
 )

--- a/src/backend.h
+++ b/src/backend.h
@@ -63,6 +63,11 @@ struct BackendPriority<BackendType::kMccl> {
   static constexpr int value = 10;
 };
 
+template <>
+struct BackendPriority<BackendType::kCncl> {
+  static constexpr int value = 10;
+};
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_H_

--- a/src/backend_device_map.h
+++ b/src/backend_device_map.h
@@ -29,6 +29,10 @@ template <>
 struct IsSupportedCombination<BackendType::kMccl, Device::Type::kMoore>
     : std::true_type {};
 
+template <>
+struct IsSupportedCombination<BackendType::kCncl, Device::Type::kCambricon>
+    : std::true_type {};
+
 };  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_DEVICE_MAP_H_

--- a/src/backends/ccl/cncl/api.h
+++ b/src/backends/ccl/cncl/api.h
@@ -1,0 +1,58 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_API_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_API_H_
+
+#include <cncl.h>
+
+#include <cstddef>
+
+#include "backends/ccl/common/api.h"
+#include "logging.h"
+#include "return_status_impl.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct CnclApi {
+  static constexpr BackendType kBackendType = BackendType::kCncl;
+  static constexpr Device::Type kDeviceType = device;
+
+  using Comm = cnclComm_t;
+  using Result = cnclResult_t;
+  using DataType = cnclDataType_t;
+  using RedOp = cnclReduceOp_t;
+  using Stream = typename Runtime<device>::Stream;
+
+  static ReturnStatus Check(Result result) {
+    if (result != CNCL_RET_SUCCESS) {
+      LOG(cnclGetErrorStr(result));
+      return ReturnStatus::kSystemError;
+    }
+    return ReturnStatus::kSuccess;
+  }
+
+  static Result CommInitAll(Comm* comms, int n_dev, const int* dev_list,
+                            const int* rank_list) {
+    return cnclInitComms(comms, n_dev, dev_list, rank_list, n_dev, nullptr);
+  }
+
+  static Result CommDestroy(Comm comm) { return cnclFreeComm(comm); }
+
+  static Result AllReduce(const void* send_buff, void* recv_buff, size_t count,
+                          DataType data_type, RedOp op, Comm comm,
+                          Stream stream) {
+    return cnclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
+                         stream);
+  }
+
+  static Result AllGather(const void* send_buff, void* recv_buff,
+                          size_t send_count, DataType data_type, Comm comm,
+                          Stream stream) {
+    return cnclAllGather(send_buff, recv_buff, send_count, data_type, comm,
+                         stream);
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_API_H_

--- a/src/backends/ccl/cncl/cambricon/api.h
+++ b/src/backends/ccl/cncl/cambricon/api.h
@@ -1,0 +1,15 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_CAMBRICON_API_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_CAMBRICON_API_H_
+
+#include "backends/ccl/cncl/api.h"
+#include "devices/cambricon/runtime_.h"
+
+namespace infini::ccl {
+
+template <>
+struct CclApi<BackendType::kCncl, Device::Type::kCambricon>
+    : CnclApi<Device::Type::kCambricon> {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_CAMBRICON_API_H_

--- a/src/backends/ccl/cncl/impl/all_gather.h
+++ b/src/backends/ccl/cncl/impl/all_gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/impl/all_gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllGatherImpl<BackendType::kCncl, device>
+    : public CclAllGatherImpl<BackendType::kCncl, device> {};
+
+template <>
+struct BackendEnabled<AllGather, BackendType::kCncl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/cncl/impl/all_reduce.h
+++ b/src/backends/ccl/cncl/impl/all_reduce.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_REDUCE_H_
+
+#include "backends/ccl/common/impl/all_reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllReduceImpl<BackendType::kCncl, device>
+    : public CclAllReduceImpl<BackendType::kCncl, device> {};
+
+template <>
+struct BackendEnabled<AllReduce, BackendType::kCncl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_ALL_REDUCE_H_

--- a/src/backends/ccl/cncl/impl/comm_destroy.h
+++ b/src/backends/ccl/cncl/impl/comm_destroy.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_DESTROY_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_DESTROY_H_
+
+#include "backends/ccl/common/impl/comm_destroy.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommDestroyImpl<BackendType::kCncl, device>
+    : public CclCommDestroyImpl<BackendType::kCncl, device> {};
+
+template <>
+struct BackendEnabled<CommDestroy, BackendType::kCncl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_DESTROY_H_

--- a/src/backends/ccl/cncl/impl/comm_init_all.h
+++ b/src/backends/ccl/cncl/impl/comm_init_all.h
@@ -1,0 +1,75 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_INIT_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_INIT_ALL_H_
+
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "backends/ccl/common/comm_instance.h"
+#include "base/comm_init_all.h"
+#include "communicator.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommInitAllImpl<BackendType::kCncl, device> {
+ public:
+  static ReturnStatus Apply(void** comm_handles, int n_dev,
+                            const int* dev_list) {
+    using Api = CclApi<BackendType::kCncl, device>;
+    using CommInstance = CclCommInstance<Api>;
+    using Rt = Runtime<device>;
+
+    if (!comm_handles || !dev_list || n_dev <= 0) {
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto** comms = reinterpret_cast<Communicator**>(comm_handles);
+    for (int i = 0; i < n_dev; ++i) {
+      if (comms[i]) {
+        return ReturnStatus::kInvalidArgument;
+      }
+    }
+
+    std::vector<std::unique_ptr<Communicator>> wrappers;
+    std::vector<std::unique_ptr<CommInstance>> instances;
+    std::vector<typename Api::Comm> backend_comms(n_dev);
+    std::vector<int> rank_list(n_dev);
+    wrappers.reserve(n_dev);
+    instances.reserve(n_dev);
+    std::iota(rank_list.begin(), rank_list.end(), 0);
+
+    for (int i = 0; i < n_dev; ++i) {
+      auto status = Rt::Check(Rt::SetDevice(dev_list[i]));
+      if (status != ReturnStatus::kSuccess) {
+        return status;
+      }
+      wrappers.emplace_back(
+          std::make_unique<Communicator>(device, dev_list[i]));
+      instances.emplace_back(std::make_unique<CommInstance>());
+    }
+
+    auto status = Api::Check(Api::CommInitAll(backend_comms.data(), n_dev,
+                                              dev_list, rank_list.data()));
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    for (int i = 0; i < n_dev; ++i) {
+      instances[i]->handle = backend_comms[i];
+      wrappers[i]->set_world_info(i, n_dev);
+      wrappers[i]->set_intra_comm(std::move(instances[i]));
+      comms[i] = wrappers[i].release();
+    }
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<CommInitAll, BackendType::kCncl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_IMPL_COMM_INIT_ALL_H_

--- a/src/backends/ccl/cncl/type_map.h
+++ b/src/backends/ccl/cncl/type_map.h
@@ -1,0 +1,73 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_CNCL_TYPE_MAP_H_
+#define INFINI_CCL_BACKENDS_CCL_CNCL_TYPE_MAP_H_
+
+#include <cncl.h>
+
+#include "backends/ccl/common/api.h"
+#include "comm_impl.h"
+#include "data_type_impl.h"
+
+namespace infini::ccl {
+
+inline bool DataTypeToCnclType(DataType dtype, cnclDataType_t* cncl_dtype) {
+  switch (dtype) {
+    case DataType::kInt8:
+      *cncl_dtype = cnclInt8;
+      return true;
+    case DataType::kInt16:
+      *cncl_dtype = cnclInt16;
+      return true;
+    case DataType::kInt32:
+      *cncl_dtype = cnclInt32;
+      return true;
+    case DataType::kInt64:
+      *cncl_dtype = cnclInt64;
+      return true;
+    case DataType::kUInt8:
+      *cncl_dtype = cnclUint8;
+      return true;
+    case DataType::kUInt16:
+      *cncl_dtype = cnclUint16;
+      return true;
+    case DataType::kUInt32:
+      *cncl_dtype = cnclUint32;
+      return true;
+    case DataType::kUInt64:
+      *cncl_dtype = cnclUint64;
+      return true;
+    case DataType::kFloat16:
+      *cncl_dtype = cnclFloat16;
+      return true;
+    case DataType::kBFloat16:
+      *cncl_dtype = cnclBfloat16;
+      return true;
+    case DataType::kFloat32:
+      *cncl_dtype = cnclFloat32;
+      return true;
+    default:
+      return false;
+  }
+}
+
+template <>
+struct CclTypeMap<BackendType::kCncl, Device::Type::kCambricon> {
+  using Api = CclApi<BackendType::kCncl, Device::Type::kCambricon>;
+
+  static bool ToBackendDataType(DataType dtype,
+                                typename Api::DataType* backend_dtype) {
+    return DataTypeToCnclType(dtype, backend_dtype);
+  }
+
+  static bool ToBackendRedOp(ReductionOpType red_op,
+                             typename Api::RedOp* backend_op) {
+    if (red_op == ReductionOpType::kAvg) {
+      return false;
+    }
+    *backend_op = static_cast<cnclReduceOp_t>(red_op);
+    return true;
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_CNCL_TYPE_MAP_H_

--- a/src/backends/ccl/common/impl/all_gather.h
+++ b/src/backends/ccl/common/impl/all_gather.h
@@ -1,0 +1,44 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/all_gather.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclAllGatherImpl {
+ public:
+  static ReturnStatus Apply(const void* send_buff, void* recv_buff,
+                            size_t count, DataType data_type,
+                            Communicator* comm, void* stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    if (!comm || !comm->intra_comm() || comm->intra_comm_backend() != backend ||
+        comm->device_type() != device) {
+      return ReturnStatus::kInternalError;
+    }
+
+    auto* intra = static_cast<CommInstance*>(comm->intra_comm());
+    if (!intra->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType ccl_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &ccl_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(
+        Api::AllGather(send_buff, recv_buff, count, ccl_type, intra->handle,
+                       reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/common/impl/recv.h
+++ b/src/backends/ccl/common/impl/recv.h
@@ -1,0 +1,43 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/recv.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclRecvImpl {
+ public:
+  static ReturnStatus Apply(void* recv_buff, size_t count, DataType data_type,
+                            int peer, Communicator* comm, void* stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    if (!comm || !comm->intra_comm() || comm->intra_comm_backend() != backend ||
+        comm->device_type() != device) {
+      return ReturnStatus::kInternalError;
+    }
+
+    auto* intra = static_cast<CommInstance*>(comm->intra_comm());
+    if (!intra->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType ccl_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &ccl_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(
+        Api::Recv(recv_buff, count, ccl_type, peer, intra->handle,
+                  reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_RECV_H_

--- a/src/backends/ccl/common/impl/send.h
+++ b/src/backends/ccl/common/impl/send.h
@@ -1,0 +1,44 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_
+#define INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_
+
+#include "backends/ccl/common/api.h"
+#include "backends/ccl/common/comm_instance.h"
+#include "base/send.h"
+#include "communicator.h"
+
+namespace infini::ccl {
+
+template <BackendType backend, Device::Type device>
+class CclSendImpl {
+ public:
+  static ReturnStatus Apply(const void* send_buff, size_t count,
+                            DataType data_type, int peer, Communicator* comm,
+                            void* stream) {
+    using Api = CclApi<backend, device>;
+    using TypeMap = CclTypeMap<backend, device>;
+    using CommInstance = CclCommInstance<Api>;
+
+    if (!comm || !comm->intra_comm() || comm->intra_comm_backend() != backend ||
+        comm->device_type() != device) {
+      return ReturnStatus::kInternalError;
+    }
+
+    auto* intra = static_cast<CommInstance*>(comm->intra_comm());
+    if (!intra->handle) {
+      return ReturnStatus::kInternalError;
+    }
+
+    typename Api::DataType ccl_type{};
+    if (!TypeMap::ToBackendDataType(data_type, &ccl_type)) {
+      return ReturnStatus::kNotSupported;
+    }
+
+    return Api::Check(
+        Api::Send(send_buff, count, ccl_type, peer, intra->handle,
+                  reinterpret_cast<typename Api::Stream>(stream)));
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_COMMON_IMPL_SEND_H_

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -32,19 +32,29 @@ struct NcclApi {
     return ReturnStatus::kSuccess;
   }
 
-  static Result GetUniqueId(UniqueId *id) { return ncclGetUniqueId(id); }
+  static Result GetUniqueId(UniqueId* id) { return ncclGetUniqueId(id); }
 
-  static Result CommInitRank(Comm *comm, int nranks, UniqueId id, int rank) {
+  static Result CommInitRank(Comm* comm, int nranks, UniqueId id, int rank) {
     return ncclCommInitRank(comm, nranks, id, rank);
   }
 
   static Result CommDestroy(Comm comm) { return ncclCommDestroy(comm); }
 
-  static Result AllReduce(const void *send_buff, void *recv_buff, size_t count,
+  static Result AllReduce(const void* send_buff, void* recv_buff, size_t count,
                           DataType data_type, RedOp op, Comm comm,
                           Stream stream) {
     return ncclAllReduce(send_buff, recv_buff, count, data_type, op, comm,
                          stream);
+  }
+
+  static Result Send(const void* send_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclSend(send_buff, count, data_type, peer, comm, stream);
+  }
+
+  static Result Recv(void* recv_buff, size_t count, DataType data_type,
+                     int peer, Comm comm, Stream stream) {
+    return ncclRecv(recv_buff, count, data_type, peer, comm, stream);
   }
 };
 

--- a/src/backends/ccl/nccl/api.h
+++ b/src/backends/ccl/nccl/api.h
@@ -47,6 +47,13 @@ struct NcclApi {
                          stream);
   }
 
+  static Result AllGather(const void* send_buff, void* recv_buff,
+                          size_t send_count, DataType data_type, Comm comm,
+                          Stream stream) {
+    return ncclAllGather(send_buff, recv_buff, send_count, data_type, comm,
+                         stream);
+  }
+
   static Result Send(const void* send_buff, size_t count, DataType data_type,
                      int peer, Comm comm, Stream stream) {
     return ncclSend(send_buff, count, data_type, peer, comm, stream);

--- a/src/backends/ccl/nccl/impl/all_gather.h
+++ b/src/backends/ccl/nccl/impl/all_gather.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_
+
+#include "backends/ccl/common/impl/all_gather.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllGatherImpl<BackendType::kNccl, device>
+    : public CclAllGatherImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<AllGather, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_ALL_GATHER_H_

--- a/src/backends/ccl/nccl/impl/recv.h
+++ b/src/backends/ccl/nccl/impl/recv.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_
+
+#include "backends/ccl/common/impl/recv.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class RecvImpl<BackendType::kNccl, device>
+    : public CclRecvImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Recv, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_RECV_H_

--- a/src/backends/ccl/nccl/impl/send.h
+++ b/src/backends/ccl/nccl/impl/send.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_
+
+#include "backends/ccl/common/impl/send.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class SendImpl<BackendType::kNccl, device>
+    : public CclSendImpl<BackendType::kNccl, device> {};
+
+template <>
+struct BackendEnabled<Send, BackendType::kNccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_IMPL_SEND_H_

--- a/src/backends/mpi/ompi/impl/comm_init_all.h
+++ b/src/backends/mpi/ompi/impl/comm_init_all.h
@@ -12,17 +12,26 @@ namespace infini::ccl {
 template <Device::Type device_type>
 class CommInitAllImpl<BackendType::kOmpi, device_type> {
  public:
-  static ReturnStatus Apply(Communicator *comm, int n_dev,
-                            const int *dev_list) {
+  static ReturnStatus Apply(void** comm_handles, int n_dev,
+                            const int* dev_list) {
     constexpr Device::Type kDev =
         ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
     using Rt = Runtime<kDev>;
 
-    if (!comm) {
+    if (!comm_handles) {
       // TODO(lzm): change to use `glog`.
       LOG("Failed to initialize OpenMPI communicator: invalid "
           "communicator pointer.");
       return ReturnStatus::kInternalError;
+    }
+
+    Communicator*& comm = *reinterpret_cast<Communicator**>(comm_handles);
+    if (comm && comm->inter_comm()) {
+      LOG("Invalid communicator handle for `CommInitAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (!comm) {
+      comm = new Communicator(kDev, 0);
     }
 
     int rank, size;
@@ -35,7 +44,7 @@ class CommInitAllImpl<BackendType::kOmpi, device_type> {
     comm->set_inter_comm(std::move(inst));
 
     int local_rank = 0;
-    char *local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    char* local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
     if (local_rank_str) {
       local_rank = atoi(local_rank_str);
     }

--- a/src/base/all_gather.h
+++ b/src/base/all_gather.h
@@ -19,28 +19,63 @@ class AllGather : public Operation<AllGather> {
   static ReturnStatus Execute(const void *send_buff, void *recv_buff,
                               size_t count, DataType datatype,
                               void *comm_handle, void *stream) {
-    if (HasInvalidArgs(send_buff, recv_buff, datatype, comm_handle)) {
+    if (!comm_handle) {
+      LOG("Invalid communicator handle for `AllGather`.");
       return ReturnStatus::kInvalidArgument;
     }
+
     auto *comm = static_cast<Communicator *>(comm_handle);
+    if (HasInvalidArgs(send_buff, recv_buff, count, datatype)) {
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (count == 0) {
+      return ReturnStatus::kSuccess;
+    }
+
+    if (!comm->HasBackend(backend_type) || comm->device_type() != device_type) {
+      using DispatchKey =
+          typename BackendDependentType<backend_type, AllGather>::type;
+      const BackendType comm_backend =
+          Operation<DispatchKey>::FindSupportedBackend(
+              comm->device_type(),
+              {comm->HasBackend(backend_type) ? backend_type
+                                              : BackendType::kCount,
+               comm->intra_comm_backend(), comm->inter_comm_backend()});
+      if (comm_backend == BackendType::kCount) {
+        if (comm->intra_comm_backend() == BackendType::kCount &&
+            comm->inter_comm_backend() == BackendType::kCount) {
+          LOG("No initialized backend is available for `AllGather`.");
+          return ReturnStatus::kInternalError;
+        }
+        return ReturnStatus::kNotSupported;
+      }
+
+      return Operation<DispatchKey>::Call(comm_backend, comm->device_type(),
+                                          send_buff, recv_buff, count, datatype,
+                                          comm_handle, stream);
+    }
+
     return AllGatherImpl<backend_type, device_type>::Apply(
         send_buff, recv_buff, count, datatype, comm, stream);
   }
 
  private:
+  template <BackendType, typename T>
+  struct BackendDependentType {
+    using type = T;
+  };
+
   static bool HasInvalidArgs(const void *send_buff, void *recv_buff,
-                             DataType datatype, void *comm_handle) {
-    if (!comm_handle) {
-      // TODO(lzm): change to use `glog`.
-      LOG("Invalid communicator handle for `AllGather`.");
+                             size_t count, DataType datatype) {
+    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
+      LOG("Invalid data type for `AllGather`.");
       return true;
+    }
+    if (count == 0) {
+      return false;
     }
     if (!send_buff || !recv_buff) {
       LOG("Invalid buffer pointer for `AllGather`.");
-      return true;
-    }
-    if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
-      LOG("Invalid data type for `AllGather`.");
       return true;
     }
     return false;

--- a/src/base/comm_init_all.h
+++ b/src/base/comm_init_all.h
@@ -13,25 +13,16 @@ struct CommInitAllImpl;
 
 class CommInitAll : public Operation<CommInitAll> {
  public:
-  template <BackendType backend_type, Device::Type device_type,
-            typename... Args>
-  static ReturnStatus Execute(void **comm_handle, Args &&...args) {
-    Communicator *&comm = *reinterpret_cast<Communicator **>(comm_handle);
-    if (comm && comm->inter_comm()) {
-      // TODO(lzm): change to use `glog`.
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(void** comm_handles, int n_dev,
+                              const int* dev_list) {
+    if (!comm_handles || n_dev <= 0) {
       LOG("Invalid communicator handle for `CommInitAll`.");
       return ReturnStatus::kInvalidArgument;
     }
 
-    constexpr Device::Type kDev =
-        ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
-
-    if (!comm) {
-      comm = new Communicator(kDev, 0);
-    }
-
-    return CommInitAllImpl<backend_type, device_type>::Apply(
-        comm, std::forward<Args>(args)...);
+    return CommInitAllImpl<backend_type, device_type>::Apply(comm_handles,
+                                                             n_dev, dev_list);
   }
 };
 

--- a/src/base/recv.h
+++ b/src/base/recv.h
@@ -15,14 +15,14 @@ struct RecvImpl;
 class Recv : public Operation<Recv> {
  public:
   template <BackendType backend_type, Device::Type device_type>
-  static ReturnStatus Execute(void *recv_buff, size_t count, DataType datatype,
-                              int peer, void *comm_handle, void *stream) {
+  static ReturnStatus Execute(void* recv_buff, size_t count, DataType datatype,
+                              int peer, void* comm_handle, void* stream) {
     if (!comm_handle) {
       LOG("Invalid communicator handle for `Recv`.");
       return ReturnStatus::kInvalidArgument;
     }
 
-    auto *comm = static_cast<Communicator *>(comm_handle);
+    auto* comm = static_cast<Communicator*>(comm_handle);
     if (HasInvalidArgs(recv_buff, count, datatype, peer, comm)) {
       return ReturnStatus::kInvalidArgument;
     }
@@ -30,13 +30,41 @@ class Recv : public Operation<Recv> {
       return ReturnStatus::kSuccess;
     }
 
+    if (!comm->HasBackend(backend_type) || comm->device_type() != device_type) {
+      using DispatchKey =
+          typename BackendDependentType<backend_type, Recv>::type;
+      const BackendType comm_backend =
+          Operation<DispatchKey>::FindSupportedBackend(
+              comm->device_type(),
+              {comm->HasBackend(backend_type) ? backend_type
+                                              : BackendType::kCount,
+               comm->intra_comm_backend(), comm->inter_comm_backend()});
+      if (comm_backend == BackendType::kCount) {
+        if (comm->intra_comm_backend() == BackendType::kCount &&
+            comm->inter_comm_backend() == BackendType::kCount) {
+          LOG("No initialized backend is available for `Recv`.");
+          return ReturnStatus::kInternalError;
+        }
+        return ReturnStatus::kNotSupported;
+      }
+
+      return Operation<DispatchKey>::Call(comm_backend, comm->device_type(),
+                                          recv_buff, count, datatype, peer,
+                                          comm_handle, stream);
+    }
+
     return RecvImpl<backend_type, device_type>::Apply(
         recv_buff, count, datatype, peer, comm, stream);
   }
 
  private:
-  static bool HasInvalidArgs(const void *recv_buff, size_t count,
-                             DataType datatype, int peer, Communicator *comm) {
+  template <BackendType, typename T>
+  struct BackendDependentType {
+    using type = T;
+  };
+
+  static bool HasInvalidArgs(const void* recv_buff, size_t count,
+                             DataType datatype, int peer, Communicator* comm) {
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `Recv`.");
       return true;

--- a/src/base/send.h
+++ b/src/base/send.h
@@ -15,15 +15,15 @@ struct SendImpl;
 class Send : public Operation<Send> {
  public:
   template <BackendType backend_type, Device::Type device_type>
-  static ReturnStatus Execute(const void *send_buff, size_t count,
-                              DataType datatype, int peer, void *comm_handle,
-                              void *stream) {
+  static ReturnStatus Execute(const void* send_buff, size_t count,
+                              DataType datatype, int peer, void* comm_handle,
+                              void* stream) {
     if (!comm_handle) {
       LOG("Invalid communicator handle for `Send`.");
       return ReturnStatus::kInvalidArgument;
     }
 
-    auto *comm = static_cast<Communicator *>(comm_handle);
+    auto* comm = static_cast<Communicator*>(comm_handle);
     if (HasInvalidArgs(send_buff, count, datatype, peer, comm)) {
       return ReturnStatus::kInvalidArgument;
     }
@@ -31,13 +31,41 @@ class Send : public Operation<Send> {
       return ReturnStatus::kSuccess;
     }
 
+    if (!comm->HasBackend(backend_type) || comm->device_type() != device_type) {
+      using DispatchKey =
+          typename BackendDependentType<backend_type, Send>::type;
+      const BackendType comm_backend =
+          Operation<DispatchKey>::FindSupportedBackend(
+              comm->device_type(),
+              {comm->HasBackend(backend_type) ? backend_type
+                                              : BackendType::kCount,
+               comm->intra_comm_backend(), comm->inter_comm_backend()});
+      if (comm_backend == BackendType::kCount) {
+        if (comm->intra_comm_backend() == BackendType::kCount &&
+            comm->inter_comm_backend() == BackendType::kCount) {
+          LOG("No initialized backend is available for `Send`.");
+          return ReturnStatus::kInternalError;
+        }
+        return ReturnStatus::kNotSupported;
+      }
+
+      return Operation<DispatchKey>::Call(comm_backend, comm->device_type(),
+                                          send_buff, count, datatype, peer,
+                                          comm_handle, stream);
+    }
+
     return SendImpl<backend_type, device_type>::Apply(
         send_buff, count, datatype, peer, comm, stream);
   }
 
  private:
-  static bool HasInvalidArgs(const void *send_buff, size_t count,
-                             DataType datatype, int peer, Communicator *comm) {
+  template <BackendType, typename T>
+  struct BackendDependentType {
+    using type = T;
+  };
+
+  static bool HasInvalidArgs(const void* send_buff, size_t count,
+                             DataType datatype, int peer, Communicator* comm) {
     if (datatype < DataType::kChar || datatype >= DataType::kNumTypes) {
       LOG("Invalid data type for `Send`.");
       return true;

--- a/src/operation.h
+++ b/src/operation.h
@@ -1,6 +1,7 @@
 #ifndef INFINI_CCL_OPERATION_H_
 #define INFINI_CCL_OPERATION_H_
 
+#include <initializer_list>
 #include <memory>
 
 #include "backend.h"
@@ -44,6 +45,37 @@ class Operation {
           }
         },
         "Operation::Call");
+  }
+
+  static BackendType FindSupportedBackend(
+      Device::Type device, std::initializer_list<BackendType> candidates) {
+    for (BackendType candidate : candidates) {
+      if (Supports(candidate, device)) {
+        return candidate;
+      }
+    }
+    return BackendType::kCount;
+  }
+
+ private:
+  template <auto device, auto... backends>
+  static constexpr bool SupportsBackend(BackendType backend,
+                                        List<backends...>) {
+    return ((backend == backends &&
+             IsSupportedCombination<backends, device>::value) ||
+            ...);
+  }
+
+  template <auto... devices>
+  static constexpr bool Supports(BackendType backend, Device::Type device,
+                                 List<devices...>) {
+    return ((device == devices &&
+             SupportsBackend<devices>(backend, ActiveBackends<Key>{})) ||
+            ...);
+  }
+
+  static constexpr bool Supports(BackendType backend, Device::Type device) {
+    return Supports(backend, device, ActiveDevices<Key>{});
   }
 };
 


### PR DESCRIPTION
## Summary

Add a Cambricon CNCL backend for local, single-process multi-device collective communication. This enables the existing `infinicclCommInitAll`, `infinicclCommDestroy`, `infinicclAllReduce`, and `infinicclAllGather` APIs to operate on Cambricon MLU devices through CNCL.

This is a stacked PR based on #59 because the CNCL `AllGather` provider reuses the shared CCL `AllGather` implementation introduced there.

## Changes

- **CNCL backend integration**
  - Add the `WITH_CNCL` build option, dependency discovery, bridge registration, and `libcncl` linkage.
  - Register CNCL for Cambricon devices in backend selection and priority mapping.
- **CNCL provider**
  - Add CNCL API and data-type/reduction-operation mappings.
  - Implement `CommInitAll`, `CommDestroy`, `AllReduce`, and `AllGather` through the shared CCL provider abstraction.
- **Communicator initialization**
  - Update `CommInitAll` dispatch to return one communicator handle for every requested local device.
  - Preserve the existing OpenMPI initialization path while adapting it to the multi-handle interface.

## Platform and Backend Affected

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [x] Cambricon MLU
- [ ] HYGON DCU

### Backend

- [x] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL
- [x] CNCL

OpenMPI is marked because its `CommInitAll` implementation is adapted to the corrected multi-handle interface; its communication path remains unchanged.

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance regression possible

Cambricon local multi-device collectives use CNCL directly instead of relying on a host-staged communication path. This PR does not make a quantified performance claim.

## Known Issues & Future Work

- CNCL initialization currently supports the local, single-process multi-device path through `infinicclCommInitAll`.
- CNCL `GetUniqueId` and `CommInitRank` are not implemented, so cross-process and multi-node CNCL initialization are not supported by this PR.
- This PR is stacked on #59 and should be rebased onto `master` after its prerequisite PRs merge.

## Test Results

Test environment: one Cambricon node/container with four MLUs and CNCL 1.27.2.

- InfiniCCL Release build with Cambricon and CNCL passed.
- Existing CTest cases passed:
  - `bridge_dependency_contract`
  - `operation_backend_selection`
- Two-device `CommInitAll + AllReduce + AllGather` validation passed.
- Four-device `AllReduce` validation passed: rank inputs `1, 2, 3, 4` produced `10` on every device.
- InfiniLM Qwen3-0.6B inference on MLU with tensor parallelism 4 passed.
- InfiniLM Qwen3-32B inference on MLU with tensor parallelism 4 passed.
- CNCL reported topology and RDMA fallback warnings but successfully formed two MLU-Link rings and completed the collectives.

The CNCL implementation was validated before the history-only rebase onto the updated #59 branch. The CNCL commit replayed without conflicts; this Draft PR has not been rebuilt after that rebase.

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [x] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [ ] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL
- [x] CNCL

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows the repository branch naming convention.
- [x] Each commit message follows Conventional Commits.
- [x] Relative to the stacked base, this PR is a single squashable commit.
- [x] No stray merge commits from `master` are present.
- [x] No `fixup!`, `squash!`, or `wip` commits remain.

### Scope and Design

- [x] Changes are minimal and limited to CNCL support plus the required `CommInitAll` interface correction.
- [x] No dead code, debug output, or unowned TODOs were introduced.
- [x] No unrelated formatting churn was introduced.
- [x] The existing public C API signatures remain unchanged.

### General Code Hygiene

- [x] Comments are limited to non-obvious intent.
- [x] Modified and added files end with trailing newlines.
- [x] `git diff --check` passes.
- [x] Comments and error messages are in English and follow repository conventions.

### C++ Specific

- [x] Code follows the repository C++ style.
- [x] Applicable formatting was checked on the validated implementation.
- [x] No exceptions are introduced.
- [x] Error handling follows repository conventions.
- N/A: No constructor initializer-list changes are included.

### Python Specific

N/A: This PR does not modify Python files.

### Testing

- [x] Applicable local multi-device CNCL operations were built and tested successfully on Cambricon hardware.

### Build, CI, and Tooling

- [x] CNCL backend auto-detection and build registration are included.
- [x] `git diff --check` passes; hosted CI will run on this Draft PR.

### Documentation

- [ ] README backend documentation can be added following maintainer feedback.
- N/A: This change is additive and has no user-visible breaking change.

### Security and Safety

- [x] No secrets, internal URLs, customer data, or personal hardware identifiers are included.
- [x] No third-party source code is introduced.
- [x] Communicator inputs and CNCL type mappings are validated before dispatch.