### PR TITLE
feat(ascend): add HCCL backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(WITH_ILUVATAR    "Enable ILUVATAR GPU support"   OFF)
 option(WITH_METAX       "Enable MetaX GPU support"      OFF)
 option(WITH_MOORE       "Enable Moore GPU support"      OFF)
 option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
+option(WITH_ASCEND      "Enable Ascend NPU support"     OFF)
 option(WITH_HYGON       "Enable Hygon DCU support"      OFF)
 
 set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
@@ -23,6 +24,7 @@ option(WITH_OMPI "Enable OpenMPI backend" OFF)
 option(WITH_MPICH "Enable MPICH backend" OFF)
 option(WITH_NCCL "Enable NCCL backend"    OFF)
 option(WITH_MCCL "Enable MCCL backend"    OFF)
+option(WITH_HCCL "Enable HCCL backend"    OFF)
 
 # =========================================================
 # --- MISC. BUILD OPTIONS ---
@@ -178,6 +180,35 @@ if(AUTO_DETECT_DEVICES)
         message(STATUS "Cambricon environment not detected.")
     endif()
 
+    # Ascend
+    set(ASCEND_FOUND FALSE)
+
+    if(DEFINED ENV{ASCEND_HOME_PATH} OR DEFINED ENV{ASCEND_TOOLKIT_HOME} OR DEFINED ENV{ASCEND_HOME})
+        set(ASCEND_FOUND TRUE)
+    elseif(EXISTS "/dev/davinci0" OR EXISTS "/dev/davinci_manager")
+        set(ASCEND_FOUND TRUE)
+    else()
+        find_program(ASCEND_SMI_PATH npu-smi)
+        if(ASCEND_SMI_PATH)
+            execute_process(
+                COMMAND ${ASCEND_SMI_PATH} info
+                RESULT_VARIABLE ASCEND_SMI_RESULT
+                OUTPUT_QUIET
+                ERROR_QUIET
+            )
+            if(ASCEND_SMI_RESULT EQUAL 0)
+                set(ASCEND_FOUND TRUE)
+            endif()
+        endif()
+    endif()
+
+    if(ASCEND_FOUND)
+        set(WITH_ASCEND ON)
+        message(STATUS "Ascend environment detected.")
+    else()
+        message(STATUS "Ascend environment not detected.")
+    endif()
+
     # Hygon DCU
     if(NOT WITH_HYGON)
         set(HYGON_FOUND FALSE)
@@ -307,10 +338,30 @@ if(AUTO_DETECT_BACKENDS)
     else()
         message(STATUS "No suitable device environment, skipping MCCL detection.")
     endif()
+
+    # Detect HCCL dependencies.
+    if(WITH_ASCEND)
+        set(_HCCL_HINTS
+            "${ASCEND_HOME}"
+            "$ENV{ASCEND_HOME_PATH}"
+            "$ENV{ASCEND_TOOLKIT_HOME}"
+            "$ENV{ASCEND_HOME}"
+            /usr/local/Ascend/ascend-toolkit/latest
+        )
+        find_path(AUTO_HCCL_INC NAMES hccl/hccl.h HINTS ${_HCCL_HINTS} PATH_SUFFIXES include QUIET)
+        find_library(AUTO_HCCL_LIB NAMES hccl HINTS ${_HCCL_HINTS} PATH_SUFFIXES lib64 aarch64-linux/lib64 QUIET)
+
+        if(AUTO_HCCL_INC AND AUTO_HCCL_LIB)
+            set(WITH_HCCL ON)
+            message(STATUS "Auto-detected HCCL backend.")
+        else()
+            message(STATUS "HCCL library/headers not found in Ascend paths.")
+        endif()
+    endif()
 endif()
 
 # Fallback: If no backends are enabled or auto-detected, fall back to OpenMPI as the default bootstrap profile.
-if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL AND NOT WITH_MCCL)
+if(NOT WITH_OMPI AND NOT WITH_MPICH AND NOT WITH_NCCL AND NOT WITH_MCCL AND NOT WITH_HCCL)
     set(WITH_OMPI ON)
     message(STATUS "No backend specified or detected. Defaulting to `WITH_OMPI=ON`")
 endif()
@@ -420,6 +471,26 @@ if(WITH_CAMBRICON)
     find_library(CAMBRICON_PAPI_LIB       NAMES cnpapi     HINTS "${NEUWARE_HOME}/lib64" REQUIRED)
 endif()
 
+if(WITH_ASCEND)
+    set(_ASCEND_HINTS)
+    if(ASCEND_HOME)
+        list(APPEND _ASCEND_HINTS "${ASCEND_HOME}")
+    endif()
+    foreach(_ascend_env ASCEND_HOME_PATH ASCEND_TOOLKIT_HOME ASCEND_HOME)
+        if(DEFINED ENV{${_ascend_env}} AND NOT "$ENV{${_ascend_env}}" STREQUAL "")
+            list(APPEND _ASCEND_HINTS "$ENV{${_ascend_env}}")
+        endif()
+    endforeach()
+    list(APPEND _ASCEND_HINTS
+        /usr/local/Ascend/ascend-toolkit/latest
+    )
+
+    find_path(ASCEND_INC NAMES acl/acl.h HINTS ${_ASCEND_HINTS} PATH_SUFFIXES include REQUIRED)
+    find_library(ASCENDCL_LIB NAMES ascendcl HINTS ${_ASCEND_HINTS} PATH_SUFFIXES lib64 aarch64-linux/lib64 REQUIRED)
+
+    include_directories(${ASCEND_INC})
+endif()
+
 if(WITH_HYGON)
     set(HYGON_DTK_ROOT "")
     foreach(_hygon_env DTKROOT DTK_ROOT ROCM_PATH)
@@ -502,6 +573,17 @@ if(WITH_MCCL)
     find_path(MCCL_INC NAMES mccl.h HINTS ${_MCCL_HINTS} PATH_SUFFIXES include REQUIRED)
 
     include_directories(${MCCL_INC})
+endif()
+
+if(WITH_HCCL)
+    if(NOT WITH_ASCEND)
+        message(FATAL_ERROR "HCCL backend requires Ascend device support. Please enable `WITH_ASCEND`.")
+    endif()
+
+    find_library(HCCL_LIB NAMES hccl HINTS ${_ASCEND_HINTS} PATH_SUFFIXES lib64 aarch64-linux/lib64 REQUIRED)
+    find_path(HCCL_INC NAMES hccl/hccl.h HINTS ${_ASCEND_HINTS} PATH_SUFFIXES include REQUIRED)
+
+    include_directories(${HCCL_INC})
 endif()
 
 # Python is required for code generation.

--- a/scripts/gen_bridge.py
+++ b/scripts/gen_bridge.py
@@ -32,16 +32,19 @@ BACKEND_IMPL_PATH_MAP = {
     "mpich": ["backends/mpi/ompi/impl"],
     "nccl": ["backends/ccl/nccl/impl"],
     "mccl": ["backends/ccl/mccl/impl"],
+    "hccl": ["backends/ccl/hccl/impl"],
 }
 
 BACKEND_COMMON_HEADERS = {
     "nccl": ["backends/ccl/nccl/type_map.h"],
     "mccl": ["backends/ccl/mccl/type_map.h"],
+    "hccl": ["backends/ccl/hccl/type_map.h"],
 }
 
 CCL_PROVIDER_BACKENDS = {
     "nccl": "backends/ccl/nccl",
     "mccl": "backends/ccl/mccl",
+    "hccl": "backends/ccl/hccl",
 }
 
 # =================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -215,6 +215,20 @@ if(WITH_CAMBRICON)
     )
 endif()
 
+# Ascend
+if(WITH_ASCEND)
+    list(APPEND DEVICE_LIST "ascend")
+
+    file(GLOB_RECURSE ASCEND_SRCS
+        "devices/ascend/*.cc"
+        "devices/ascend/*.cpp"
+    )
+
+    target_sources(infiniccl PRIVATE ${ASCEND_SRCS})
+    target_include_directories(infiniccl PRIVATE ${ASCEND_INC})
+    target_link_libraries(infiniccl PRIVATE ${ASCENDCL_LIB})
+endif()
+
 # Hygon
 if(WITH_HYGON)
     list(APPEND DEVICE_LIST "hygon")
@@ -277,6 +291,16 @@ if(WITH_MCCL)
     target_sources(infiniccl PRIVATE ${MCCL_SRCS})
     target_include_directories(infiniccl PRIVATE ${MCCL_INC})
     target_link_libraries(infiniccl PRIVATE ${MCCL_LIB})
+endif()
+
+# HCCL
+if(WITH_HCCL)
+    list(APPEND BACKEND_LIST "hccl")
+    file(GLOB_RECURSE HCCL_SRCS "backends/ccl/hccl/*.cc" "backends/ccl/hccl/*.cpp")
+
+    target_sources(infiniccl PRIVATE ${HCCL_SRCS})
+    target_include_directories(infiniccl PRIVATE ${HCCL_INC})
+    target_link_libraries(infiniccl PRIVATE ${HCCL_LIB})
 endif()
 
 # =========================================================

--- a/src/backend.h
+++ b/src/backend.h
@@ -63,6 +63,11 @@ struct BackendPriority<BackendType::kMccl> {
   static constexpr int value = 10;
 };
 
+template <>
+struct BackendPriority<BackendType::kHccl> {
+  static constexpr int value = 10;
+};
+
 }  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_H_

--- a/src/backend_device_map.h
+++ b/src/backend_device_map.h
@@ -29,6 +29,10 @@ template <>
 struct IsSupportedCombination<BackendType::kMccl, Device::Type::kMoore>
     : std::true_type {};
 
+template <>
+struct IsSupportedCombination<BackendType::kHccl, Device::Type::kAscend>
+    : std::true_type {};
+
 };  // namespace infini::ccl
 
 #endif  // INFINI_CCL_BACKEND_DEVICE_MAP_H_

--- a/src/backends/ccl/hccl/api.h
+++ b/src/backends/ccl/hccl/api.h
@@ -1,0 +1,90 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_API_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_API_H_
+
+#include <hccl/hccl.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "backends/ccl/common/api.h"
+#include "logging.h"
+#include "return_status_impl.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+struct HcclApi {
+  static constexpr BackendType kBackendType = BackendType::kHccl;
+  static constexpr Device::Type kDeviceType = device;
+
+  using Comm = HcclComm;
+  using Result = HcclResult;
+  using DataType = HcclDataType;
+  using RedOp = HcclReduceOp;
+  using Stream = typename Runtime<device>::Stream;
+
+  struct ThreadLocalStream {
+    Stream stream{};
+    Result status = HCCL_SUCCESS;
+
+    ThreadLocalStream() {
+      if (Runtime<device>::StreamCreate(&stream) != 0) {
+        status = HCCL_E_RUNTIME;
+      }
+    }
+
+    ~ThreadLocalStream() {
+      if (stream != nullptr) {
+        Runtime<device>::StreamDestroy(stream);
+      }
+    }
+  };
+
+  static ReturnStatus Check(Result result) {
+    if (result != HCCL_SUCCESS) {
+      const char* message = HcclGetErrorString(result);
+      LOG(message ? message : "Unknown HCCL error");
+      return ReturnStatus::kSystemError;
+    }
+    return ReturnStatus::kSuccess;
+  }
+
+  static Result CommInitAll(Comm* comms, int n_dev, const int* dev_list,
+                            const int*) {
+    return HcclCommInitAll(
+        static_cast<uint32_t>(n_dev),
+        reinterpret_cast<int32_t*>(const_cast<int*>(dev_list)), comms);
+  }
+
+  static Result CommDestroy(Comm comm) { return HcclCommDestroy(comm); }
+
+  static Result ResolveStream(Stream requested, Stream* resolved) {
+    if (requested != nullptr) {
+      *resolved = requested;
+      return HCCL_SUCCESS;
+    }
+
+    thread_local ThreadLocalStream default_stream;
+    if (default_stream.status != HCCL_SUCCESS) {
+      return default_stream.status;
+    }
+    *resolved = default_stream.stream;
+    return HCCL_SUCCESS;
+  }
+
+  static Result AllReduce(const void* send_buff, void* recv_buff, size_t count,
+                          DataType data_type, RedOp op, Comm comm,
+                          Stream stream) {
+    auto status = ResolveStream(stream, &stream);
+    if (status != HCCL_SUCCESS) {
+      return status;
+    }
+    return HcclAllReduce(const_cast<void*>(send_buff), recv_buff, count,
+                         data_type, op, comm, stream);
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_API_H_

--- a/src/backends/ccl/hccl/ascend/api.h
+++ b/src/backends/ccl/hccl/ascend/api.h
@@ -1,0 +1,15 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_ASCEND_API_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_ASCEND_API_H_
+
+#include "backends/ccl/hccl/api.h"
+#include "devices/ascend/runtime_.h"
+
+namespace infini::ccl {
+
+template <>
+struct CclApi<BackendType::kHccl, Device::Type::kAscend>
+    : HcclApi<Device::Type::kAscend> {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_ASCEND_API_H_

--- a/src/backends/ccl/hccl/impl/all_reduce.h
+++ b/src/backends/ccl/hccl/impl/all_reduce.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_ALL_REDUCE_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_ALL_REDUCE_H_
+
+#include "backends/ccl/common/impl/all_reduce.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class AllReduceImpl<BackendType::kHccl, device>
+    : public CclAllReduceImpl<BackendType::kHccl, device> {};
+
+template <>
+struct BackendEnabled<AllReduce, BackendType::kHccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_ALL_REDUCE_H_

--- a/src/backends/ccl/hccl/impl/comm_destroy.h
+++ b/src/backends/ccl/hccl/impl/comm_destroy.h
@@ -1,0 +1,17 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_DESTROY_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_DESTROY_H_
+
+#include "backends/ccl/common/impl/comm_destroy.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommDestroyImpl<BackendType::kHccl, device>
+    : public CclCommDestroyImpl<BackendType::kHccl, device> {};
+
+template <>
+struct BackendEnabled<CommDestroy, BackendType::kHccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_DESTROY_H_

--- a/src/backends/ccl/hccl/impl/comm_init_all.h
+++ b/src/backends/ccl/hccl/impl/comm_init_all.h
@@ -1,0 +1,76 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_INIT_ALL_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_INIT_ALL_H_
+
+#include <memory>
+#include <numeric>
+#include <vector>
+
+#include "backends/ccl/common/comm_instance.h"
+#include "base/comm_init_all.h"
+#include "communicator.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <Device::Type device>
+class CommInitAllImpl<BackendType::kHccl, device> {
+ public:
+  static ReturnStatus Apply(void** comm_handles, int n_dev,
+                            const int* dev_list) {
+    using Api = CclApi<BackendType::kHccl, device>;
+    using CommInstance = CclCommInstance<Api>;
+    using Rt = Runtime<device>;
+
+    if (!comm_handles || !dev_list || n_dev <= 0) {
+      return ReturnStatus::kInvalidArgument;
+    }
+
+    auto** comms = reinterpret_cast<Communicator**>(comm_handles);
+    for (int i = 0; i < n_dev; ++i) {
+      if (comms[i]) {
+        return ReturnStatus::kInvalidArgument;
+      }
+    }
+
+    std::vector<std::unique_ptr<Communicator>> wrappers;
+    std::vector<std::unique_ptr<CommInstance>> instances;
+    std::vector<typename Api::Comm> backend_comms(n_dev);
+    std::vector<int> rank_list(n_dev);
+    wrappers.reserve(n_dev);
+    instances.reserve(n_dev);
+    std::iota(rank_list.begin(), rank_list.end(), 0);
+
+    // HCCL requires every local device context to be initialized first.
+    for (int i = n_dev - 1; i >= 0; --i) {
+      auto status = Rt::Check(Rt::SetDevice(dev_list[i]));
+      if (status != ReturnStatus::kSuccess) {
+        return status;
+      }
+    }
+
+    auto status = Api::Check(Api::CommInitAll(backend_comms.data(), n_dev,
+                                              dev_list, rank_list.data()));
+    if (status != ReturnStatus::kSuccess) {
+      return status;
+    }
+
+    for (int i = 0; i < n_dev; ++i) {
+      wrappers.emplace_back(
+          std::make_unique<Communicator>(device, dev_list[i]));
+      instances.emplace_back(std::make_unique<CommInstance>());
+      instances.back()->handle = backend_comms[i];
+      wrappers.back()->set_world_info(i, n_dev);
+      wrappers.back()->set_intra_comm(std::move(instances.back()));
+      comms[i] = wrappers.back().release();
+    }
+
+    return ReturnStatus::kSuccess;
+  }
+};
+
+template <>
+struct BackendEnabled<CommInitAll, BackendType::kHccl> : std::true_type {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_IMPL_COMM_INIT_ALL_H_

--- a/src/backends/ccl/hccl/type_map.h
+++ b/src/backends/ccl/hccl/type_map.h
@@ -1,0 +1,91 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_HCCL_TYPE_MAP_H_
+#define INFINI_CCL_BACKENDS_CCL_HCCL_TYPE_MAP_H_
+
+#include <hccl/hccl.h>
+
+#include "backends/ccl/common/api.h"
+#include "comm_impl.h"
+#include "data_type_impl.h"
+
+namespace infini::ccl {
+
+inline bool DataTypeToHcclType(DataType dtype, HcclDataType* hccl_dtype) {
+  switch (dtype) {
+    case DataType::kInt8:
+      *hccl_dtype = HCCL_DATA_TYPE_INT8;
+      return true;
+    case DataType::kInt16:
+      *hccl_dtype = HCCL_DATA_TYPE_INT16;
+      return true;
+    case DataType::kInt32:
+      *hccl_dtype = HCCL_DATA_TYPE_INT32;
+      return true;
+    case DataType::kInt64:
+      *hccl_dtype = HCCL_DATA_TYPE_INT64;
+      return true;
+    case DataType::kUInt8:
+      *hccl_dtype = HCCL_DATA_TYPE_UINT8;
+      return true;
+    case DataType::kUInt16:
+      *hccl_dtype = HCCL_DATA_TYPE_UINT16;
+      return true;
+    case DataType::kUInt32:
+      *hccl_dtype = HCCL_DATA_TYPE_UINT32;
+      return true;
+    case DataType::kUInt64:
+      *hccl_dtype = HCCL_DATA_TYPE_UINT64;
+      return true;
+    case DataType::kFloat16:
+      *hccl_dtype = HCCL_DATA_TYPE_FP16;
+      return true;
+    case DataType::kBFloat16:
+      *hccl_dtype = HCCL_DATA_TYPE_BFP16;
+      return true;
+    case DataType::kFloat32:
+      *hccl_dtype = HCCL_DATA_TYPE_FP32;
+      return true;
+    case DataType::kFloat64:
+      *hccl_dtype = HCCL_DATA_TYPE_FP64;
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool RedOpToHcclOp(ReductionOpType red_op, HcclReduceOp* hccl_op) {
+  switch (red_op) {
+    case ReductionOpType::kSum:
+      *hccl_op = HCCL_REDUCE_SUM;
+      return true;
+    case ReductionOpType::kProd:
+      *hccl_op = HCCL_REDUCE_PROD;
+      return true;
+    case ReductionOpType::kMax:
+      *hccl_op = HCCL_REDUCE_MAX;
+      return true;
+    case ReductionOpType::kMin:
+      *hccl_op = HCCL_REDUCE_MIN;
+      return true;
+    default:
+      return false;
+  }
+}
+
+template <>
+struct CclTypeMap<BackendType::kHccl, Device::Type::kAscend> {
+  using Api = CclApi<BackendType::kHccl, Device::Type::kAscend>;
+
+  static bool ToBackendDataType(DataType dtype,
+                                typename Api::DataType* backend_dtype) {
+    return DataTypeToHcclType(dtype, backend_dtype);
+  }
+
+  static bool ToBackendRedOp(ReductionOpType red_op,
+                             typename Api::RedOp* backend_op) {
+    return RedOpToHcclOp(red_op, backend_op);
+  }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_HCCL_TYPE_MAP_H_

--- a/src/backends/mpi/ompi/impl/comm_init_all.h
+++ b/src/backends/mpi/ompi/impl/comm_init_all.h
@@ -12,17 +12,26 @@ namespace infini::ccl {
 template <Device::Type device_type>
 class CommInitAllImpl<BackendType::kOmpi, device_type> {
  public:
-  static ReturnStatus Apply(Communicator *comm, int n_dev,
-                            const int *dev_list) {
+  static ReturnStatus Apply(void** comm_handles, int n_dev,
+                            const int* dev_list) {
     constexpr Device::Type kDev =
         ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
     using Rt = Runtime<kDev>;
 
-    if (!comm) {
+    if (!comm_handles) {
       // TODO(lzm): change to use `glog`.
       LOG("Failed to initialize OpenMPI communicator: invalid "
           "communicator pointer.");
       return ReturnStatus::kInternalError;
+    }
+
+    Communicator*& comm = *reinterpret_cast<Communicator**>(comm_handles);
+    if (comm && comm->inter_comm()) {
+      LOG("Invalid communicator handle for `CommInitAll`.");
+      return ReturnStatus::kInvalidArgument;
+    }
+    if (!comm) {
+      comm = new Communicator(kDev, 0);
     }
 
     int rank, size;
@@ -35,7 +44,7 @@ class CommInitAllImpl<BackendType::kOmpi, device_type> {
     comm->set_inter_comm(std::move(inst));
 
     int local_rank = 0;
-    char *local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    char* local_rank_str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
     if (local_rank_str) {
       local_rank = atoi(local_rank_str);
     }

--- a/src/base/comm_init_all.h
+++ b/src/base/comm_init_all.h
@@ -13,25 +13,16 @@ struct CommInitAllImpl;
 
 class CommInitAll : public Operation<CommInitAll> {
  public:
-  template <BackendType backend_type, Device::Type device_type,
-            typename... Args>
-  static ReturnStatus Execute(void **comm_handle, Args &&...args) {
-    Communicator *&comm = *reinterpret_cast<Communicator **>(comm_handle);
-    if (comm && comm->inter_comm()) {
-      // TODO(lzm): change to use `glog`.
+  template <BackendType backend_type, Device::Type device_type>
+  static ReturnStatus Execute(void** comm_handles, int n_dev,
+                              const int* dev_list) {
+    if (!comm_handles || n_dev <= 0) {
       LOG("Invalid communicator handle for `CommInitAll`.");
       return ReturnStatus::kInvalidArgument;
     }
 
-    constexpr Device::Type kDev =
-        ListGetBest<DevicePriority>(ActiveDevices<CommInitAll>{});
-
-    if (!comm) {
-      comm = new Communicator(kDev, 0);
-    }
-
-    return CommInitAllImpl<backend_type, device_type>::Apply(
-        comm, std::forward<Args>(args)...);
+    return CommInitAllImpl<backend_type, device_type>::Apply(comm_handles,
+                                                             n_dev, dev_list);
   }
 };
 

--- a/src/device.h
+++ b/src/device.h
@@ -157,6 +157,11 @@ struct DevicePriority<Device::Type::kCambricon> {
 };
 
 template <>
+struct DevicePriority<Device::Type::kAscend> {
+  static constexpr int value = 5;
+};
+
+template <>
 struct DevicePriority<Device::Type::kHygon> {
   static constexpr int value = 5;
 };

--- a/src/devices/ascend/device_.h
+++ b/src/devices/ascend/device_.h
@@ -1,0 +1,31 @@
+#ifndef INFINI_CCL_DEVICES_ASCEND_DEVICE_H_
+#define INFINI_CCL_DEVICES_ASCEND_DEVICE_H_
+
+#include <acl/acl.h>
+
+#include "device.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kAscend> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kAscend>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  aclrtPtrAttributes attributes{};
+  if (aclrtPointerGetAttributes(ptr, &attributes) != ACL_SUCCESS) {
+    return MemorySpace::kHost;
+  }
+
+  return attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE
+             ? MemorySpace::kDevice
+             : MemorySpace::kHost;
+}
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_ASCEND_DEVICE_H_

--- a/src/devices/ascend/runtime_.h
+++ b/src/devices/ascend/runtime_.h
@@ -1,0 +1,85 @@
+#ifndef INFINI_CCL_DEVICES_ASCEND_RUNTIME_H_
+#define INFINI_CCL_DEVICES_ASCEND_RUNTIME_H_
+
+#include <acl/acl.h>
+
+#include <string>
+
+#include "devices/ascend/device_.h"
+#include "logging.h"
+#include "return_status_impl.h"
+#include "runtime.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kAscend>
+    : DeviceRuntime<Runtime<Device::Type::kAscend>> {
+  using Stream = aclrtStream;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kAscend;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != ACL_SUCCESS) {
+          const char* message = aclGetRecentErrMsg();
+          if (message) {
+            LOG(message);
+          } else {
+            LOG(("Ascend ACL error code: " +
+                 std::to_string(static_cast<int>(status)))
+                    .c_str());
+          }
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](void** ptr, size_t size) {
+    return aclrtMalloc(ptr, size, ACL_MEM_MALLOC_HUGE_FIRST);
+  };
+
+  static constexpr auto Memcpy = [](void* dst, const void* src, size_t count,
+                                    aclrtMemcpyKind kind) {
+    return aclrtMemcpy(dst, count, src, count, kind);
+  };
+
+  static constexpr auto Free = aclrtFree;
+
+  static constexpr auto MemcpyHostToDevice = ACL_MEMCPY_HOST_TO_DEVICE;
+
+  static constexpr auto MemcpyDeviceToHost = ACL_MEMCPY_DEVICE_TO_HOST;
+
+  static constexpr auto Memset = [](void* ptr, int value, size_t count) {
+    return aclrtMemset(ptr, count, value, count);
+  };
+
+  static constexpr auto GetDevice = aclrtGetDevice;
+
+  static constexpr auto SetDevice = aclrtSetDevice;
+
+  static aclError EnsureDeviceContext() {
+    int32_t device_id = 0;
+    const aclError status = aclrtGetDevice(&device_id);
+    if (status == ACL_SUCCESS) {
+      return ACL_SUCCESS;
+    }
+    return aclrtSetDevice(0);
+  }
+
+  static constexpr auto DeviceSynchronize = aclrtSynchronizeDevice;
+
+  static constexpr auto StreamCreate = aclrtCreateStream;
+
+  static constexpr auto StreamDestroy = aclrtDestroyStream;
+
+  static constexpr auto StreamSynchronize = [](aclrtStream stream) {
+    return stream ? aclrtSynchronizeStream(stream) : aclrtSynchronizeDevice();
+  };
+};
+
+static_assert(Runtime<Device::Type::kAscend>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_ASCEND_RUNTIME_H_


### PR DESCRIPTION
## Summary

Add the minimal Ascend HCCL backend required for single-node tensor parallelism. The implementation supports communicator initialization with `infinicclCommInitAll`, collective reduction with `infinicclAllReduce`, and communicator cleanup with `infinicclCommDestroy`.

The scope is intentionally limited to the communication path currently exercised by InfiniLM pure TP inference.

## Changes

- **Ascend device integration**
  - Add Ascend device registration, runtime operations, memory-space detection, and CANN discovery.
  - Add the `WITH_ASCEND` build option and automatic Ascend environment detection.

- **HCCL backend**
  - Add the `WITH_HCCL` build option, backend registration, and HCCL dependency discovery.
  - Add Ascend/HCCL data type and reduction operation mappings.
  - Implement `CommInitAll`, `AllReduce`, and `CommDestroy`.
  - Resolve a null caller stream through a thread-local Ascend stream.

- **Common communicator initialization**
  - Update the internal `CommInitAll` contract to return one communicator per requested device.
  - Adapt the OpenMPI implementation to the updated internal contract without changing its public API.

## Platform and Backend Affected

### Platform

- [x] CPU (shared `CommInitAll` dispatch path)
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU
- [x] Ascend NPU

### Backend

- [x] OpenMPI (internal `CommInitAll` adapter)
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL
- [x] HCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

N/A. This adds a new backend and does not change an existing communication kernel.

## Known Issues & Future Work

- The HCCL backend currently exposes only `CommInitAll`, `AllReduce`, and `CommDestroy`.
- Rank-based multi-process initialization and additional collectives are outside this PR's pure-TP scope.
- OpenMPI regression validation and repository example integration remain pending before the PR is marked ready for review.

## Test Results

Environment:

- Ascend 910C, two logical devices (`0,1`)
- CANN 9.0.0
- openEuler 24.03, AArch64
- GCC 12.3.1

Results:

- Fresh CMake configuration with `WITH_ASCEND=ON`, `WITH_HCCL=ON`, and `WITH_OMPI=OFF`: passed.
- InfiniCCL build and installation: passed.
- Dynamic dependency and exported-symbol checks: passed.
- Two-device `CommInitAll + AllReduce(sum) + CommDestroy` smoke test: passed.
  - Device 0 input: all elements `1.0`.
  - Device 1 input: all elements `2.0`.
  - Both outputs: all elements `3.0`.
- `git diff --check`: passed.
- `ruff check scripts/gen_bridge.py`: passed.
- `ruff format --check scripts/gen_bridge.py`: passed.
- `clang-format-diff.py` on changed C++ lines: clean with clang-format 21.1.8.

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU
- [x] Ascend NPU

### Test Involved Backend

- [ ] OpenMPI
- [ ] MPICH
- [ ] NCCL
- [ ] MCCL
- [x] HCCL

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Each commit message follows Conventional Commits.
- [x] The PR contains one squashable commit.
- [x] The branch is rebased cleanly on the current `master`.
- [x] No `fixup!`, `squash!`, or `wip` commits remain.

### Scope and Design

- [x] Changes are limited to the minimal pure-TP HCCL path and its required build/runtime integration.
- [x] No debug code, commented-out blocks, or unrelated formatting churn is included.
- [x] The internal `CommInitAll` change is intentional and its OpenMPI implementation is adapted in the same commit.

### General Code Hygiene

- [x] `git diff --check` passes.
- [x] Comments and error messages added by this PR are in English.
- [x] Modified and added files end with a trailing newline.

### C++ Specific

- [x] Changed C++ lines pass `clang-format-diff.py`.
- [ ] clang-format 16 CI is pending; local validation used clang-format 21.1.8.
- [x] No exceptions are introduced.

### Python Specific

- [x] `ruff check` passes.
- [x] `ruff format --check` passes.

### Testing

- [ ] Repository example programs are pending; the out-of-tree two-device HCCL smoke test passes.

### Build, CI, and Tooling

- [x] Ascend and HCCL are included in build options and auto-detection.
- [ ] GitHub CI is pending.

### Documentation

- [ ] User-facing documentation is intentionally deferred while the backend remains limited to the pure-TP API subset.

### Security and Safety

- [x] No secrets, internal URLs, customer data, or hardware identifiers are committed.
- [x] No third-party source code is copied into the repository.