### PR TITLE
support T-Head PPU with NCCL in InfiniCCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,17 @@ option(WITH_METAX       "Enable MetaX GPU support"      OFF)
 option(WITH_MOORE       "Enable Moore GPU support"      OFF)
 option(WITH_CAMBRICON   "Enable Cambricon MLU support"  OFF)
 option(WITH_HYGON       "Enable Hygon DCU support"      OFF)
+option(WITH_THEAD       "Enable T-Head PPU support"     OFF)
 
 set(WITH_CPU ON CACHE INTERNAL "CPU backend is always enabled")
+
+if(WITH_THEAD)
+    if(DEFINED ENV{CUDA_SDK} AND NOT "$ENV{CUDA_SDK}" STREQUAL "")
+        set(THEAD_CUDA_ROOT "$ENV{CUDA_SDK}")
+    else()
+        set(THEAD_CUDA_ROOT "/usr/local/PPU_SDK/CUDA_SDK")
+    endif()
+endif()
 
 # =========================================================
 # --- BACKEND OPTIONS (Communication Protocols) ---
@@ -343,6 +352,20 @@ if(WITH_NVIDIA)
     find_package(CUDAToolkit REQUIRED)
 endif()
 
+if(WITH_THEAD)
+    if(NOT EXISTS "${THEAD_CUDA_ROOT}/bin/nvcc")
+        message(FATAL_ERROR
+            "`WITH_THEAD` is `ON` but `${THEAD_CUDA_ROOT}/bin/nvcc` was not found. "
+            "Set `CUDA_SDK` to the PPU CUDA SDK root.")
+    endif()
+
+    set(CMAKE_CUDA_COMPILER "${THEAD_CUDA_ROOT}/bin/nvcc" CACHE FILEPATH
+        "T-Head PPU CUDA compiler" FORCE)
+    set(CUDAToolkit_ROOT "${THEAD_CUDA_ROOT}" CACHE PATH
+        "T-Head PPU CUDA toolkit root" FORCE)
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
+endif()
 if(WITH_ILUVATAR)
     find_program(ILUVATAR_CUDA_COMPILER NAMES clang++ HINTS /usr/local/corex/bin)
     
@@ -490,8 +513,8 @@ if(WITH_OMPI OR WITH_MPICH)
 endif()
 
 if(WITH_NCCL)
-    if (NOT WITH_NVIDIA AND NOT WITH_ILUVATAR AND NOT WITH_HYGON)
-        message(FATAL_ERROR "NCCL backend requires NVIDIA, Iluvatar, or Hygon GPU support. Please enable `WITH_NVIDIA`, `WITH_ILUVATAR`, or `WITH_HYGON`.")
+    if(NOT WITH_NVIDIA AND NOT WITH_ILUVATAR AND NOT WITH_HYGON AND NOT WITH_THEAD)
+        message(FATAL_ERROR "NCCL backend requires NVIDIA, Iluvatar, Hygon, or T-Head GPU support.")
     endif()
 
     set(_NCCL_HEADER_NAMES nccl.h)
@@ -503,6 +526,10 @@ if(WITH_NCCL)
         set(_NCCL_HEADER_NAMES rccl/rccl.h rccl.h)
         set(_NCCL_LIBRARY_NAMES rccl)
         set(NCCL_COMPILE_DEFINITIONS INFINI_CCL_USE_RCCL)
+    elseif(WITH_THEAD)
+        list(APPEND _NCCL_HINTS
+            "${THEAD_CUDA_ROOT}"
+            "${THEAD_CUDA_ROOT}/targets/x86_64-linux")
     endif()
 
     find_library(NCCL_LIB NAMES ${_NCCL_LIBRARY_NAMES} HINTS ${_NCCL_HINTS} PATH_SUFFIXES lib lib64 rccl/lib REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,29 @@ if(WITH_NVIDIA)
     )
 endif()
 
+# T-Head PPU
+if(WITH_THEAD)
+    list(APPEND DEVICE_LIST "thead")
+
+    set(THEAD_PATTERNS
+        "devices/cuda/*.cc"
+        "devices/cuda/*.cpp"
+        "devices/cuda/*.cu"
+        "devices/thead/*.cc"
+        "devices/thead/*.cpp"
+        "devices/thead/*.cu"
+    )
+    file(GLOB_RECURSE THEAD_SOURCES ${THEAD_PATTERNS})
+
+    target_sources(infiniccl PRIVATE ${THEAD_SOURCES})
+    target_link_libraries(infiniccl PRIVATE CUDA::cudart CUDA::cuda_driver)
+
+    set_target_properties(infiniccl PROPERTIES
+        CUDA_STANDARD 17
+        CUDA_STANDARD_REQUIRED ON
+    )
+endif()
+
 # Iluvatar
 if(WITH_ILUVATAR)
     list(APPEND DEVICE_LIST "iluvatar")

--- a/src/backend_device_map.h
+++ b/src/backend_device_map.h
@@ -26,6 +26,10 @@ struct IsSupportedCombination<BackendType::kNccl, Device::Type::kHygon>
     : std::true_type {};
 
 template <>
+struct IsSupportedCombination<BackendType::kNccl, Device::Type::kThead>
+    : std::true_type {};
+
+template <>
 struct IsSupportedCombination<BackendType::kMccl, Device::Type::kMetax>
     : std::true_type {};
 

--- a/src/backends/ccl/nccl/thead/api.h
+++ b/src/backends/ccl/nccl/thead/api.h
@@ -1,0 +1,24 @@
+#ifndef INFINI_CCL_BACKENDS_CCL_NCCL_THEAD_API_H_
+#define INFINI_CCL_BACKENDS_CCL_NCCL_THEAD_API_H_
+
+#include "backends/ccl/nccl/api.h"
+#include "devices/thead/runtime_.h"
+
+namespace infini::ccl {
+
+template <>
+struct NcclDataTypeTraits<Device::Type::kThead> {
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+  static constexpr ncclDataType_t kBFloat16 = ncclBfloat16;
+#else
+  static constexpr ncclDataType_t kBFloat16 = ncclNumTypes;
+#endif
+};
+
+template <>
+struct CclApi<BackendType::kNccl, Device::Type::kThead>
+    : NcclApi<Device::Type::kThead> {};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_BACKENDS_CCL_NCCL_THEAD_API_H_

--- a/src/device.h
+++ b/src/device.h
@@ -22,6 +22,7 @@ class Device {
     kKunlun = 7,
     kHygon = 8,
     kQy = 9,
+    kThead = 10,
     kCount
   };
 
@@ -67,6 +68,7 @@ class Device {
           {Type::kKunlun, "kunlun"},
           {Type::kHygon, "hygon"},
           {Type::kQy, "qy"},
+          {Type::kThead, "thead"},
       }}};
 
   static constexpr ConstexprMap<std::string_view, Device::Type,
@@ -82,6 +84,7 @@ class Device {
           {"kunlun", Type::kKunlun},
           {"hygon", Type::kHygon},
           {"qy", Type::kQy},
+          {"thead", Type::kThead},
       }}};
 
   int index_{0};
@@ -97,7 +100,7 @@ using AllDeviceTypes =
     List<Device::Type::kCpu, Device::Type::kNvidia, Device::Type::kCambricon,
          Device::Type::kAscend, Device::Type::kMetax, Device::Type::kMoore,
          Device::Type::kIluvatar, Device::Type::kKunlun, Device::Type::kHygon,
-         Device::Type::kQy>;
+         Device::Type::kQy, Device::Type::kThead>;
 
 // Deferred computation of active devices. The `Filter` and `FilterList`
 // evaluation are nested inside a class template so that `DeviceEnabled`
@@ -158,6 +161,11 @@ struct DevicePriority<Device::Type::kCambricon> {
 
 template <>
 struct DevicePriority<Device::Type::kHygon> {
+  static constexpr int value = 5;
+};
+
+template <>
+struct DevicePriority<Device::Type::kThead> {
   static constexpr int value = 5;
 };
 

--- a/src/devices/thead/caster_.cuh
+++ b/src/devices/thead/caster_.cuh
@@ -1,0 +1,64 @@
+#ifndef INFINI_CCL_DEVICES_THEAD_CASTER_CUH_
+#define INFINI_CCL_DEVICES_THEAD_CASTER_CUH_
+
+#include "caster.h"
+#include "data_type_.h"
+
+namespace infini::ccl {
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, float, half> {
+  __host__ __device__ static float Apply(half x) { return __half2float(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, half, float> {
+  __host__ __device__ static half Apply(float x) { return __float2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, float, __nv_bfloat16> {
+  __host__ __device__ static float Apply(__nv_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, __nv_bfloat16, float> {
+  __host__ __device__ static __nv_bfloat16 Apply(float x) {
+    return __float2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, __nv_bfloat16, int> {
+  __host__ __device__ static __nv_bfloat16 Apply(int x) {
+    return __int2bfloat16_rn(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, half, int> {
+  __host__ __device__ static half Apply(int x) { return __int2half_rn(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, __nv_bfloat16, double> {
+  __host__ __device__ static __nv_bfloat16 Apply(double x) {
+    return __double2bfloat16(x);
+  }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, half, double> {
+  __host__ __device__ static half Apply(double x) { return __double2half(x); }
+};
+
+template <>
+struct HardwareCastImpl<Device::Type::kThead, half, __nv_bfloat16> {
+  __host__ __device__ static half Apply(__nv_bfloat16 x) { return __half(x); }
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_THEAD_CASTER_CUH_

--- a/src/devices/thead/data_type_.h
+++ b/src/devices/thead/data_type_.h
@@ -1,0 +1,26 @@
+#ifndef INFINI_CCL_DEVICES_THEAD_DATA_TYPE_H_
+#define INFINI_CCL_DEVICES_THEAD_DATA_TYPE_H_
+
+// clang-format off
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+// clang-format on
+
+#include "data_type_impl.h"
+#include "devices/thead/device_.h"
+
+namespace infini::ccl {
+
+template <>
+struct TypeMap<Device::Type::kThead, DataType::kFloat16> {
+  using type = half;
+};
+
+template <>
+struct TypeMap<Device::Type::kThead, DataType::kBFloat16> {
+  using type = __nv_bfloat16;
+};
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_THEAD_DATA_TYPE_H_

--- a/src/devices/thead/device_.h
+++ b/src/devices/thead/device_.h
@@ -1,0 +1,32 @@
+#ifndef INFINI_CCL_DEVICES_THEAD_DEVICE_H_
+#define INFINI_CCL_DEVICES_THEAD_DEVICE_H_
+
+#include <cuda_runtime.h>
+
+#include "device.h"
+#include "devices/cuda/checks.h"
+
+namespace infini::ccl {
+
+template <>
+struct DeviceEnabled<Device::Type::kThead> : std::true_type {};
+
+template <>
+MemorySpace GetMemorySpace<Device::Type::kThead>(const void* ptr) {
+  if (!ptr) {
+    return MemorySpace::kHost;
+  }
+
+  cudaPointerAttributes attr;
+  INFINI_CHECK_CUDA(cudaPointerGetAttributes(&attr, ptr));
+
+  if (attr.type == cudaMemoryTypeDevice || attr.type == cudaMemoryTypeManaged) {
+    return MemorySpace::kDevice;
+  }
+
+  return MemorySpace::kHost;
+}
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_THEAD_DEVICE_H_

--- a/src/devices/thead/runtime_.h
+++ b/src/devices/thead/runtime_.h
@@ -1,0 +1,52 @@
+#ifndef INFINI_CCL_DEVICES_THEAD_RUNTIME_H_
+#define INFINI_CCL_DEVICES_THEAD_RUNTIME_H_
+
+#include <utility>
+
+// clang-format off
+#include <cuda_runtime.h>
+// clang-format on
+
+#include "devices/cuda/runtime_.h"
+#include "devices/thead/device_.h"
+#include "logging.h"
+#include "return_status_impl.h"
+
+namespace infini::ccl {
+
+template <>
+struct Runtime<Device::Type::kThead>
+    : CudaRuntime<Runtime<Device::Type::kThead>> {
+  using Stream = cudaStream_t;
+
+  static constexpr Device::Type kDeviceType = Device::Type::kThead;
+
+  static constexpr auto Check =
+      [](auto status, ReturnStatus err_code = ReturnStatus::kSystemError) {
+        if (status != cudaSuccess) {
+          LOG(cudaGetErrorString(static_cast<cudaError_t>(status)));
+          return err_code;
+        }
+        return ReturnStatus::kSuccess;
+      };
+
+  static constexpr auto Malloc = [](auto&&... args) {
+    return cudaMalloc(std::forward<decltype(args)>(args)...);
+  };
+
+  static constexpr auto Memcpy = cudaMemcpy;
+  static constexpr auto Free = cudaFree;
+  static constexpr auto MemcpyHostToDevice = cudaMemcpyHostToDevice;
+  static constexpr auto MemcpyDeviceToHost = cudaMemcpyDeviceToHost;
+  static constexpr auto Memset = cudaMemset;
+  static constexpr auto GetDevice = cudaGetDevice;
+  static constexpr auto SetDevice = cudaSetDevice;
+  static constexpr auto DeviceSynchronize = cudaDeviceSynchronize;
+  static constexpr auto StreamSynchronize = cudaStreamSynchronize;
+};
+
+static_assert(Runtime<Device::Type::kThead>::Validate());
+
+}  // namespace infini::ccl
+
+#endif  // INFINI_CCL_DEVICES_THEAD_RUNTIME_H_


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniCCL! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support NCCL backend
  fix: correct the averaging logic in `AllReduce`
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes and **why** this change is needed. Reference files with backtick-fenced paths (e.g. `src/device.h`).
-->

support T-Head PPU with NCCL in InfiniCCL

## Changes

<!--
Provide a categorized summary of the changes introduced in this PR.

Guidelines:
- Use first-level bullet points with bolded category titles.
- Under each category, describe the specific changes in concise bullet points.
- Keep descriptions concise and focused on what changed and why it matters.
- Multiple nesting levels are allowed when necessary, but should generally not exceed three levels.
-->

- **T-Head Backend**
Add T-Head backend support to InfiniCCL.
Add T-Head device and runtime definitions.
Add T-Head NCCL-compatible API interfaces.

- **Device Management**
Add T-Head device implementation and data type support.
Update backend-device mapping for the T-Head backend.

- **Build System**
Update CMake configuration to build the T-Head backend.
Add the required T-Head backend source files and headers.


## Platform and Backend Affected

<!--
Please check all the platforms and/or backends this PR affects (i.e., code is touched, behavior may change, etc.). 
-->

### Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU
- [x] T-Head PPU

### Backend

- [ ] OpenMPI
- [ ] MPICH
- [x] NCCL/RCCL
- [ ] MCCL

## Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance regression possible

<!--
Benchmark is required for `perf` PRs; optional otherwise. Describe the benchmark harness,
data size, dtypes, hardware, and include baseline vs. new numbers. If the PR is not 
performance-sensitive, write "N/A".
-->
If applicable, provide benchmark results.

## Known Issues & Future Work

<!--
Describe any known limitations, caveats, or unresolved issues introduced by this PR in bullet points.

If applicable, also outline potential follow-up improvements, extensions, or future work related to these changes.
-->

## Test Results

<!--
Describe the test environment and list the test results. 

Check the corresponding boxes for all applicable test setups. 

At minimum, attach the log files generated from running `scripts/run_examples.py` with all applicable example programs and configurations related to this PR.

See `CONTRIBUTING.md` § Pull Requests for the official testing requirements and expectations for submitted PRs.
-->

### Test Involved Platform

- [ ] CPU
- [ ] NVIDIA GPU
- [ ] Iluvatar GPU
- [ ] MetaX GPU
- [ ] Moore Threads GPU
- [ ] Cambricon MLU
- [ ] HYGON DCU

### Test Involved Backend

- [ ] OpenMPI
- [ ] MPICH
- [ ] NCCL/RCCL
- [ ] MCCL

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: …`, `fix(nccl): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `master` — the branch is rebased cleanly on top of the current `master`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.

### Scope and Design

- [ ] Changes are **minimal** — no unrelated modifications were introduced (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene

- [ ] The code is self-explanatory; comments were added **only** where the intent or rationale is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, inconsistent indentation, or mixed formatting styles remain.
- [ ] Identifiers referenced in comments or error messages are wrapped in Markdown backticks (e.g. ``the `AllReduce` implementation``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] `clang-format` (version **16**, per `.github/workflows/clang-format.yml`) has been run against all modified applicable files; the diff is clean.
- [ ] **No exceptions** are thrown. Error paths use `assert` with messages that include at least `__FILE__`, `__LINE__`, and `__func__` (`CONTRIBUTING.md` §C++).
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] Exactly **one blank line** between classes, between classes and functions, and between functions (`CONTRIBUTING.md` §C++).
- [ ] Exactly **one blank line** between members (functions *and* variables) within a class (`CONTRIBUTING.md` §C++).
- [ ] Exactly **one blank line** before and after the contents of a namespace (`CONTRIBUTING.md` §C++).

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant; `ruff check` passes cleanly on CI (see `.github/workflows/ruff.yml`).
- [ ] `ruff format --check` passes cleanly — if not, run `ruff format` and commit the result.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Framework-specific conventions (e.g. lowercase `pytest.skip` messages without terminal period) are honored where applicable (`CONTRIBUTING.md` §Python).
- [ ] **No blank line** between the function signature and the body when there is no docstring or comment (`CONTRIBUTING.md` §Python).
- [ ] A blank line is present **before and after** `if`, `for`, and similar control-flow statements (`CONTRIBUTING.md` §Python).
- [ ] A blank line appears **before** each `return`, except when it directly follows a control-flow statement (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Type hints are added / kept consistent with the surrounding code.

### Testing

- [ ] All applicable example programs have been built and tested successfully on at least one supported heterogeneous cluster setup.

### Build, CI, and Tooling

- [ ] New backends or devices have been added to auto-detection in `CMakeLists.txt` under `if(AUTO_DETECT_DEVICES)` or to `if(AUTO_DETECT_BACKENDS)` if applicable.
- [ ] Both CI workflows (`clang-format.yml`, `ruff.yml`) are green locally (or expected to be green on CI).

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Summary" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
